### PR TITLE
Make Turmoil global event cards magnify and zoom scale the party icons.

### DIFF
--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -1845,12 +1845,14 @@
   display: inherit;
   position: absolute;
   margin: -7px 0 0 -285px;
+  transform: scale(1.4);
 }
 
 .card-party--current {
   display: inherit;
   position: absolute;
   margin: 129px 0 0 280px;
+  transform: scale(1.4);
 }
 
 @parties: greens, kelvinists, mars-first, reds, scientists, unity;

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -319,6 +319,11 @@
     transform: scale(1);
 }
 
+.preferences_magnify_cards .global-event:hover {
+    transform: scale(1.2);
+    z-index: 2;
+}
+
 /* Magnify the wee little cards in a special way, if requested */
 .preferences_small_cards.preferences_magnify_cards .filterDiv:hover {
     transform: scale(0.95);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/413481/144690013-aa47b4d9-b67e-4a5d-9008-170b2ed3f995.png)

There's still a z-index issue when highlighting the first one. :/