### PR TITLE
Add method canAddOcean, and further refine Artifical Lake.

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1446,12 +1446,17 @@ export class Game implements ISerializable<SerializedGame> {
     });
   }
 
+  public canAddOcean(): boolean {
+    if (this.board.getOceansOnBoard() === constants.MAX_OCEAN_TILES) {
+      return false;
+    }
+    return true;
+  }
   public addOceanTile(
     player: Player, spaceId: SpaceId,
     spaceType: SpaceType = SpaceType.OCEAN): void {
-    if (this.board.getOceansOnBoard() === constants.MAX_OCEAN_TILES) {
-      return;
-    }
+    if (this.canAddOcean() === false) return;
+
     this.addTile(player, spaceType, this.board.getSpace(spaceId), {
       tileType: TileType.OCEAN,
     });

--- a/src/cards/base/ArtificialLake.ts
+++ b/src/cards/base/ArtificialLake.ts
@@ -7,7 +7,6 @@ import {ISpace} from '../../boards/ISpace';
 import {SelectSpace} from '../../inputs/SelectSpace';
 import {SpaceType} from '../../SpaceType';
 import {CardName} from '../../CardName';
-import {MAX_OCEAN_TILES} from '../../constants';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
@@ -30,8 +29,12 @@ export class ArtificialLake extends Card implements IProjectCard {
     });
   }
 
+  public canPlay(player: Player) {
+    return player.game.board.getAvailableSpacesOnLand(player).length > 0;
+  }
+
   public play(player: Player) {
-    if (player.game.board.getOceansOnBoard() >= MAX_OCEAN_TILES) return undefined;
+    if (!player.game.canAddOcean()) return undefined;
 
     return new SelectSpace('Select a land space to place an ocean', player.game.board.getAvailableSpacesOnLand(player), (foundSpace: ISpace) => {
       player.game.addOceanTile(player, foundSpace.id, SpaceType.LAND);

--- a/tests/cards/base/ArtificialLake.spec.ts
+++ b/tests/cards/base/ArtificialLake.spec.ts
@@ -56,4 +56,27 @@ describe('ArtificialLake', function() {
     const action = card.play(player);
     expect(action).is.undefined;
   });
+
+  it('Cannot place ocean if all land spaces are occupied', function() {
+    // Set temperature level to fit requirements
+    (game as any).temperature = -6;
+
+    // Take all but one space.
+    const spaces = game.board.getAvailableSpacesOnLand(player);
+    spaces.forEach((space, idx) => {
+      if (idx !== 0) game.simpleAddTile(player, space, {tileType: TileType.GREENERY});
+    });
+
+    expect(game.board.getAvailableSpacesOnLand(player)).has.length(1);
+
+    // Card is still playable.
+    expect(player.canPlayIgnoringCost(card)).is.true;
+
+    // No spaces left?
+    game.simpleAddTile(player, spaces[0], {tileType: TileType.GREENERY});
+    expect(game.board.getAvailableSpacesOnLand(player)).has.length(0);
+
+    // Cannot play.
+    expect(player.canPlayIgnoringCost(card)).is.false;
+  });
 });


### PR DESCRIPTION
Artificial Lake should not be playable if no land spaces are available.