### PR TITLE
Use an Experiemental UI preference to show the new global events icons.

### DIFF
--- a/src/client/components/GlobalEvent.vue
+++ b/src/client/components/GlobalEvent.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="getClass()">
-    <div v-if="showIcons === false">
+    <div v-if="showIcons() === false">
       <div class="event-party event-party--revealed" :class="partyNameClass(globalEvent.revealed)" v-i18n>{{ globalEvent.revealed }}</div>
       <div class="event-party event-party--current" :class="partyNameClass(globalEvent.current)" v-i18n>{{ globalEvent.current }}</div>
       <div class="event-content"><div class="event-text" v-i18n>{{ globalEvent.description }}</div></div>
@@ -29,6 +29,7 @@ import {IGlobalEvent} from '@/turmoil/globalEvents/IGlobalEvent';
 import {CardRenderer} from '@/cards/render/CardRenderer';
 import {getGlobalEventByName} from '@/turmoil/globalEvents/GlobalEventDealer';
 import CardDescription from '@/client/components/card/CardDescription.vue';
+import {PreferencesManager} from '../utils/PreferencesManager';
 
 export default Vue.extend({
   name: 'global-event',
@@ -43,9 +44,6 @@ export default Vue.extend({
     },
     type: {
       type: String,
-    },
-    showIcons: {
-      type: Boolean,
     },
   },
   data() {
@@ -78,6 +76,9 @@ export default Vue.extend({
       default:
         return common;
       }
+    },
+    showIcons(): boolean {
+      return PreferencesManager.loadBoolean('experimental_ui');
     },
   },
 });

--- a/src/client/components/PreferencesDialog.vue
+++ b/src/client/components/PreferencesDialog.vue
@@ -22,6 +22,7 @@ export default Vue.extend({
       'hide_discount_on_cards': false,
       'learner_mode': true,
       'hide_animated_sidebar': false,
+      'experimental_ui': false,
     };
   },
   methods: {
@@ -165,6 +166,14 @@ export default Vue.extend({
           <i class="form-icon"></i>
           <span v-i18n>Learner Mode (req. refresh)</span>
           <span class="tooltip tooltip-left" data-tooltip="Show information that can be helpful\n to players who are still learning the games">&#9432;</span>
+        </label>
+      </div>
+      <div class="preferences_panel_item">
+        <label class="form-switch">
+          <input type="checkbox" v-on:change="updatePreferences" v-model="experimental_ui">
+          <i class="form-icon"></i>
+          <span v-i18n>Experimental UI</span>
+          <span class="tooltip tooltip-left" data-tooltip="Test out any possible new experimental UI features for feedback.">&#9432;</span>
         </label>
       </div>
       <div class="preferences_panel_item form-group">

--- a/src/client/components/Turmoil.vue
+++ b/src/client/components/Turmoil.vue
@@ -1,12 +1,11 @@
 
 <template>
     <div class="turmoil" v-trim-whitespace>
-      <div class="events-board" @click='toggleGlobalEventView'>
-        <global-event v-if="turmoil.distant" :globalEvent="turmoil.distant" type="distant" :showIcons="showIcons"></global-event>
-        <global-event v-if="turmoil.coming" :globalEvent="turmoil.coming" type="coming" :showIcons="showIcons"></global-event>
-        <global-event v-if="turmoil.current" :globalEvent="turmoil.current" type="current" :showIcons="showIcons"></global-event>
+      <div class="events-board">
+        <global-event v-if="turmoil.distant" :globalEvent="turmoil.distant" type="distant"></global-event>
+        <global-event v-if="turmoil.coming" :globalEvent="turmoil.coming" type="coming"></global-event>
+        <global-event v-if="turmoil.current" :globalEvent="turmoil.current" type="current"></global-event>
       </div>
-      <div @click='toggleGlobalEventView'>{{ showIcons ? "T" : "I" }}</div>
 
       <div class="turmoil-board">
         <div class="turmoil-header">
@@ -231,11 +230,6 @@ export default Vue.extend({
       type: Object as () => TurmoilModel,
     },
   },
-  data() {
-    return {
-      showIcons: false,
-    };
-  },
   methods: {
     partyNameToCss(party: PartyName | undefined): string {
       if (party === undefined) {
@@ -313,9 +307,6 @@ export default Vue.extend({
     },
     isVisible() {
       return (this.$root as any).getVisibilityState('turmoil_parties');
-    },
-    toggleGlobalEventView() {
-      this.showIcons = !this.showIcons;
     },
   },
   components: {

--- a/src/client/utils/PreferencesManager.ts
+++ b/src/client/utils/PreferencesManager.ts
@@ -17,6 +17,7 @@ export const preferences = [
   'hide_discount_on_cards',
   'learner_mode',
   'hide_animated_sidebar',
+  'experimental_ui',
 ] as const;
 
 export type Key = typeof preferences[number];


### PR DESCRIPTION
I'm going to move the card requirements UI feature under the same preference.