### PR TITLE
Optimize playerinput cases for simpler card coding.

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -623,7 +623,9 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public getResourcesOnCard(card: ICard): number | undefined {
-    return card.resourceCount;
+    if (card.resourceCount !== undefined) {
+      return card.resourceCount;
+    } else return undefined;
   }
 
   public getResourcesOnCorporation():number {

--- a/src/cards/ares/BioengineeringEnclosure.ts
+++ b/src/cards/ares/BioengineeringEnclosure.ts
@@ -57,13 +57,6 @@ export class BioengineeringEnclosure extends Card implements IProjectCard, IActi
           return undefined;
         }
 
-        if (resourceCards.length === 1) {
-          this.resourceCount--;
-          player.addResourceTo(resourceCards[0], 1);
-          player.game.log('${0} moved 1 animal from Bioengineering Enclosure to ${1}.', (b) => b.player(player).card(resourceCards[0]));
-          return undefined;
-        }
-
         return new SelectCard(
           'Select card to add 1 animal',
           'Add animal',

--- a/src/cards/base/ElectroCatapult.ts
+++ b/src/cards/base/ElectroCatapult.ts
@@ -45,31 +45,26 @@ export class ElectroCatapult extends Card implements IActionCard, IProjectCard {
     return player.plants > 0 || player.steel > 0;
   }
   public action(player: Player) {
-    if (player.plants > 0 && player.steel > 0) {
-      return new OrOptions(
+    const orOptions = new OrOptions();
+    if (player.plants > 0) {
+      orOptions.options.push(
         new SelectOption('Spend 1 plant to gain 7 M€', 'Spend plant', () => {
           player.plants--;
           player.megaCredits += 7;
           this.log(player, Resources.PLANTS);
           return undefined;
-        }),
+        }));
+    }
+    if (player.steel > 0) {
+      orOptions.options.push(
         new SelectOption('Spend 1 steel to gain 7 M€', 'Spend steel', () => {
           player.steel--;
           player.megaCredits += 7;
           this.log(player, Resources.STEEL);
           return undefined;
-        }),
-      );
-    } else if (player.plants > 0) {
-      player.plants--;
-      this.log(player, Resources.PLANTS);
-      player.megaCredits += 7;
-    } else if (player.steel > 0) {
-      player.steel--;
-      this.log(player, Resources.STEEL);
-      player.megaCredits += 7;
+        }));
     }
-    return undefined;
+    return orOptions;
   }
   public play(player: Player) {
     player.addProduction(Resources.ENERGY, -1);

--- a/src/cards/base/ExtremeColdFungus.ts
+++ b/src/cards/base/ExtremeColdFungus.ts
@@ -44,41 +44,36 @@ export class ExtremeColdFungus extends Card implements IActionCard, IProjectCard
     return true;
   }
   public action(player: Player) {
+    const orOptions = new OrOptions();
+
     const otherMicrobeCards = player.getResourceCards(ResourceType.MICROBE);
-
-    if (otherMicrobeCards.length === 0) {
-      player.addResource(Resources.PLANTS, 1, {log: true});
-      return undefined;
-    }
-
-    const gainPlantOption = new SelectOption('Gain 1 plant', 'Gain plant', () => {
-      player.addResource(Resources.PLANTS, 1, {log: true});
-      return undefined;
-    });
-
     if (otherMicrobeCards.length === 1) {
       const targetCard = otherMicrobeCards[0];
-
-      return new OrOptions(
+      orOptions.options.push(
         new SelectOption('Add 2 microbes to ' + targetCard.name, 'Add microbes', () => {
           player.addResourceTo(targetCard, {qty: 2, log: true});
           return undefined;
-        }),
-        gainPlantOption,
-      );
+        }));
+    }
+    if (otherMicrobeCards.length > 1) {
+      orOptions.options.push(
+        new SelectCard(
+          'Select card to add 2 microbes',
+          'Add microbes',
+          otherMicrobeCards,
+          (foundCards: Array<ICard>) => {
+            player.addResourceTo(foundCards[0], {qty: 2, log: true});
+            return undefined;
+          },
+        ));
     }
 
-    return new OrOptions(
-      new SelectCard(
-        'Select card to add 2 microbes',
-        'Add microbes',
-        otherMicrobeCards,
-        (foundCards: Array<ICard>) => {
-          player.addResourceTo(foundCards[0], {qty: 2, log: true});
-          return undefined;
-        },
-      ),
-      gainPlantOption,
-    );
+    orOptions.options.push(
+      new SelectOption('Gain 1 plant', 'Gain plant', () => {
+        player.addResource(Resources.PLANTS, 1, {log: true});
+        return undefined;
+      }));
+
+    return orOptions;
   }
 }

