### PR TITLE
Automate computing starting megacredits, and expand to fit The Moon and Pathfinders

### DIFF
--- a/src/CardFinder.ts
+++ b/src/CardFinder.ts
@@ -15,6 +15,7 @@ import {ARES_CARD_MANIFEST} from './cards/ares/AresCardManifest';
 import {MOON_CARD_MANIFEST} from './cards/moon/MoonCardManifest';
 import {Deck} from './Deck';
 import {PATHFINDERS_CARD_MANIFEST} from './cards/pathfinders/PathfindersCardManifest';
+import {PreludeCard} from './cards/prelude/PreludeCard';
 
 export class CardFinder {
     private static decks: undefined | Array<CardManifest>;
@@ -63,6 +64,10 @@ export class CardFinder {
     //              another function, perhaps?
     public getProjectCardByName(cardName: CardName): IProjectCard | undefined {
       return this.getCardByName(cardName, (manifest) => [manifest.projectCards, manifest.preludeCards]);
+    }
+
+    public getPreludeByName(cardName: CardName): PreludeCard | undefined {
+      return this.getCardByName(cardName, (manifest) => [manifest.preludeCards]);
     }
 
     public cardsFromJSON(cards: Array<ICard | CardName>): Array<IProjectCard> {

--- a/src/cards/CardManifest.ts
+++ b/src/cards/CardManifest.ts
@@ -6,13 +6,14 @@ import {ICardFactory} from './ICardFactory';
 import {IProjectCard} from './IProjectCard';
 import {StandardProjectCard} from './StandardProjectCard';
 import {StandardActionCard} from './StandardActionCard';
+import {PreludeCard} from './prelude/PreludeCard';
 
 export class CardManifest {
     module: GameModule;
     projectCards : Deck<IProjectCard>;
     cardsToRemove: Set<CardName>;
     corporationCards : Deck<CorporationCard>;
-    preludeCards : Deck<IProjectCard>;
+    preludeCards : Deck<PreludeCard>;
     standardProjects : Deck<StandardProjectCard>;
     standardActions : Deck<StandardActionCard>;
     constructor(arg: {
@@ -20,7 +21,7 @@ export class CardManifest {
          projectCards?: Array<ICardFactory<IProjectCard>>,
          cardsToRemove?: Array<CardName>,
          corporationCards?: Array<ICardFactory<CorporationCard>>,
-         preludeCards?: Array<ICardFactory<IProjectCard>>,
+         preludeCards?: Array<ICardFactory<PreludeCard>>,
          standardProjects?: Array<ICardFactory<StandardProjectCard>>,
          standardActions?: Array<ICardFactory<StandardActionCard>>,
          }) {
@@ -28,7 +29,7 @@ export class CardManifest {
       this.projectCards = new Deck<IProjectCard>(arg.projectCards || []);
       this.cardsToRemove = new Set(arg.cardsToRemove || []);
       this.corporationCards = new Deck<CorporationCard>(arg.corporationCards || []);
-      this.preludeCards = new Deck<IProjectCard>(arg.preludeCards || []);
+      this.preludeCards = new Deck<PreludeCard>(arg.preludeCards || []);
       this.standardProjects = new Deck<StandardProjectCard>(arg.standardProjects || []);
       this.standardActions = new Deck<StandardActionCard>(arg.standardActions || []);
     }

--- a/src/cards/community/AerospaceMission.ts
+++ b/src/cards/community/AerospaceMission.ts
@@ -11,6 +11,7 @@ export class AerospaceMission extends PreludeCard {
     super({
       name: CardName.AEROSPACE_MISSION,
       tags: [Tags.SPACE],
+      startingMegacredits: -14,
 
       metadata: {
         cardNumber: 'Y01',

--- a/src/cards/community/ResearchGrant.ts
+++ b/src/cards/community/ResearchGrant.ts
@@ -10,6 +10,7 @@ export class ResearchGrant extends PreludeCard implements IProjectCard {
     super({
       name: CardName.RESEARCH_GRANT,
       tags: [Tags.SCIENCE, Tags.SCIENCE],
+      startingMegacredits: 8,
 
       metadata: {
         cardNumber: 'Y04',

--- a/src/cards/community/TradeAdvance.ts
+++ b/src/cards/community/TradeAdvance.ts
@@ -11,6 +11,7 @@ export class TradeAdvance extends PreludeCard implements IProjectCard {
     super({
       name: CardName.TRADE_ADVANCE,
       tags: [Tags.EARTH],
+      startingMegacredits: 2,
 
       metadata: {
         cardNumber: 'Y05',

--- a/src/cards/community/ValuableGases.ts
+++ b/src/cards/community/ValuableGases.ts
@@ -14,6 +14,7 @@ export class ValuableGases extends PreludeCard implements IProjectCard {
     super({
       name: CardName.VALUABLE_GASES,
       tags: [Tags.JOVIAN, Tags.VENUS],
+      startingMegacredits: 6,
 
       metadata: {
         cardNumber: 'Y06',

--- a/src/cards/moon/BasicInfrastructure.ts
+++ b/src/cards/moon/BasicInfrastructure.ts
@@ -22,6 +22,8 @@ export class BasicInfrastructure extends PreludeCard {
     });
   };
 
+  public tilesBuilt = [TileType.MOON_ROAD];
+
   public play(player: Player) {
     player.game.defer(new PlaceMoonRoadTile(player));
     player.increaseFleetSize();

--- a/src/cards/moon/CoreMine.ts
+++ b/src/cards/moon/CoreMine.ts
@@ -3,16 +3,18 @@ import {Player} from '../../Player';
 import {Tags} from '../Tags';
 import {PreludeCard} from '../prelude/PreludeCard';
 import {CardRenderer} from '../render/CardRenderer';
-import {Resources} from '../../Resources';
 import {PlaceMoonMineTile} from '../../moon/PlaceMoonMineTile';
 import {IProjectCard} from '../IProjectCard';
 import {AltSecondaryTag} from '../render/CardRenderItem';
+import {Units} from '../../Units';
+import {TileType} from '../../TileType';
 
 export class CoreMine extends PreludeCard implements IProjectCard {
   constructor() {
     super({
       name: CardName.CORE_MINE,
       tags: [Tags.MOON],
+      productionBox: Units.of({titanium: 1}),
       metadata: {
         description: 'Place a mine tile on the Moon and raise the Mining Rate 1 step. Increase your titanium production 1 step.',
         cardNumber: '',
@@ -23,8 +25,10 @@ export class CoreMine extends PreludeCard implements IProjectCard {
     });
   }
 
+  public tilesBuilt = [TileType.MOON_MINE];
+
   public play(player: Player) {
-    player.addProduction(Resources.TITANIUM, 1, {log: true});
+    player.adjustProduction(this.productionBox, {log: true});
     player.game.defer(new PlaceMoonMineTile(player));
     return undefined;
   }

--- a/src/cards/moon/FirstLunarSettlement.ts
+++ b/src/cards/moon/FirstLunarSettlement.ts
@@ -2,18 +2,19 @@ import {CardName} from '../../CardName';
 import {Player} from '../../Player';
 import {Tags} from '../Tags';
 import {PreludeCard} from '../prelude/PreludeCard';
-import {Resources} from '../../Resources';
 import {PlaceMoonColonyTile} from '../../moon/PlaceMoonColonyTile';
 import {CardRenderer} from '../render/CardRenderer';
 import {TileType} from '../../TileType';
 import {IProjectCard} from '../IProjectCard';
 import {AltSecondaryTag} from '../render/CardRenderItem';
+import {Units} from '../../Units';
 
 export class FirstLunarSettlement extends PreludeCard implements IProjectCard {
   constructor() {
     super({
       name: CardName.FIRST_LUNAR_SETTLEMENT,
       tags: [Tags.CITY, Tags.MOON],
+      productionBox: Units.of({megacredits: 1}),
       metadata: {
         description: 'Place a colony tile on the Moon and Raise the Colony Rate 1 step. Increase your M€ production 1 step.',
         cardNumber: '',
@@ -27,7 +28,7 @@ export class FirstLunarSettlement extends PreludeCard implements IProjectCard {
   public tilesBuilt = [TileType.MOON_COLONY];
 
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 1, {log: true});
+    player.adjustProduction(this.productionBox, {log: true});
     player.game.defer(new PlaceMoonColonyTile(player));
     return undefined;
   }

--- a/src/cards/moon/MiningComplex.ts
+++ b/src/cards/moon/MiningComplex.ts
@@ -9,12 +9,14 @@ import {PlaceMoonRoadTile} from '../../moon/PlaceMoonRoadTile';
 import {SpaceType} from '../../SpaceType';
 import {Resources} from '../../Resources';
 import {AltSecondaryTag} from '../render/CardRenderItem';
+import {TileType} from '../../TileType';
 
 export class MiningComplex extends PreludeCard {
   constructor() {
     super({
       name: CardName.MINING_COMPLEX,
       tags: [Tags.MOON],
+      startingMegacredits: -7,
 
       metadata: {
         description: 'Place a mine tile on the Moon and raise the Mining Rate 1 step. ' +
@@ -27,6 +29,8 @@ export class MiningComplex extends PreludeCard {
       },
     });
   };
+
+  public tilesBuilt = [TileType.MOON_MINE, TileType.MOON_ROAD];
 
   public play(player: Player) {
     player.game.defer(new PlaceMoonMineTile(player)

--- a/src/cards/pathfinders/AntidesertificationTechniques.ts
+++ b/src/cards/pathfinders/AntidesertificationTechniques.ts
@@ -3,11 +3,14 @@ import {PreludeCard} from '../prelude/PreludeCard';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Resources} from '../../Resources';
+import {Units} from '../../Units';
 
 export class AntidesertificationTechniques extends PreludeCard {
   constructor() {
     super({
       name: CardName.ANTI_DESERTIFICATION_TECHNIQUES,
+      productionBox: Units.of({plants: 1, steel: 1}),
+      startingMegacredits: 5,
 
       metadata: {
         cardNumber: 'P08',
@@ -20,8 +23,7 @@ export class AntidesertificationTechniques extends PreludeCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.PLANTS, 1);
-    player.addProduction(Resources.STEEL, 1);
+    player.adjustProduction(this.productionBox, {log: true});
     player.addResource(Resources.MEGACREDITS, 5);
     return undefined;
   }

--- a/src/cards/pathfinders/CO2Reducers.ts
+++ b/src/cards/pathfinders/CO2Reducers.ts
@@ -2,14 +2,15 @@ import {Player} from '../../Player';
 import {PreludeCard} from '../prelude/PreludeCard';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
-import {Resources} from '../../Resources';
 import {Tags} from '../Tags';
+import {Units} from '../../Units';
 
 export class CO2Reducers extends PreludeCard {
   constructor() {
     super({
       name: CardName.CO2_REDUCERS,
       tags: [Tags.MICROBE, Tags.VENUS],
+      productionBox: Units.of({megacredits: 3}),
 
       metadata: {
         cardNumber: '',
@@ -22,7 +23,7 @@ export class CO2Reducers extends PreludeCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 3);
+    player.adjustProduction(this.productionBox);
     player.drawCard(2, {tag: Tags.MICROBE});
     return undefined;
   }

--- a/src/cards/pathfinders/DesignCompany.ts
+++ b/src/cards/pathfinders/DesignCompany.ts
@@ -3,13 +3,14 @@ import {PreludeCard} from '../prelude/PreludeCard';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Tags} from '../Tags';
-import {Resources} from '../../Resources';
+import {Units} from '../../Units';
 
 export class DesignCompany extends PreludeCard {
   constructor() {
     super({
       name: CardName.DESIGN_COMPANY,
       tags: [Tags.MARS],
+      productionBox: Units.of({steel: 1}),
 
       metadata: {
         cardNumber: 'P08',
@@ -22,7 +23,7 @@ export class DesignCompany extends PreludeCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.STEEL, 1);
+    player.adjustProduction(this.productionBox, {log: true});
     player.drawCard(3, {tag: Tags.BUILDING});
     return undefined;
   }

--- a/src/cards/pathfinders/HydrogenBombardment.ts
+++ b/src/cards/pathfinders/HydrogenBombardment.ts
@@ -3,11 +3,14 @@ import {PreludeCard} from '../prelude/PreludeCard';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Resources} from '../../Resources';
+import {Units} from '../../Units';
 
 export class HydrogenBombardment extends PreludeCard {
   constructor() {
     super({
       name: CardName.HYDROGEN_BOMBARDMENT,
+      productionBox: Units.of({titanium: 1}),
+      startingMegacredits: 6,
 
       metadata: {
         cardNumber: 'P08',
@@ -21,8 +24,8 @@ export class HydrogenBombardment extends PreludeCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.TITANIUM, 1);
-    player.addResource(Resources.MEGACREDITS, 6);
+    player.adjustProduction(this.productionBox);
+    player.addResource(Resources.MEGACREDITS, this.startingMegaCredits);
     player.game.increaseVenusScaleLevel(player, 1);
     return undefined;
   }

--- a/src/cards/pathfinders/PersonalAgenda.ts
+++ b/src/cards/pathfinders/PersonalAgenda.ts
@@ -2,14 +2,15 @@ import {Player} from '../../Player';
 import {PreludeCard} from '../prelude/PreludeCard';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
-import {Resources} from '../../Resources';
 import {Tags} from '../Tags';
 import {CardType} from '../CardType';
+import {Units} from '../../Units';
 
 export class PersonalAgenda extends PreludeCard {
   constructor() {
     super({
       name: CardName.PERSONAL_AGENDA,
+      productionBox: Units.of({megacredits: 3}),
 
       metadata: {
         cardNumber: 'P08',
@@ -23,7 +24,7 @@ export class PersonalAgenda extends PreludeCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 3);
+    player.adjustProduction(this.productionBox, {log: true});
     player.drawCard(3, {
       include: (card) => {
         return card.cardType === CardType.EVENT &&

--- a/src/cards/pathfinders/ResearchGrant.ts
+++ b/src/cards/pathfinders/ResearchGrant.ts
@@ -4,12 +4,15 @@ import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Resources} from '../../Resources';
 import {Tags} from '../Tags';
+import {Units} from '../../Units';
 
 export class ResearchGrant extends PreludeCard {
   constructor() {
     super({
       name: CardName.RESEARCH_GRANT_PATHFINDERS,
       tags: [Tags.SCIENCE, Tags.SCIENCE],
+      productionBox: Units.of({energy: 1}),
+      startingMegacredits: 14,
 
       metadata: {
         cardNumber: 'P08',
@@ -22,7 +25,7 @@ export class ResearchGrant extends PreludeCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.ENERGY, 1);
+    player.adjustProduction(this.productionBox, {log: true});
     player.addResource(Resources.MEGACREDITS, 14);
     return undefined;
   }

--- a/src/cards/prelude/AlliedBanks.ts
+++ b/src/cards/prelude/AlliedBanks.ts
@@ -1,15 +1,18 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {Units} from '../../Units';
 
 export class AlliedBanks extends PreludeCard {
   constructor() {
     super({
       name: CardName.ALLIED_BANKS,
       tags: [Tags.EARTH],
+
+      productionBox: Units.of({megacredits: 4}),
+      startingMegacredits: 3,
 
       metadata: {
         cardNumber: 'P01',
@@ -22,8 +25,8 @@ export class AlliedBanks extends PreludeCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 4);
-    player.megaCredits += 3;
+    player.adjustProduction(this.productionBox);
+    player.megaCredits += this.startingMegaCredits;
     return undefined;
   }
 }

--- a/src/cards/prelude/AquiferTurbines.ts
+++ b/src/cards/prelude/AquiferTurbines.ts
@@ -1,17 +1,20 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
 import {CardRenderer} from '../render/CardRenderer';
+import {Units} from '../../Units';
 
 export class AquiferTurbines extends PreludeCard {
   constructor() {
     super({
       name: CardName.AQUIFER_TURBINES,
       tags: [Tags.ENERGY],
+
+      productionBox: Units.of({energy: 2}),
+      startingMegacredits: -3,
 
       metadata: {
         cardNumber: 'P02',
@@ -27,7 +30,7 @@ export class AquiferTurbines extends PreludeCard {
     return player.canAfford(3);
   }
   public play(player: Player) {
-    player.addProduction(Resources.ENERGY, 2);
+    player.adjustProduction(this.productionBox);
     player.game.defer(new PlaceOceanTile(player));
     player.game.defer(new SelectHowToPayDeferred(player, 3));
     return undefined;

--- a/src/cards/prelude/BusinessEmpire.ts
+++ b/src/cards/prelude/BusinessEmpire.ts
@@ -1,16 +1,19 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
 import {CardRenderer} from '../render/CardRenderer';
+import {Units} from '../../Units';
 
 export class BusinessEmpire extends PreludeCard {
   constructor() {
     super({
       name: CardName.BUSINESS_EMPIRE,
       tags: [Tags.EARTH],
+
+      productionBox: Units.of({megacredits: 6}),
+      startingMegacredits: -6,
 
       metadata: {
         cardNumber: 'P06',
@@ -27,7 +30,7 @@ export class BusinessEmpire extends PreludeCard {
     return player.canAfford(6);
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 6);
+    player.adjustProduction(this.productionBox);
     player.game.defer(new SelectHowToPayDeferred(player, 6));
     return undefined;
   }

--- a/src/cards/prelude/DomeFarming.ts
+++ b/src/cards/prelude/DomeFarming.ts
@@ -1,7 +1,6 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Units} from '../../Units';
@@ -23,8 +22,7 @@ export class DomeFarming extends PreludeCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.PLANTS, 1);
-    player.addProduction(Resources.MEGACREDITS, 2);
+    player.adjustProduction(this.productionBox);
     return undefined;
   }
 }

--- a/src/cards/prelude/Donation.ts
+++ b/src/cards/prelude/Donation.ts
@@ -8,6 +8,8 @@ export class Donation extends PreludeCard {
     super({
       name: CardName.DONATION,
 
+      startingMegacredits: 21,
+
       metadata: {
         cardNumber: 'P08',
         renderData: CardRenderer.builder((b) => {

--- a/src/cards/prelude/GalileanMining.ts
+++ b/src/cards/prelude/GalileanMining.ts
@@ -12,6 +12,8 @@ export class GalileanMining extends PreludeCard {
       name: CardName.GALILEAN_MINING,
       tags: [Tags.JOVIAN],
 
+      startingMegacredits: -5,
+
       metadata: {
         cardNumber: 'P13',
         renderData: CardRenderer.builder((b) => {

--- a/src/cards/prelude/HugeAsteroid.ts
+++ b/src/cards/prelude/HugeAsteroid.ts
@@ -9,6 +9,8 @@ export class HugeAsteroid extends PreludeCard {
     super({
       name: CardName.HUGE_ASTEROID,
 
+      startingMegacredits: -5,
+
       metadata: {
         cardNumber: 'P15',
         renderData: CardRenderer.builder((b) => {

--- a/src/cards/prelude/Loan.ts
+++ b/src/cards/prelude/Loan.ts
@@ -10,6 +10,8 @@ export class Loan extends PreludeCard implements IProjectCard {
     super({
       name: CardName.LOAN,
 
+      startingMegacredits: 30,
+
       metadata: {
         cardNumber: 'P17',
         renderData: CardRenderer.builder((b) => {

--- a/src/cards/prelude/MartianIndustries.ts
+++ b/src/cards/prelude/MartianIndustries.ts
@@ -13,6 +13,7 @@ export class MartianIndustries extends PreludeCard implements IProjectCard {
       name: CardName.MARTIAN_INDUSTRIES,
       tags: [Tags.BUILDING],
       productionBox: Units.of({energy: 1, steel: 1}),
+      startingMegacredits: 6,
 
       metadata: {
         cardNumber: 'P18',

--- a/src/cards/prelude/MetalsCompany.ts
+++ b/src/cards/prelude/MetalsCompany.ts
@@ -1,15 +1,16 @@
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
-import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {Units} from '../../Units';
 
 export class MetalsCompany extends PreludeCard implements IProjectCard {
   constructor() {
     super({
       name: CardName.METALS_COMPANY,
 
+      productionBox: Units.of({megacredits: 1, steel: 1, titanium: 1}),
       metadata: {
         cardNumber: 'P20',
         renderData: CardRenderer.builder((b) => {
@@ -20,9 +21,7 @@ export class MetalsCompany extends PreludeCard implements IProjectCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 1);
-    player.addProduction(Resources.TITANIUM, 1);
-    player.addProduction(Resources.STEEL, 1);
+    player.adjustProduction(this.productionBox);
     return undefined;
   }
 }

--- a/src/cards/prelude/NitrogenDelivery.ts
+++ b/src/cards/prelude/NitrogenDelivery.ts
@@ -9,6 +9,8 @@ export class NitrogenDelivery extends PreludeCard implements IProjectCard {
   constructor() {
     super({
       name: CardName.NITROGEN_SHIPMENT,
+      startingMegacredits: 5,
+
 
       metadata: {
         cardNumber: 'P24',

--- a/src/cards/prelude/PreludeCard.ts
+++ b/src/cards/prelude/PreludeCard.ts
@@ -12,6 +12,7 @@ interface StaticPreludeProperties {
     metadata: ICardMetadata;
     name: CardName;
     tags?: Array<Tags>;
+    startingMegacredits?: number;
     productionBox?: Units;
 }
 
@@ -23,6 +24,7 @@ export abstract class PreludeCard extends Card implements IProjectCard {
       tags: properties.tags,
       metadata: properties.metadata,
       productionBox: properties.productionBox,
+      startingMegaCredits: properties.startingMegacredits,
     });
   }
   public abstract play(player: Player): PlayerInput | undefined;

--- a/src/cards/prelude/ResearchNetwork.ts
+++ b/src/cards/prelude/ResearchNetwork.ts
@@ -2,7 +2,6 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
-import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Units} from '../../Units';
@@ -25,7 +24,7 @@ export class ResearchNetwork extends PreludeCard implements IProjectCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 1);
+    player.adjustProduction(this.productionBox),
     player.drawCard(3);
     return undefined;
   }

--- a/src/cards/prelude/SelfSufficientSettlement.ts
+++ b/src/cards/prelude/SelfSufficientSettlement.ts
@@ -2,7 +2,6 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
-import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {PlaceCityTile} from '../../deferredActions/PlaceCityTile';
 import {CardRenderer} from '../render/CardRenderer';
@@ -25,7 +24,7 @@ export class SelfSufficientSettlement extends PreludeCard implements IProjectCar
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 2);
+    player.adjustProduction(this.productionBox);
     player.game.defer(new PlaceCityTile(player));
     return undefined;
   }

--- a/src/models/CardModel.ts
+++ b/src/models/CardModel.ts
@@ -19,4 +19,5 @@ export interface CardModel {
     reserveUnits: Readonly<Units>;
     bonusResource?: Array<Resources>;
     cloneTag?: Tags; // Used with Pathfinders
+    startingMegacredits?: number;
 }

--- a/tests/CardLoader.spec.ts
+++ b/tests/CardLoader.spec.ts
@@ -61,7 +61,7 @@ describe('CardLoader', function() {
     const turmoilPreludes: Array<CardName> = [];
     COMMUNITY_CARD_MANIFEST.preludeCards.factories.forEach((cf) => turmoilPreludes.push(cf.cardName));
     turmoilPreludes.forEach((preludeName) => {
-      const preludeCard = new CardFinder().getProjectCardByName(preludeName)!;
+      const preludeCard = new CardFinder().getPreludeByName(preludeName)!;
       expect(preludeDeck.includes(preludeCard)).is.not.true;
     });
   });


### PR DESCRIPTION
Rather than have an n^2 matrix (which I admit isn't very big) this puts most of the logic for prelude x corp behavior on the cards themselves.

It doesn't handle all of them,  and I'd like to follow up with something that handles the last couple of cases.

It relies on `productionBox` and `startingMegacredits`, and some of the cards' existing behaviors. The `tr` and moon-specific `tilesBuilt` can also be applicable to preludes - not that they would be used for Reds computation and Moon discounts, but they would fit perfectly here (not to mention could be applied in a couple other places.)