### PR TITLE
Series of minor Turmoil API changes.

### DIFF
--- a/src/LogBuilder.ts
+++ b/src/LogBuilder.ts
@@ -13,6 +13,7 @@ import {TileType} from './TileType';
 import {SpaceBonus} from './SpaceBonus';
 import {IGlobalEvent} from './turmoil/globalEvents/IGlobalEvent';
 import {GlobalEventName} from './turmoil/globalEvents/GlobalEventName';
+import {PartyName} from './turmoil/parties/PartyName';
 
 export class LogBuilder {
     private message: string;
@@ -85,6 +86,11 @@ export class LogBuilder {
 
     public party(value: IParty): LogBuilder {
       this.parameters.push(new LogMessageData(LogMessageDataType.PARTY, value.name));
+      return this;
+    }
+
+    public partyName(value: PartyName): LogBuilder {
+      this.parameters.push(new LogMessageData(LogMessageDataType.PARTY, value));
       return this;
     }
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2080,9 +2080,9 @@ export class Player implements ISerializable<SerializedPlayer> {
       let sendDelegate;
       if (turmoil.lobby.has(this.id)) {
         sendDelegate = new SendDelegateToArea(this, 'Send a delegate in an area (from lobby)');
-      } else if (this.isCorporation(CardName.INCITE) && this.canAfford(3) && turmoil.hasAvailableDelegates(this.id)) {
+      } else if (this.isCorporation(CardName.INCITE) && this.canAfford(3) && turmoil.hasDelegatesInReserve(this.id)) {
         sendDelegate = new SendDelegateToArea(this, 'Send a delegate in an area (3 M€)', {cost: 3});
-      } else if (this.canAfford(5) && turmoil.hasAvailableDelegates(this.id)) {
+      } else if (this.canAfford(5) && turmoil.hasDelegatesInReserve(this.id)) {
         sendDelegate = new SendDelegateToArea(this, 'Send a delegate in an area (5 M€)', {cost: 5});
       }
       if (sendDelegate) {

--- a/src/cards/moon/AnOfferYouCantRefuse.ts
+++ b/src/cards/moon/AnOfferYouCantRefuse.ts
@@ -35,7 +35,7 @@ export class AnOfferYouCantRefuse extends ProjectCard {
   // You can play this if you have an available delegate, and if there are non-neutral non-leader delegates available to swap with.
   public canPlay(player: Player) {
     const turmoil = Turmoil.getTurmoil(player.game);
-    const hasDelegate = turmoil.hasAvailableDelegates(player.id) || turmoil.lobby.has(player.id);
+    const hasDelegate = turmoil.hasDelegatesInReserve(player.id) || turmoil.lobby.has(player.id);
     if (!hasDelegate) return false;
 
     return turmoil.parties.some((party) =>
@@ -75,7 +75,7 @@ export class AnOfferYouCantRefuse extends ProjectCard {
 
           const playerName = game.getPlayerById(delegate).name;
           const option = new SelectOption(`${party.name} / ${playerName}`, 'Select', () => {
-            const source = turmoil.hasAvailableDelegates(player.id) ? 'reserve' : 'lobby';
+            const source = turmoil.hasDelegatesInReserve(player.id) ? 'reserve' : 'lobby';
             turmoil.replaceDelegateFromParty(delegate, player.id, source, party.name, game);
             turmoil.checkDominantParty(party); // Check dominance right after replacement (replace doesn't check dominance.)
             return this.moveToAnotherParty(game, party.name, player.id);

--- a/src/cards/moon/LunaPoliticalInstitute.ts
+++ b/src/cards/moon/LunaPoliticalInstitute.ts
@@ -36,7 +36,7 @@ export class LunaPoliticalInstitute extends Card implements IActionCard, IProjec
   }
 
   public canAct(player: Player) {
-    return Turmoil.getTurmoil(player.game).hasAvailableDelegates(player.id);
+    return Turmoil.getTurmoil(player.game).hasDelegatesInReserve(player.id);
   }
 
   public action(player: Player) {

--- a/src/cards/moon/TempestConsultancy.ts
+++ b/src/cards/moon/TempestConsultancy.ts
@@ -52,7 +52,7 @@ export class TempestConsultancy extends Card implements CorporationCard {
   public action(player: Player) {
     let count = Math.floor(player.getTagCount(Tags.MOON) / 5);
     count = Math.min(count, 3);
-    count = Math.min(count, Turmoil.getTurmoil(player.game).getDelegatesInReserve(player.id));
+    count = Math.min(count, Turmoil.getTurmoil(player.game).getAvailableDelegateCount(player.id, 'reserve'));
     if (count > 0) {
       player.game.defer(new SendDelegateToArea(
         player,

--- a/src/cards/pathfinders/DeclarationOfIndependence.ts
+++ b/src/cards/pathfinders/DeclarationOfIndependence.ts
@@ -21,6 +21,7 @@ export class DeclarationOfIndependence extends Card implements IProjectCard {
       metadata: {
         cardNumber: 'Pf34',
         renderData: CardRenderer.builder((b) => b.delegates(2).asterix),
+        // TODO(kberg): remove "in reserve" to work like Cultural Metropolis.
         description: 'Have at least 6 Mars tags in play. Place 2 delegates from the reserve in 1 party.',
         victoryPoints: 4,
       },

--- a/src/cards/pathfinders/DeclarationOfIndependence.ts
+++ b/src/cards/pathfinders/DeclarationOfIndependence.ts
@@ -21,14 +21,14 @@ export class DeclarationOfIndependence extends Card implements IProjectCard {
       metadata: {
         cardNumber: 'Pf34',
         renderData: CardRenderer.builder((b) => b.delegates(2).asterix),
-        description: 'Have at least 6 Mars tags in play. Place 2 delegates in 1 party.',
+        description: 'Have at least 6 Mars tags in play. Place 2 delegates from the reserve in 1 party.',
         victoryPoints: 4,
       },
     });
   }
 
   public canPlay(player: Player) {
-    return Turmoil.getTurmoil(player.game).getDelegatesInReserve(player.id) >= 2;
+    return Turmoil.getTurmoil(player.game).getAvailableDelegateCount(player.id, 'reserve') >= 2;
   }
   public play(player: Player) {
     const title = 'Select a party to place 2 delegates.';

--- a/src/cards/pathfinders/DeclarationOfIndependence.ts
+++ b/src/cards/pathfinders/DeclarationOfIndependence.ts
@@ -24,7 +24,6 @@ export class DeclarationOfIndependence extends Card implements IProjectCard {
         renderData: CardRenderer.builder((b) => b.delegates(2).asterix),
         // TODO(kberg): remove "in reserve" to work like Cultural Metropolis.
         description: 'Have at least 6 Mars tags in play. Place 2 delegates from the reserve in 1 party.',
-        victoryPoints: 4,
       },
     });
   }

--- a/src/cards/turmoil/CulturalMetropolis.ts
+++ b/src/cards/turmoil/CulturalMetropolis.ts
@@ -43,8 +43,7 @@ export class CulturalMetropolis extends Card implements IProjectCard {
 
     // This card requires player has 2 delegates available
     const turmoil = Turmoil.getTurmoil(player.game);
-    const hasEnoughDelegates = turmoil.getDelegatesInReserve(player.id) > 1 ||
-      (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id));
+    const hasEnoughDelegates = turmoil.getAvailableDelegateCount(player.id, 'both') > 2;
     return hasEnoughDelegates;
   }
 
@@ -55,9 +54,11 @@ export class CulturalMetropolis extends Card implements IProjectCard {
     const title = 'Select where to send two delegates';
 
     const turmoil = Turmoil.getTurmoil(player.game);
-    if (turmoil.getDelegatesInReserve(player.id) > 1) {
+    const availableReserveDelegates = turmoil.getAvailableDelegateCount(player.id, 'reserve');
+    if (availableReserveDelegates > 1) {
       player.game.defer(new SendDelegateToArea(player, title, {count: 2, source: 'reserve'}));
-    } else if (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id)) {
+    } else if (availableReserveDelegates === 1 && turmoil.lobby.has(player.id)) {
+      // TODO(kberg): it's not that clear that 'lobby' when count > 1 falls into the reserve.
       player.game.defer(new SendDelegateToArea(player, title, {count: 2, source: 'lobby'}));
     }
     return undefined;

--- a/src/cards/turmoil/MartianMediaCenter.ts
+++ b/src/cards/turmoil/MartianMediaCenter.ts
@@ -44,7 +44,7 @@ export class MartianMediaCenter extends Card implements IProjectCard {
   }
 
   public canAct(player: Player): boolean {
-    return player.canAfford(3) && Turmoil.getTurmoil(player.game).hasAvailableDelegates(player.id);
+    return player.canAfford(3) && Turmoil.getTurmoil(player.game).hasDelegatesInReserve(player.id);
   }
 
   public action(player: Player) {

--- a/src/cards/turmoil/Recruitment.ts
+++ b/src/cards/turmoil/Recruitment.ts
@@ -27,7 +27,7 @@ export class Recruitment extends Card implements IProjectCard {
 
   public canPlay(player: Player): boolean {
     const turmoil = Turmoil.getTurmoil(player.game);
-    if (turmoil.hasAvailableDelegates(player.id) === false) {
+    if (turmoil.hasDelegatesInReserve(player.id) === false) {
       return false;
     }
 

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -32,7 +32,7 @@ export class VoteOfNoConfidence extends Card implements IProjectCard {
 
   public canPlay(player: Player): boolean {
     const turmoil = Turmoil.getTurmoil(player.game);
-    if (!turmoil.hasAvailableDelegates(player.id)) return false;
+    if (!turmoil.hasDelegatesInReserve(player.id)) return false;
 
     return turmoil.chairman === 'NEUTRAL';
   }

--- a/src/colonies/Colony.ts
+++ b/src/colonies/Colony.ts
@@ -229,7 +229,7 @@ export abstract class Colony implements SerializedColony {
       case ColonyBenefit.PLACE_DELEGATES:
         Turmoil.ifTurmoil(game, (turmoil) => {
           const playerHasLobbyDelegate = turmoil.lobby.has(player.id);
-          let availablePlayerDelegates = turmoil.getDelegatesInReserve(player.id);
+          let availablePlayerDelegates = turmoil.getAvailableDelegateCount(player.id, 'reserve');
           if (playerHasLobbyDelegate) availablePlayerDelegates += 1;
 
           const qty = Math.min(quantity, availablePlayerDelegates);
@@ -243,7 +243,7 @@ export abstract class Colony implements SerializedColony {
 
       case ColonyBenefit.GIVE_MC_PER_DELEGATE:
         Turmoil.ifTurmoil(game, (turmoil) => {
-          let partyDelegateCount = PLAYER_DELEGATES_COUNT - turmoil.getDelegatesInReserve(player.id);
+          let partyDelegateCount = PLAYER_DELEGATES_COUNT - turmoil.getAvailableDelegateCount(player.id, 'reserve');
           if (turmoil.lobby.has(player.id)) partyDelegateCount--;
           if (turmoil.chairman === player.id) partyDelegateCount--;
 

--- a/src/deferredActions/SendDelegateToArea.ts
+++ b/src/deferredActions/SendDelegateToArea.ts
@@ -7,19 +7,20 @@ import {PartyName} from '../turmoil/parties/PartyName';
 
 export class SendDelegateToArea implements DeferredAction {
   public priority = Priority.DEFAULT;
+  private turmoil: Turmoil;
   constructor(
         public player: Player,
         public title: string = 'Select where to send a delegate',
         public options: SendDelegateToArea.Options = {},
-  ) {}
+  ) {
+    this.turmoil = Turmoil.getTurmoil(this.player.game);
+  }
 
-  public execute() {
-    const turmoil = Turmoil.getTurmoil(this.player.game);
-
+  private getAvailableParties() {
     // All parties are eligible, unless this action is used to replace a delegate.
-    let parties = turmoil.parties;
+    let parties = this.turmoil.parties;
     if (this.options.replace) {
-      parties = turmoil.parties.filter((party) => {
+      parties = this.turmoil.parties.filter((party) => {
         if (party.delegates.length < 2) return false;
 
         for (const delegate of party.delegates) {
@@ -30,13 +31,19 @@ export class SendDelegateToArea implements DeferredAction {
         return false;
       });
     } else {
-      parties = turmoil.parties;
+      parties = this.turmoil.parties;
     }
 
+    return parties.map((party) => party.name);
+  }
+
+  public execute() {
+    const availableParties = this.getAvailableParties();
+    if (availableParties.length === 0) {
+      return undefined;
+    }
     // How many delegate to send
     const numDelegateToSend = this.options.count || 1;
-
-    const availableParties = parties.map((party) => party.name);
 
     const sendDelegate = new SelectPartyToSendDelegate(this.title, 'Send delegate', availableParties, (partyName: PartyName) => {
       if (this.options.cost) {
@@ -45,21 +52,21 @@ export class SendDelegateToArea implements DeferredAction {
 
       const source = this.options.source || 'lobby';
       if (numDelegateToSend > 1 && source === 'lobby') { // For card: Cultural Metropolis
-        turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, 'lobby');
+        this.turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, 'lobby');
         for (let i = 0; i < numDelegateToSend - 1; i++) {
-          turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, 'reserve');
+          this.turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, 'reserve');
         }
       } else {
         for (let i = 0; i < numDelegateToSend; i++) {
           if (this.options.replace) {
-            turmoil.replaceDelegateFromParty(this.options.replace, this.player.id, source, partyName, this.player.game);
+            this.turmoil.replaceDelegateFromParty(this.options.replace, this.player.id, source, partyName, this.player.game);
           } else {
-            turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, source);
+            this.turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, source);
           }
         }
       }
 
-      this.player.game.log('${0} sent ${1} delegate(s) in ${2} area', (b) => b.player(this.player).number(numDelegateToSend).party(turmoil.getPartyByName(partyName)));
+      this.player.game.log('${0} sent ${1} delegate(s) in ${2} area', (b) => b.player(this.player).number(numDelegateToSend).partyName(partyName));
       return undefined;
     });
 
@@ -75,6 +82,7 @@ export namespace SendDelegateToArea {
     replace?: PlayerId | NeutralPlayer | undefined,
     /** Cost for sending this delegate. Default is no cost. */
     cost?: number,
+    // TODO(kberg): add 'both'
     /** Source of the delegates being added. Default is 'lobby' */
     source?: 'lobby' | 'reserve'
   }

--- a/src/models/TurmoilModel.ts
+++ b/src/models/TurmoilModel.ts
@@ -78,8 +78,8 @@ export function getTurmoilModel(game: Game): TurmoilModel | undefined {
       (player) => game.getPlayerById(player).color,
     );
 
-    const reserve = turmoil.getPresentPlayers().map((player) => {
-      const number = turmoil.getDelegatesInReserve(player);
+    const reserve = turmoil.getPresentPlayersInReserve().map((player) => {
+      const number = turmoil.getAvailableDelegateCount(player, 'reserve');
       if (player !== 'NEUTRAL') {
         return {
           color: game.getPlayerById(player).color,

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -270,7 +270,7 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
       this.lobby = new Set<string>();
 
       game.getPlayers().forEach((player) => {
-        if (this.hasAvailableDelegates(player.id)) {
+        if (this.hasDelegatesInReserve(player.id)) {
           const index = this.delegateReserve.indexOf(player.id);
           if (index > -1) {
             this.delegateReserve.splice(index, 1);
@@ -413,19 +413,29 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
     }
 
     // List players present in the reserve
-    public getPresentPlayers(): Array<PlayerId | NeutralPlayer> {
+    public getPresentPlayersInReserve(): Array<PlayerId | NeutralPlayer> {
       return Array.from(new Set(this.delegateReserve));
     }
 
-    // Return number of delegates in reserve
-    public getDelegatesInReserve(playerId: PlayerId | NeutralPlayer): number {
-      const delegates = this.delegateReserve.filter((p) => p === playerId).length;
-      return delegates;
+    // Return number of delegates
+    // TODO(kberg): Find a way to remove the default value for source.
+    public getAvailableDelegateCount(playerId: PlayerId | NeutralPlayer, source: 'lobby' | 'reserve' | 'both'): number {
+      const delegatesInReserve = this.delegateReserve.filter((p) => p === playerId).length;
+      const delegatesInLobby = this.lobby.has(playerId) ? 1: 0;
+
+      switch (source) {
+      case 'lobby':
+        return delegatesInLobby;
+      case 'reserve':
+        return delegatesInReserve;
+      case 'both':
+        return delegatesInLobby + delegatesInReserve;
+      }
     }
 
     // Check if player has delegates available
-    public hasAvailableDelegates(playerId: PlayerId | NeutralPlayer): boolean {
-      return this.getDelegatesInReserve(playerId) > 0;
+    public hasDelegatesInReserve(playerId: PlayerId | NeutralPlayer): boolean {
+      return this.getAvailableDelegateCount(playerId, 'reserve') > 0;
     }
 
     // Get Victory Points

--- a/tests/cards/moon/AnOfferYouCantRefuse.spec.ts
+++ b/tests/cards/moon/AnOfferYouCantRefuse.spec.ts
@@ -70,14 +70,14 @@ describe('AnOfferYouCantRefuse', () => {
 
     // Now do a delegate exchange
     // Swap with Reds / red
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(6);
-    expect(turmoil.getDelegatesInReserve(redPlayer.id)).eq(6);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(6);
+    expect(turmoil.getAvailableDelegateCount(redPlayer.id, 'reserve')).eq(6);
     expect(parties.reds.delegates).to.have.members(['NEUTRAL', 'NEUTRAL', redPlayer.id, redPlayer.id]);
 
     const switchParties = options.options[2].cb() as OrOptions;
 
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(5);
-    expect(turmoil.getDelegatesInReserve(redPlayer.id)).eq(7);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(5);
+    expect(turmoil.getAvailableDelegateCount(redPlayer.id, 'reserve')).eq(7);
     expect(parties.reds.delegates).to.have.members(['NEUTRAL', 'NEUTRAL', redPlayer.id, player.id]);
 
     // Now player may switch parties.

--- a/tests/cards/moon/TempestConsultancy.spec.ts
+++ b/tests/cards/moon/TempestConsultancy.spec.ts
@@ -42,38 +42,38 @@ describe('TempestConsultancy', () => {
 
   it('action, 1 delegate', () => {
     player.tagsForTest = {moon: 5};
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(6);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(6);
     // This test is brittle - it assumes mars first will be orOptions[0]. But OK.
     const marsFirst = turmoil.getPartyByName(PartyName.MARS)!;
     expect(marsFirst.getDelegates(player.id)).eq(0);
     card.action(player);
     const action = player.game.deferredActions.pop() as SendDelegateToArea;
     const options = action.execute();
-    options.cb(marsFirst.name);
+    options!.cb(marsFirst.name);
 
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(5);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(5);
     expect(marsFirst.getDelegates(player.id)).eq(1);
   });
 
   it('action, 3 delegates', () => {
     player.tagsForTest = {moon: 16};
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(6);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(6);
     // This test is brittle - it assumes mars first will be orOptions[0]. But OK.
     const marsFirst = turmoil.getPartyByName(PartyName.MARS)!;
     expect(marsFirst.getDelegates(player.id)).eq(0);
     card.action(player);
     const action = player.game.deferredActions.pop() as SendDelegateToArea;
     const options = action.execute();
-    options.cb(marsFirst.name);
+    options!.cb(marsFirst.name);
 
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(3);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(3);
     expect(marsFirst.getDelegates(player.id)).eq(3);
   });
 
   it('action, 3 delegates, only 2 available', () => {
     player.tagsForTest = {moon: 16};
     turmoil.delegateReserve = [player.id, player.id];
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(2);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(2);
     // This test is brittle - it assumes mars first will be orOptions[0]. But OK.
     const marsFirst = turmoil.getPartyByName(PartyName.MARS)!;
     expect(marsFirst.getDelegates(player.id)).eq(0);
@@ -82,9 +82,9 @@ describe('TempestConsultancy', () => {
 
     const action = player.game.deferredActions.pop() as SendDelegateToArea;
     const options = action.execute();
-    options.cb(marsFirst.name);
+    options!.cb(marsFirst.name);
 
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(0);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(0);
     expect(marsFirst.getDelegates(player.id)).eq(2);
   });
 

--- a/tests/cards/pathfinders/DeclarationOfIndependence.spec.ts
+++ b/tests/cards/pathfinders/DeclarationOfIndependence.spec.ts
@@ -35,16 +35,16 @@ describe('DeclarationOfIndependence', function() {
 
 
   it('play', function() {
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(6);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(6);
     // This test is brittle - it assumes mars first will be orOptions[0]. But OK.
     const marsFirst = turmoil.getPartyByName(PartyName.MARS)!;
     expect(marsFirst.getDelegates(player.id)).eq(0);
     card.play(player);
     const action = player.game.deferredActions.pop() as SendDelegateToArea;
     const options = action.execute();
-    options.cb(marsFirst.name);
+    options!.cb(marsFirst.name);
 
-    expect(turmoil.getDelegatesInReserve(player.id)).eq(4);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(4);
     expect(marsFirst.getDelegates(player.id)).eq(2);
   });
 });

--- a/tests/cards/turmoil/CulturalMetropolis.spec.ts
+++ b/tests/cards/turmoil/CulturalMetropolis.spec.ts
@@ -42,7 +42,7 @@ describe('Cultural Metropolis', function() {
     for (let i = 0; i < PLAYER_DELEGATES_COUNT - 3; i++) {
       turmoil.sendDelegateToParty(player.id, PartyName.REDS, game, 'reserve');
     }
-    expect(turmoil.getDelegatesInReserve(player.id)).to.equal(1);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).to.equal(1);
     expect(player.canPlayIgnoringCost(card)).is.not.true;
   });
 
@@ -55,7 +55,7 @@ describe('Cultural Metropolis', function() {
     turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'reserve');
 
     expect(unity.delegates).has.lengthOf(startingUnityDelegateCount + 2);
-    expect(turmoil.getDelegatesInReserve(player.id)).to.equal(5);
+    expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).to.equal(5);
     expect(player.canPlayIgnoringCost(card)).is.true;
 
     card.play(player);
@@ -63,7 +63,7 @@ describe('Cultural Metropolis', function() {
     player.game.deferredActions.pop(); // Pop out the city placement deferred action
     const action = player.game.deferredActions.pop() as SendDelegateToArea;
     const options = action.execute();
-    options.cb(PartyName.UNITY);
+    options!.cb(PartyName.UNITY);
 
     expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);


### PR DESCRIPTION
1. counting delegates can include the lobby.
2. can log by party name.
3. Rename hasAvailableDelegates to hasDelegatesInReserve.
4. Rename getDelegatesInReserve to getAvailablePartyDelegateCount.
5. For now, make Declaration of Independence only take delegates from the reserve. Later make it like Cultural Metropolis.
6. Organize SendDelegateToArea just a little bit. It'll make it easier to read. Plus I want to get it to be more protective of accidentally sending more delegates than it has.