### PR TITLE
only use name when serializing IAward for Game

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -414,7 +414,7 @@ export class Game implements ISerializable<SerializedGame> {
   public serialize(): SerializedGame {
     const result: SerializedGame = {
       activePlayer: this.activePlayer,
-      awards: this.awards,
+      awards: this.awards.map((a) => a.name),
       board: this.board.serialize(),
       claimedMilestones: serializeClaimedMilestones(this.claimedMilestones),
       colonies: this.colonies,
@@ -1591,12 +1591,12 @@ export class Game implements ISerializable<SerializedGame> {
     game.claimedMilestones = deserializeClaimedMilestones(d.claimedMilestones, players, milestones);
 
     const awards: Array<IAward> = [];
-    d.awards.forEach((element: IAward) => {
-      ALL_AWARDS.forEach((award: IAward) => {
-        if (award.name === element.name) {
-          awards.push(award);
-        }
-      });
+    d.awards.forEach((element: IAward | string) => {
+      const awardName = typeof element === 'string' ? element : element.name;
+      const foundAward = ALL_AWARDS.find((award) => award.name === awardName);
+      if (foundAward !== undefined) {
+        awards.push(foundAward);
+      }
     });
 
     game.awards = awards;

--- a/src/SerializedGame.ts
+++ b/src/SerializedGame.ts
@@ -21,7 +21,7 @@ import {SerializedPathfindersData} from './pathfinders/SerializedPathfindersData
 export interface SerializedGame {
     activePlayer: PlayerId;
     aresData?: IAresData;
-    awards: Array<IAward>;
+    awards: Array<IAward> | Array<string>;
     board: SerializedBoard;
     claimedMilestones: Array<SerializedClaimedMilestone>;
     clonedGamedId?: string;

--- a/src/SerializedGame.ts
+++ b/src/SerializedGame.ts
@@ -21,7 +21,7 @@ import {SerializedPathfindersData} from './pathfinders/SerializedPathfindersData
 export interface SerializedGame {
     activePlayer: PlayerId;
     aresData?: IAresData;
-    awards: Array<IAward> | Array<string>;
+    awards: Array<IAward> | Array<string>; // TODO(bafolts): remove Array<IAward> by 2021-12-01
     board: SerializedBoard;
     claimedMilestones: Array<SerializedClaimedMilestone>;
     clonedGamedId?: string;

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -26,6 +26,7 @@ import {Color} from '../src/Color';
 import {RandomMAOptionType} from '../src/RandomMAOptionType';
 import {SpaceBonus} from '../src/SpaceBonus';
 import {TileType} from '../src/TileType';
+import {ALL_AWARDS} from '../src/awards/Awards';
 
 describe('Game', () => {
   it('should initialize with right defaults', () => {
@@ -663,5 +664,14 @@ describe('Game', () => {
     (serialized.gameOptions as any).pathfindersData = undefined;
     const deserialized = Game.deserialize(serialized);
     expect(deserialized.pathfindersData).is.undefined;
+  });
+
+  it('deserializing a game with award as an object', () => {
+    const player = TestPlayers.BLUE.newPlayer();
+    const game = Game.newInstance('foobar', [player], player, TestingUtils.setCustomGameOptions({pathfindersExpansion: false}));
+    const serialized = game.serialize();
+    serialized.awards = serialized.awards.map((a) => ALL_AWARDS.find((b) => b.name === a)!);
+    const deserialized = Game.deserialize(serialized);
+    expect(deserialized.awards).deep.eq(game.awards);
   });
 });


### PR DESCRIPTION
This will use less space per entry by storing only the award name instead of the entire award object. There are plans to eventually keep more records in the database and this will help use less space.