### PR TITLE
Make StrategicBasePlanning determinsitic.

### DIFF
--- a/tests/cards/pathfinders/StrategicBasePlanning.spec.ts
+++ b/tests/cards/pathfinders/StrategicBasePlanning.spec.ts
@@ -16,7 +16,16 @@ describe('StrategicBasePlanning', function() {
   beforeEach(function() {
     card = new StrategicBasePlanning();
     // 2 players to remove an early-game solo action in the deferred actions queue.
-    game = newTestGame(2, {coloniesExtension: true});
+    game = newTestGame(2, {
+      coloniesExtension: true,
+      customColoniesList: [
+        // The important thing is that Europa is absent.
+        ColonyName.GANYMEDE,
+        ColonyName.LUNA,
+        ColonyName.PLUTO,
+        ColonyName.TITAN,
+        ColonyName.TRITON],
+    });
     player = getTestPlayer(game, 0);
   });
 


### PR DESCRIPTION
The test was failing beacuse often Europa was the chosen colony, causing
the next event in the queue to be to place the ocean tile,  and not the
city tile.