--- a/src/cards/base/GHGProducingBacteria.ts
+++ b/src/cards/base/GHGProducingBacteria.ts
@@ -71,7 +71,6 @@ export class GHGProducingBacteria extends Card implements IActionCard, IProjectC
         return undefined;
       }));
 
-      if (orOptions.options.length === 1) return orOptions.options[0].cb();
       return orOptions;
     }
 }

--- a/src/cards/base/ImportedHydrogen.ts
+++ b/src/cards/base/ImportedHydrogen.ts
@@ -50,33 +50,24 @@ export class ImportedHydrogen extends Card implements IProjectCard {
   }
 
   public play(player: Player): undefined | PlayerInput {
-    const availableMicrobeCards = player.getResourceCards(ResourceType.MICROBE);
-    const availableAnimalCards = player.getResourceCards(ResourceType.ANIMAL);
+    const orOptions = new OrOptions();
 
-    const gainPlants = function() {
+    orOptions.options.push(new SelectOption('Gain 3 plants', 'Gain plants', () => {
       player.addResource(Resources.PLANTS, 3, {log: true});
       player.game.defer(new PlaceOceanTile(player));
       return undefined;
-    };
+    }));
 
-    if (availableMicrobeCards.length === 0 && availableAnimalCards.length === 0) {
-      return gainPlants();
-    }
-
-    const availableActions: Array<SelectOption | SelectCard<ICard>> = [];
-
-    const gainPlantsOption = new SelectOption('Gain 3 plants', 'Gain plants', gainPlants);
-    availableActions.push(gainPlantsOption);
-
+    const availableMicrobeCards = player.getResourceCards(ResourceType.MICROBE);
     if (availableMicrobeCards.length === 1) {
       const targetMicrobeCard = availableMicrobeCards[0];
-      availableActions.push(new SelectOption('Add 3 microbes to ' + targetMicrobeCard.name, 'Add microbes', () => {
+      orOptions.options.push(new SelectOption('Add 3 microbes to ' + targetMicrobeCard.name, 'Add microbes', () => {
         player.addResourceTo(targetMicrobeCard, {qty: 3, log: true});
         player.game.defer(new PlaceOceanTile(player));
         return undefined;
       }));
     } else if (availableMicrobeCards.length > 1) {
-      availableActions.push(new SelectCard('Add 3 microbes to a card',
+      orOptions.options.push(new SelectCard('Add 3 microbes to a card',
         'Add microbes',
         availableMicrobeCards, (foundCards: Array<ICard>) => {
           player.addResourceTo(foundCards[0], {qty: 3, log: true});
@@ -85,21 +76,22 @@ export class ImportedHydrogen extends Card implements IProjectCard {
         }));
     }
 
+    const availableAnimalCards = player.getResourceCards(ResourceType.ANIMAL);
     if (availableAnimalCards.length === 1) {
       const targetAnimalCard = availableAnimalCards[0];
-      availableActions.push(new SelectOption('Add 2 animals to ' + targetAnimalCard.name, 'Add animals', () => {
+      orOptions.options.push(new SelectOption('Add 2 animals to ' + targetAnimalCard.name, 'Add animals', () => {
         player.addResourceTo(targetAnimalCard, {qty: 2, log: true});
         player.game.defer(new PlaceOceanTile(player));
         return undefined;
       }));
     } else if (availableAnimalCards.length > 1) {
-      availableActions.push(new SelectCard('Add 2 animals to a card', 'Add animals', availableAnimalCards, (foundCards: Array<ICard>) => {
+      orOptions.options.push(new SelectCard('Add 2 animals to a card', 'Add animals', availableAnimalCards, (foundCards: Array<ICard>) => {
         player.addResourceTo(foundCards[0], {qty: 2, log: true});
         player.game.defer(new PlaceOceanTile(player));
         return undefined;
       }));
     }
 
-    return new OrOptions(...availableActions);
+    return orOptions;
   }
 }

--- a/src/cards/base/LargeConvoy.ts
+++ b/src/cards/base/LargeConvoy.ts
@@ -55,6 +55,7 @@ export class LargeConvoy extends Card implements IProjectCard {
 
     orOptions.options.push(new SelectOption('Gain 5 plants', 'Gain plants', function() {
       player.addResource(Resources.PLANTS, 5, {log: true});
+      player.game.defer(new PlaceOceanTile(player));
       return undefined;
     }));
 
@@ -63,6 +64,7 @@ export class LargeConvoy extends Card implements IProjectCard {
       const targetAnimalCard = animalCards[0];
       orOptions.options.push(new SelectOption('Add 4 animals to ' + targetAnimalCard.name, 'Add animals', () => {
         player.addResourceTo(targetAnimalCard, {qty: 4, log: true});
+        player.game.defer(new PlaceOceanTile(player));
         return undefined;
       }));
     } else if (animalCards.length > 1) {
@@ -73,16 +75,12 @@ export class LargeConvoy extends Card implements IProjectCard {
           animalCards,
           (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], {qty: 4, log: true});
+            player.game.defer(new PlaceOceanTile(player));
             return undefined;
           },
         ),
       );
     }
-
-    orOptions.cb = () => {
-      player.game.defer(new PlaceOceanTile(player));
-      return undefined;
-    };
 
     return orOptions;
   }

--- a/src/cards/base/LargeConvoy.ts
+++ b/src/cards/base/LargeConvoy.ts
@@ -51,44 +51,40 @@ export class LargeConvoy extends Card implements IProjectCard {
   public play(player: Player): PlayerInput | undefined {
     player.drawCard(2);
 
-    const animalCards = player.getResourceCards(ResourceType.ANIMAL);
+    const orOptions = new OrOptions();
 
-    const gainPlants = function() {
+    orOptions.options.push(new SelectOption('Gain 5 plants', 'Gain plants', function() {
       player.addResource(Resources.PLANTS, 5, {log: true});
-      player.game.defer(new PlaceOceanTile(player));
       return undefined;
-    };
+    }));
 
-    if (animalCards.length === 0 ) return gainPlants();
-
-    const availableActions: Array<SelectOption | SelectCard<ICard>> = [];
-
-    const gainPlantsOption = new SelectOption('Gain 5 plants', 'Gain plants', gainPlants);
-    availableActions.push(gainPlantsOption);
-
+    const animalCards = player.getResourceCards(ResourceType.ANIMAL);
     if (animalCards.length === 1) {
       const targetAnimalCard = animalCards[0];
-      availableActions.push(new SelectOption('Add 4 animals to ' + targetAnimalCard.name, 'Add animals', () => {
+      orOptions.options.push(new SelectOption('Add 4 animals to ' + targetAnimalCard.name, 'Add animals', () => {
         player.addResourceTo(targetAnimalCard, {qty: 4, log: true});
-        player.game.defer(new PlaceOceanTile(player));
         return undefined;
       }));
-    } else {
-      availableActions.push(
+    } else if (animalCards.length > 1) {
+      orOptions.options.push(
         new SelectCard(
           'Select card to add 4 animals',
           'Add animals',
           animalCards,
           (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], {qty: 4, log: true});
-            player.game.defer(new PlaceOceanTile(player));
             return undefined;
           },
         ),
       );
     }
 
-    return new OrOptions(...availableActions);
+    orOptions.cb = () => {
+      player.game.defer(new PlaceOceanTile(player));
+      return undefined;
+    };
+
+    return orOptions;
   }
   public getVictoryPoints() {
     return 2;

--- a/src/cards/base/LocalHeatTrapping.ts
+++ b/src/cards/base/LocalHeatTrapping.ts
@@ -35,32 +35,27 @@ export class LocalHeatTrapping extends Card implements IProjectCard {
     const animalCards: Array<ICard> = player.getResourceCards(ResourceType.ANIMAL);
     const availableActions = new OrOptions();
 
-    const gain4Plants = function() {
+    availableActions.options.push(new SelectOption('Gain 4 plants', 'Gain plants', () => {
       player.addResource(Resources.PLANTS, 4, {log: true});
       return undefined;
-    };
+    }));
+
     if (animalCards.length === 0) {
-      availableActions.options.push(new SelectOption('Gain 4 plants', 'Gain plants', gain4Plants));
     } else if (animalCards.length === 1) {
       const targetCard = animalCards[0];
       availableActions.options.push(
-        new SelectOption('Gain 4 plants', 'Gain plants', gain4Plants),
         new SelectOption('Add 2 animals to ' + targetCard.name, 'Add animals', () => {
           player.addResourceTo(targetCard, {qty: 2, log: true});
           return undefined;
         }));
     } else {
       availableActions.options.push(
-        new SelectOption('Gain 4 plants', 'Gain plants', gain4Plants),
         new SelectCard('Select card to add 2 animals', 'Add animals', animalCards, (foundCards: Array<ICard>) => {
           player.addResourceTo(foundCards[0], {qty: 2, log: true});
           return undefined;
         }));
     }
 
-    return player.spendHeat(5, () => {
-      if (availableActions.options.length === 1) return availableActions.options[0].cb();
-      return availableActions;
-    });
+    return player.spendHeat(5, () => availableActions);
   }
 }

--- a/src/cards/base/NitriteReducingBacteria.ts
+++ b/src/cards/base/NitriteReducingBacteria.ts
@@ -79,7 +79,6 @@ export class NitriteReducingBacteria extends Card implements IActionCard, IProje
         return undefined;
       }));
 
-      if (orOptions.options.length === 1) return orOptions.options[0].cb();
       return orOptions;
     }
 }

--- a/src/cards/base/RegolithEaters.ts
+++ b/src/cards/base/RegolithEaters.ts
@@ -68,7 +68,6 @@ export class RegolithEaters extends Card implements IActionCard, IProjectCard, I
         return undefined;
       }));
 
-      if (orOptions.options.length === 1) return orOptions.options[0].cb();
       return orOptions;
     }
 }

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -20,6 +20,8 @@ import {Units} from '../src/Units';
 import {SelfReplicatingRobots} from '../src/cards/promo/SelfReplicatingRobots';
 import {Pets} from '../src/cards/base/Pets';
 import {GlobalEventName} from '../src/turmoil/globalEvents/GlobalEventName';
+import {LargeConvoy} from '../src/cards/base/LargeConvoy';
+import {OrOptions} from '@/inputs/OrOptions';
 
 describe('Player', function() {
   it('should initialize with right defaults', function() {
@@ -649,6 +651,24 @@ describe('Player', function() {
           'amount': -12,
         },
       });
+  });
+
+  it('optimize orOptions', () => {
+    const player = TestPlayers.BLUE.newPlayer();
+    Game.newInstance('foobar', [player], player);
+
+    const card = new LargeConvoy();
+    player.cardsInHand.push(card);
+
+    // This card will return OrOptions[SelectOption], which is optimized to
+    // SelectOption, which is opptimized to running the option.
+    const action = card.play(player) as OrOptions;
+    expect(action.options).has.length(1);
+    expect(action.options).instanceOf(SelectOption);
+    expect(player.plants).eq(0);
+
+    player.playCard(card);
+    expect(player.plants).eq(5);
   });
 });
 

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -664,7 +664,7 @@ describe('Player', function() {
     // SelectOption, which is opptimized to running the option.
     const action = card.play(player) as OrOptions;
     expect(action.options).has.length(1);
-    expect(action.options).instanceOf(SelectOption);
+    expect(action.options[0]).instanceOf(SelectOption);
     expect(player.plants).eq(0);
 
     player.playCard(card);

--- a/tests/cards/ares/BioengineeringEnclosure.spec.ts
+++ b/tests/cards/ares/BioengineeringEnclosure.spec.ts
@@ -20,7 +20,7 @@ describe('BioengineeringEnclosure', function() {
     game = Game.newInstance('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
-  it('Can\'t play without a science tag', () => {
+  it('Cannot play without a science tag', () => {
     expect(card.canPlay(player)).is.false;
     player.playCard(new AICentral());
     expect(card.canPlay(player)).is.true;
@@ -32,14 +32,14 @@ describe('BioengineeringEnclosure', function() {
     expect(card.resourceCount).eq(2);
   });
 
-  it('Can\'t move animal if it\'s empty', () => {
+  it('Cannot move animal if it is empty', () => {
     card.play(player);
     player.playCard(animalHost);
     card.resourceCount = 0;
     expect(card.canAct(player)).is.false;
   });
 
-  it('Can\'t move animal if theres not another card', () => {
+  it('Cannot move animal if theres not another card', () => {
     card.play(player);
     expect(card.canAct(player)).is.false;
   });

--- a/tests/cards/base/ExtremeColdFungus.spec.ts
+++ b/tests/cards/base/ExtremeColdFungus.spec.ts
@@ -32,7 +32,15 @@ describe('ExtremeColdFungus', () => {
     expect(action).is.undefined;
   });
 
-  it('Should act - single target', () => {
+  it('Should act - no microbe targets', () => {
+    const action = card.action(player);
+    expect(action!.options).has.lengthOf(1);
+
+    action!.options[0].cb();
+    expect(player.plants).to.eq(1);
+  });
+
+  it('Should act - single microbe target', () => {
     const tardigrades = new Tardigrades();
     player.playedCards.push(tardigrades);
 
@@ -40,14 +48,14 @@ describe('ExtremeColdFungus', () => {
     expect(action instanceof OrOptions).is.true;
     expect(action!.options).has.lengthOf(2);
 
-        action!.options[0].cb();
-        expect(player.getResourcesOnCard(tardigrades)).to.eq(2);
+    action!.options[0].cb();
+    expect(player.getResourcesOnCard(tardigrades)).to.eq(2);
 
-        action!.options[1].cb();
-        expect(player.plants).to.eq(1);
+    action!.options[1].cb();
+    expect(player.plants).to.eq(1);
   });
 
-  it('Should act - multiple targets', () => {
+  it('Should act - multiple microbe targets', () => {
     const tardigrades = new Tardigrades();
     const ants = new Ants();
     player.playedCards.push(tardigrades, ants);

--- a/tests/cards/base/ImportedHydrogen.spec.ts
+++ b/tests/cards/base/ImportedHydrogen.spec.ts
@@ -45,9 +45,11 @@ describe('ImportedHydrogen', function() {
     expect(player.getResourcesOnCard(pets)).to.eq(2);
   });
 
-  it('Should add plants directly if no microbe or animal cards available', function() {
+  it('Only plants option is available if no microbe or animal cards available', function() {
     expect(player.plants).to.eq(0);
-    card.play(player);
+    const action = card.play(player) as OrOptions;
+    expect(action.options).has.lengthOf(1);
+    action.options[0].cb();
     expect(player.plants).to.eq(3);
   });
 });

--- a/tests/cards/base/LargeConvoy.spec.ts
+++ b/tests/cards/base/LargeConvoy.spec.ts
@@ -19,12 +19,16 @@ describe('LargeConvoy', function() {
   });
 
   it('Should play without animal cards', function() {
-    card.play(player);
+    const action = card.play(player) as OrOptions;
+    expect(action.options).has.length(1);
+    action.options[0].cb();
 
-    player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
-    expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
     expect(player.cardsInHand).has.lengthOf(2);
     expect(player.plants).to.eq(5);
+
+    player.playedCards.push(card);
+    player.getVictoryPoints();
+    expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
   });
 
   it('Should play with single animal target', function() {

--- a/tests/cards/base/LargeConvoy.spec.ts
+++ b/tests/cards/base/LargeConvoy.spec.ts
@@ -7,15 +7,18 @@ import {OrOptions} from '../../../src/inputs/OrOptions';
 import {TestPlayer} from '../../TestPlayer';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
+import {PlaceOceanTile} from '../../../src/deferredActions/PlaceOceanTile';
 
 describe('LargeConvoy', function() {
-  let card : LargeConvoy; let player : TestPlayer;
+  let card : LargeConvoy;
+  let player : TestPlayer;
+  let game : Game;
 
   beforeEach(function() {
     card = new LargeConvoy();
     player = TestPlayers.BLUE.newPlayer();
     const redPlayer = TestPlayers.RED.newPlayer();
-    Game.newInstance('foobar', [player, redPlayer], player);
+    game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
   it('Should play without animal cards', function() {
@@ -25,6 +28,8 @@ describe('LargeConvoy', function() {
 
     expect(player.cardsInHand).has.lengthOf(2);
     expect(player.plants).to.eq(5);
+
+    expect(game.deferredActions.peek()).instanceOf(PlaceOceanTile);
 
     player.playedCards.push(card);
     player.getVictoryPoints();

--- a/tests/cards/base/LocalHeatTrapping.spec.ts
+++ b/tests/cards/base/LocalHeatTrapping.spec.ts
@@ -29,8 +29,10 @@ describe('LocalHeatTrapping', () => {
     player.cardsInHand = [card];
     expect(player.getPlayableCards()).does.include(card);
 
-    card.play(player);
-    player.playedCards.push(card);
+    const action = card.play(player) as OrOptions;
+    expect(action.options).has.length(1);
+    action.options[0].cb();
+    // player.playedCards.push(card);
     expect(player.plants).to.eq(4);
     expect(player.heat).to.eq(0);
   });


### PR DESCRIPTION
This introduces two optimizations:
* If an OrOptions or AndOptions contains only one element, unwrap   that one option, and put it in the queue (instead of the And/OrOptions)
* If the return from a playerinput is just a single SelectOption,   run it immediately.

Right now we do all kinds of UX optimizations on the options presented to a player depending on conditions that could just be optimized out, letting the coder just write the conditions.

This kind of optimziation does change how tests are run, and slightly changes some of the behavior, but I suspect we can be careful enough to not prevent any significant timing issues.

I wonder whether this optimization would be better placed in `DeferredQueue`.