### PR TITLE
log mega credits gained for RoverConstruction

### DIFF
--- a/src/cards/base/RoverConstruction.ts
+++ b/src/cards/base/RoverConstruction.ts
@@ -36,7 +36,7 @@ export class RoverConstruction extends Card implements IProjectCard {
   public onTilePlaced(cardOwner: Player, activePlayer: Player, space: ISpace) {
     if (Board.isCitySpace(space)) {
       cardOwner.game.defer(
-        new GainResources(cardOwner, Resources.MEGACREDITS, {count: 2}),
+        new GainResources(cardOwner, Resources.MEGACREDITS, {count: 2, log: true}),
         cardOwner.id !== activePlayer.id ? Priority.OPPONENT_TRIGGER : undefined,
       );
     }

--- a/src/deferredActions/GainResources.ts
+++ b/src/deferredActions/GainResources.ts
@@ -6,6 +6,7 @@ export namespace GainResources {
   export interface Options {
     count?: number;
     cb?: () => void;
+    log?: boolean;
   }
 }
 
@@ -25,7 +26,7 @@ export class GainResources implements DeferredAction {
     if (this.options.count === 0) {
       return undefined;
     }
-    this.player.addResource(this.resource, this.options.count ?? 1);
+    this.player.addResource(this.resource, this.options.count ?? 1, {log: this.options.log});
     if (this.options.cb) {
       this.options.cb();
     }


### PR DESCRIPTION
This can close #3709 . We have no way to know via logs if rover construction is working properly or not. This should help players and help us determine if there is some issue with rover construction. Adds logging when the 2 mega credits are gained.