### PR TITLE
Reduce reliance on `as` for testing.

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -78,8 +78,8 @@ export type PlayerId = string;
 
 export class Player implements ISerializable<SerializedPlayer> {
   public readonly id: PlayerId;
-  private waitingFor?: PlayerInput;
-  private waitingForCb?: () => void;
+  protected waitingFor?: PlayerInput;
+  protected waitingForCb?: () => void;
   private _game: Game | undefined = undefined;
 
   // Corporate identity

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -308,13 +308,13 @@ describe('Game', () => {
     player.takeActionForFinalGreenery();
 
     // Place first greenery to get 2 plants
-    const placeFirstGreenery = player.getWaitingFor() as OrOptions;
+    const placeFirstGreenery = TestingUtils.cast(player.getWaitingFor(), OrOptions);
     const arsiaMons = game.board.getSpace(SpaceName.ARSIA_MONS);
     placeFirstGreenery.options[0].cb(arsiaMons);
     expect(player.plants).to.eq(8);
 
     // Place second greenery
-    const placeSecondGreenery = player.getWaitingFor() as OrOptions;
+    const placeSecondGreenery = TestingUtils.cast(player.getWaitingFor(), OrOptions);
     const otherSpace = game.board.getSpace('30');
     placeSecondGreenery.options[0].cb(otherSpace); ;
 

--- a/tests/TestPlayer.ts
+++ b/tests/TestPlayer.ts
@@ -85,6 +85,13 @@ export class TestPlayer extends Player {
       heat: this.heat,
     });
   }
+
+  public popWaitingFor(): PlayerInput | undefined {
+    const waitingFor = this.getWaitingFor();
+    this.waitingFor = undefined;
+    this.waitingForCb = undefined;
+    return waitingFor;
+  }
 }
 
 export interface TagsForTest {

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -147,7 +147,7 @@ export class TestingUtils {
 
   // type Class<T> = new (...args: any[]) => T;
   // export function cast<T>(klass: Class<T>, obj: any): T {
-  public static cast<T>(klass: new (...args: any[]) => T, obj: any): T {
+  public static cast<T>(obj: any, klass: new (...args: any[]) => T): T {
     if (!(obj instanceof klass)) {
       throw new Error(`Not an instance of ${klass.name}: ${obj.constructor.name}`);
     }

--- a/tests/ares/AresHandler.spec.ts
+++ b/tests/ares/AresHandler.spec.ts
@@ -134,7 +134,8 @@ describe('AresHandler', function() {
 
     player.addProduction(Resources.PLANTS, 7);
     game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
-    const input = game.deferredActions.peek()!.execute() as SelectProductionToLose;
+    TestingUtils.runAllActions(game);
+    const input = TestingUtils.cast(player.getWaitingFor(), SelectProductionToLose);
     expect(input.unitsToLose).eq(1);
     input.cb(Units.of({plants: 1}));
     expect(player.getProduction(Resources.PLANTS)).eq(6);
@@ -157,7 +158,8 @@ describe('AresHandler', function() {
     player.addProduction(Resources.PLANTS, 7);
     game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
 
-    const input = game.deferredActions.peek()!.execute() as SelectProductionToLose;
+    TestingUtils.runAllActions(game);
+    const input = TestingUtils.cast(player.getWaitingFor(), SelectProductionToLose);
     expect(input.unitsToLose).eq(2);
     input.cb(Units.of({plants: 2}));
     expect(player.getProduction(Resources.PLANTS)).eq(5);

--- a/tests/boards/ArabiaTerraBoard.spec.ts
+++ b/tests/boards/ArabiaTerraBoard.spec.ts
@@ -97,7 +97,7 @@ describe('Board', function() {
 
   it('Can land-claim, and then place on, a cove space', () => {
     const landClaim = new LandClaim();
-    const selectSpace = landClaim.play(player) as SelectSpace;
+    const selectSpace = TestingUtils.cast(landClaim.play(player), SelectSpace);
     const space = board.getSpaces(SpaceType.COVE)[0];
     expect(selectSpace.availableSpaces.map((space) => space.id)).contains(space.id);
 

--- a/tests/cards/CardRequirements.spec.ts
+++ b/tests/cards/CardRequirements.spec.ts
@@ -233,7 +233,8 @@ describe('CardRequirements', function() {
     const smallAsteroid = new SmallAsteroid();
     smallAsteroid.play(player);
     // Choose Remove 1 plant option
-    const orOptions = player.game.deferredActions.peek()!.execute() as OrOptions;
+    TestingUtils.runAllActions(player.game);
+    const orOptions = TestingUtils.cast(player.getWaitingFor(), OrOptions);
     orOptions.options[0].cb([player2]);
 
     expect(requirements.satisfies(player)).eq(true);

--- a/tests/cards/CardSerialization.spec.ts
+++ b/tests/cards/CardSerialization.spec.ts
@@ -4,6 +4,7 @@ import {LobbyHalls} from '../../src/cards/pathfinders/LobbyHalls';
 import {Tags} from '../../src/cards/Tags';
 import {deserializeProjectCard, serializeProjectCard} from '../../src/cards/CardSerialization';
 import {CardFinder} from '../../src/CardFinder';
+import {TestingUtils} from '../TestingUtils';
 
 describe('CardSerialization', function() {
   let cardFinder = new CardFinder();
@@ -19,9 +20,9 @@ describe('CardSerialization', function() {
 
     expect(serializedCard.cloneTag).eq(Tags.CLONE);
     const deserialized = deserializeProjectCard(serializedCard, cardFinder);
-    expect(deserialized).is.instanceOf(LobbyHalls);
-    expect((deserialized as LobbyHalls).cloneTag).eq(Tags.CLONE);
-    expect(deserialized.tags).deep.eq([Tags.CLONE, Tags.BUILDING]);
+    const lobbyHalls = TestingUtils.cast(deserialized, LobbyHalls);
+    expect(lobbyHalls.cloneTag).eq(Tags.CLONE);
+    expect(lobbyHalls.tags).deep.eq([Tags.CLONE, Tags.BUILDING]);
   });
 
   it('defined clone tags serialize and deserialize', function() {
@@ -32,8 +33,8 @@ describe('CardSerialization', function() {
     expect(serializedCard.cloneTag).eq(Tags.SCIENCE);
 
     const deserialized = deserializeProjectCard(serializedCard, cardFinder);
-    expect(deserialized).is.instanceOf(LobbyHalls);
-    expect((deserialized as LobbyHalls).cloneTag).eq(Tags.SCIENCE);
-    expect(deserialized.tags).deep.eq([Tags.SCIENCE, Tags.BUILDING]);
+    const lobbyHalls = TestingUtils.cast(deserialized, LobbyHalls);
+    expect(lobbyHalls.cloneTag).eq(Tags.SCIENCE);
+    expect(lobbyHalls.tags).deep.eq([Tags.SCIENCE, Tags.BUILDING]);
   });
 });

--- a/tests/cards/ares/ButterflyEffect.spec.ts
+++ b/tests/cards/ares/ButterflyEffect.spec.ts
@@ -5,6 +5,7 @@ import {ShiftAresGlobalParameters} from '../../../src/inputs/ShiftAresGlobalPara
 import {getTestPlayer, newTestGame} from '../../TestGame';
 import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/Game';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('ButterflyEffect', function() {
   let card: ButterflyEffect;
@@ -28,7 +29,8 @@ describe('ButterflyEffect', function() {
     expect(originalHazardData.severeErosionTemperature.threshold).eq(-4);
     expect(originalHazardData.severeDustStormOxygen.threshold).eq(5);
 
-    const input = game.deferredActions.peek()!.execute() as ShiftAresGlobalParameters;
+    TestingUtils.runAllActions(game);
+    const input = TestingUtils.cast(player.getWaitingFor(), ShiftAresGlobalParameters);
     input.cb(
       {
         lowOceanDelta: -1,

--- a/tests/cards/ares/MiningRightsAres.spec.ts
+++ b/tests/cards/ares/MiningRightsAres.spec.ts
@@ -8,6 +8,7 @@ import {Resources} from '../../../src/Resources';
 import {MiningRightsAres} from '../../../src/cards/ares/MiningRightsAres';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
 import {TestPlayers} from '../../TestPlayers';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('MiningRightsAres', function() {
   let card : MiningRightsAres; let player : Player; let game : Game;
@@ -44,12 +45,12 @@ describe('MiningRightsAres', function() {
     const land = game.board.getAvailableSpacesOnLand(player)
       .find((land) => land.bonus.includes(SpaceBonus.STEEL))!;
 
-    let action = card.play(player) as SelectSpace;
+    let action = TestingUtils.cast(card.play(player), SelectSpace);
     const size = action.availableSpaces.length;
     expect(action.availableSpaces).contains(land);
 
     land.tile = {tileType: TileType.MINING_RIGHTS};
-    action = card.play(player) as SelectSpace;
+    action = TestingUtils.cast(card.play(player), SelectSpace);
     expect(action.availableSpaces).has.length(size - 1);
     expect(action.availableSpaces).does.not.contain(land);
   });

--- a/tests/cards/base/Ants.spec.ts
+++ b/tests/cards/base/Ants.spec.ts
@@ -5,20 +5,21 @@ import {NitriteReducingBacteria} from '../../../src/cards/base/NitriteReducingBa
 import {ProtectedHabitats} from '../../../src/cards/base/ProtectedHabitats';
 import {SecurityFleet} from '../../../src/cards/base/SecurityFleet';
 import {Tardigrades} from '../../../src/cards/base/Tardigrades';
-import {ICard} from '../../../src/cards/ICard';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('Ants', function() {
-  let card : Ants; let player : Player; let player2 : Player; let game : Game;
+  let card : Ants; let player : TestPlayer; let player2 : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new Ants();
     player = TestPlayers.BLUE.newPlayer();
     player2 = TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
+    player.popWaitingFor();
   });
 
   it('Can\'t play without oxygen', function() {
@@ -49,10 +50,11 @@ describe('Ants', function() {
     expect(card.canAct(player)).is.true;
 
     card.action(player);
-    const selectCard = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
+    TestingUtils.runAllActions(game);
+    const selectCard = TestingUtils.cast(player.getWaitingFor(), SelectCard);
     expect(selectCard.cards).has.lengthOf(2);
     selectCard.cb([selectCard.cards[0]]);
-    game.deferredActions.pop()!.execute(); // Add microbe to ants
+    TestingUtils.runAllActions(game);
 
     expect(card.resourceCount).to.eq(1);
     expect(tardigrades.resourceCount).to.eq(0);
@@ -83,11 +85,10 @@ describe('Ants', function() {
     player2.addResourceTo(securityFleet);
 
     card.action(player);
-    const selectCard = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
-    expect(selectCard).is.undefined; // Only one option: Tardigrades
-        game.deferredActions.pop()!.execute(); // Add microbe to ants
+    TestingUtils.runAllActions(game);
+    expect(player.getWaitingFor()).is.undefined;
 
-        expect(card.resourceCount).to.eq(1);
-        expect(tardigrades.resourceCount).to.eq(0);
+    expect(card.resourceCount).to.eq(1);
+    expect(tardigrades.resourceCount).to.eq(0);
   });
 });

--- a/tests/cards/base/Asteroid.spec.ts
+++ b/tests/cards/base/Asteroid.spec.ts
@@ -5,6 +5,7 @@ import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('Asteroid', function() {
   let card : Asteroid; let player : Player; let player2 : Player; let game : Game;
@@ -19,9 +20,9 @@ describe('Asteroid', function() {
   it('Should play', function() {
     player2.plants = 2;
     card.play(player);
-    expect(game.deferredActions).has.lengthOf(1);
+    TestingUtils.runAllActions(game);
 
-    const orOptions = game.deferredActions.peek()!.execute() as OrOptions;
+    const orOptions = TestingUtils.cast(player.getWaitingFor(), OrOptions);
     orOptions.options[1].cb(); // do nothing
     expect(player2.getResource(Resources.PLANTS)).to.eq(2);
 

--- a/tests/cards/base/AsteroidMiningConsortium.spec.ts
+++ b/tests/cards/base/AsteroidMiningConsortium.spec.ts
@@ -5,6 +5,7 @@ import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
 import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('AsteroidMiningConsortium', function() {
   let card : AsteroidMiningConsortium; let player : TestPlayer; let player2 : TestPlayer; let game : Game;
@@ -39,8 +40,8 @@ describe('AsteroidMiningConsortium', function() {
     card.play(player);
     expect(player.getProduction(Resources.TITANIUM)).to.eq(2);
 
-    expect(game.deferredActions).has.lengthOf(1);
-    const selectPlayer = game.deferredActions.peek()!.execute() as SelectPlayer;
+    TestingUtils.runAllActions(game);
+    const selectPlayer = TestingUtils.cast(player.getWaitingFor(), SelectPlayer);
     selectPlayer.cb(player2);
     expect(player2.getProduction(Resources.TITANIUM)).to.eq(0);
   });

--- a/tests/cards/base/BigAsteroid.spec.ts
+++ b/tests/cards/base/BigAsteroid.spec.ts
@@ -4,6 +4,7 @@ import {Game} from '../../../src/Game';
 import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Player} from '../../../src/Player';
 import {TestPlayers} from '../../TestPlayers';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('BigAsteroid', function() {
   let card : BigAsteroid; let player : Player; let player2 : Player; let game : Game;
@@ -18,9 +19,9 @@ describe('BigAsteroid', function() {
   it('Should play', function() {
     player2.plants = 5;
     card.play(player);
-    expect(game.deferredActions).has.lengthOf(1);
+    TestingUtils.runAllActions(game);
 
-    const orOptions = game.deferredActions.peek()!.execute() as OrOptions;
+    const orOptions = TestingUtils.cast(player.getWaitingFor(), OrOptions);
     orOptions.options[1].cb(); // do nothing
     expect(player2.plants).to.eq(5);
 

--- a/tests/cards/pathfinders/Ambient.spec.ts
+++ b/tests/cards/pathfinders/Ambient.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Ambient} from '../../../src/cards/pathfinders/Ambient';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {TestingUtils} from '../../TestingUtils';
 import {Tags} from '../../../src/cards/Tags';
 import {Resources} from '../../../src/Resources';
@@ -19,8 +19,8 @@ describe('Ambient', function() {
   beforeEach(function() {
     card = new Ambient();
     game = newTestGame(2);
-    player = game.getPlayers()[0] as TestPlayer;
-    player2 = game.getPlayers()[1] as TestPlayer;
+    player = getTestPlayer(game, 0);
+    player2 = getTestPlayer(game, 1);
     player.corporationCard = card;
   });
 
@@ -86,9 +86,9 @@ describe('Ambient', function() {
     (game as any).temperature = MAX_TEMPERATURE;
 
     const getBlueActions = function() {
-      const actions = TestingUtils.cast(OrOptions, player.getActions());
+      const actions = TestingUtils.cast(player.getActions(), OrOptions);
       if (actions.options[0].title === 'Perform an action from a played card') {
-        return TestingUtils.cast(SelectCard, actions.options[0]);
+        return TestingUtils.cast(actions.options[0], SelectCard);
       }
       return undefined;
     };

--- a/tests/cards/pathfinders/AsteroidResources.spec.ts
+++ b/tests/cards/pathfinders/AsteroidResources.spec.ts
@@ -3,7 +3,7 @@ import {AsteroidResources} from '../../../src/cards/pathfinders/AsteroidResource
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Resources} from '../../../src/Resources';
 import {PlaceOceanTile} from '../../../src/deferredActions/PlaceOceanTile';
@@ -18,7 +18,7 @@ describe('AsteroidResources', function() {
   beforeEach(function() {
     card = new AsteroidResources();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
   });
 
   it('canPlay', function() {

--- a/tests/cards/pathfinders/BreedingFarms.spec.ts
+++ b/tests/cards/pathfinders/BreedingFarms.spec.ts
@@ -4,7 +4,7 @@ import {Fish} from '../../../src/cards/base/Fish';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
-import {TestingUtils} from '../../../tests/TestingUtils';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('BreedingFarms', function() {
   let card: BreedingFarms;

--- a/tests/cards/pathfinders/Chimera.spec.ts
+++ b/tests/cards/pathfinders/Chimera.spec.ts
@@ -6,7 +6,7 @@ import {AdaptationTechnology} from '../../../src/cards/base/AdaptationTechnology
 import {Cartel} from '../../../src/cards/base/Cartel';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {CardName} from '../../../src/CardName';
 import {TestingUtils} from '../../TestingUtils';
 import {CardRequirements} from '../../../src/cards/CardRequirements';
@@ -23,7 +23,7 @@ describe('Chimera', function() {
   beforeEach(function() {
     card = new Chimera();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
     player.corporationCard = card;
   });
 

--- a/tests/cards/pathfinders/ControlledBloom.spec.ts
+++ b/tests/cards/pathfinders/ControlledBloom.spec.ts
@@ -3,7 +3,7 @@ import {ControlledBloom} from '../../../src/cards/pathfinders/ControlledBloom';
 import {Game} from '../../../src/Game';
 import {ICard} from '../../../src/cards/ICard';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {CardName} from '../../../src/CardName';
 import {TestingUtils} from '../../TestingUtils';
 import {SelectCard} from '../../../src/inputs/SelectCard';
@@ -17,7 +17,7 @@ describe('ControlledBloom', function() {
   beforeEach(function() {
     card = new ControlledBloom();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
   });
 
   it('canPlay', function() {

--- a/tests/cards/pathfinders/CoordinatedRaid.spec.ts
+++ b/tests/cards/pathfinders/CoordinatedRaid.spec.ts
@@ -51,7 +51,7 @@ describe('CoordinatedRaid', function() {
     colony.addColony(player2);
     colony.addColony(player2);
     const action = card.play(player);
-    const selectColony = TestingUtils.cast(SelectColony, action);
+    const selectColony = TestingUtils.cast(action, SelectColony);
 
     expect(player.getResourcesForTest()).deep.eq(Units.EMPTY);
     expect(player2.getResourcesForTest()).deep.eq(Units.of({titanium: 6}));

--- a/tests/cards/pathfinders/CrewTraining.spec.ts
+++ b/tests/cards/pathfinders/CrewTraining.spec.ts
@@ -6,6 +6,7 @@ import {Tags} from '../../../src/cards/Tags';
 import {TestPlayer} from '../../TestPlayer';
 import {DeclareCloneTag} from '../../../src/pathfinders/DeclareCloneTag';
 import {OrOptions} from '../../../src/inputs/OrOptions';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('CrewTraining', function() {
   let card: CrewTraining;
@@ -29,7 +30,7 @@ describe('CrewTraining', function() {
     expect(game.deferredActions.length).eq(1);
     const action = game.deferredActions.pop();
     expect(action).instanceOf(DeclareCloneTag);
-    const options = action!.execute() as OrOptions;
+    const options = TestingUtils.cast(action!.execute(), OrOptions);
 
     expect(options.options[0].title).to.match(/earth/);
     expect(game.pathfindersData).deep.eq({

--- a/tests/cards/pathfinders/Cryptocurrency.spec.ts
+++ b/tests/cards/pathfinders/Cryptocurrency.spec.ts
@@ -4,6 +4,7 @@ import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 import {OrOptions} from '../../../src/inputs/OrOptions';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('Cryptocurrency', function() {
   let card: Cryptocurrency;
@@ -50,8 +51,7 @@ describe('Cryptocurrency', function() {
     card.resourceCount = 6;
     const options = card.action(player);
 
-    expect(options).is.instanceOf(OrOptions);
-    const orOptions = options as OrOptions;
+    const orOptions = TestingUtils.cast(options, OrOptions);
 
     orOptions.options[0].cb();
 

--- a/tests/cards/pathfinders/CultivationOfVenus.spec.ts
+++ b/tests/cards/pathfinders/CultivationOfVenus.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {CultivationOfVenus} from '../../../src/cards/pathfinders/CultivationOfVenus';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('CultivationOfVenus', function() {
   let card: CultivationOfVenus;
@@ -12,7 +12,7 @@ describe('CultivationOfVenus', function() {
   beforeEach(function() {
     card = new CultivationOfVenus();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
   });
 
   it('Can act', function() {

--- a/tests/cards/pathfinders/DeclarationOfIndependence.spec.ts
+++ b/tests/cards/pathfinders/DeclarationOfIndependence.spec.ts
@@ -6,7 +6,7 @@ import {TestPlayers} from '../../TestPlayers';
 import {TestingUtils} from '../../TestingUtils';
 import {Turmoil} from '../../../src/turmoil/Turmoil';
 import {PartyName} from '../../../src/turmoil/parties/PartyName';
-import {SendDelegateToArea} from '../../../src/deferredActions/SendDelegateToArea';
+import {SelectPartyToSendDelegate} from '../../../src/inputs/SelectPartyToSendDelegate';
 
 describe('DeclarationOfIndependence', function() {
   let card: DeclarationOfIndependence;
@@ -40,9 +40,9 @@ describe('DeclarationOfIndependence', function() {
     const marsFirst = turmoil.getPartyByName(PartyName.MARS)!;
     expect(marsFirst.getDelegates(player.id)).eq(0);
     card.play(player);
-    const action = player.game.deferredActions.pop() as SendDelegateToArea;
-    const options = action.execute();
-    options!.cb(marsFirst.name);
+    TestingUtils.runAllActions(player.game);
+    const action = TestingUtils.cast(player.getWaitingFor(), SelectPartyToSendDelegate);
+    action.cb(marsFirst.name);
 
     expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(4);
     expect(marsFirst.getDelegates(player.id)).eq(2);

--- a/tests/cards/pathfinders/ExpeditionToTheSurfaceVenus.spec.ts
+++ b/tests/cards/pathfinders/ExpeditionToTheSurfaceVenus.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {ExpeditionToTheSurfaceVenus} from '../../../src/cards/pathfinders/ExpeditionToTheSurfaceVenus';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('ExpeditiontotheSurfaceVenus', function() {
   let card: ExpeditionToTheSurfaceVenus;
@@ -12,7 +12,7 @@ describe('ExpeditiontotheSurfaceVenus', function() {
   beforeEach(function() {
     card = new ExpeditionToTheSurfaceVenus();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/FloaterUrbanism.spec.ts
+++ b/tests/cards/pathfinders/FloaterUrbanism.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {FloaterUrbanism} from '../../../src/cards/pathfinders/FloaterUrbanism';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {IProjectCard} from '../../../src/cards/IProjectCard';
 import {TitanShuttles} from '../../../src/cards/colonies/TitanShuttles';
 import {FloatingHabs} from '../../../src/cards/venusNext/FloatingHabs';
@@ -20,7 +20,7 @@ describe('FloaterUrbanism', function() {
   beforeEach(function() {
     card = new FloaterUrbanism();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
     floater1 = new TitanShuttles();
     floater2 = new FloatingHabs();
     other = new MartianCulture();

--- a/tests/cards/pathfinders/GeologicalExpedition.spec.ts
+++ b/tests/cards/pathfinders/GeologicalExpedition.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {GeologicalExpedition} from '../../../src/cards/pathfinders/GeologicalExpedition';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {EmptyBoard} from '../../ares/EmptyBoard';
 import {ISpace} from '../../../src/boards/ISpace';
 import {SpaceBonus} from '../../../src/SpaceBonus';
@@ -23,7 +23,7 @@ describe('GeologicalExpedition', function() {
   beforeEach(function() {
     card = new GeologicalExpedition();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
     game.board = EmptyBoard.newInstance();
     space = game.board.getAvailableSpacesOnLand(player)[0];
     microbeCard = TestingUtils.fakeCard({resourceType: ResourceType.MICROBE});
@@ -99,7 +99,7 @@ describe('GeologicalExpedition', function() {
     expect(player.getResourcesForTest()).deep.eq(Units.of({plants: 1, heat: 1}));
 
     TestingUtils.runAllActions(game);
-    const orOptions = TestingUtils.cast(OrOptions, player.getWaitingFor());
+    const orOptions = TestingUtils.cast(player.getWaitingFor(), OrOptions);
     expect(orOptions.options).has.length(3);
     orOptions.options[0].cb();
     TestingUtils.runAllActions(game);

--- a/tests/cards/pathfinders/HuygensObservatory.spec.ts
+++ b/tests/cards/pathfinders/HuygensObservatory.spec.ts
@@ -45,7 +45,7 @@ describe('HuygensObservatory', function() {
 
     TestingUtils.runAllActions(game);
 
-    const selectColony = TestingUtils.cast(SelectColony, player.popWaitingFor());
+    const selectColony = TestingUtils.cast(player.popWaitingFor(), SelectColony);
     expect(selectColony.colonies).has.length(5);
     expect(selectColony.title).eq('Select colony for Huygens Observatory');
 
@@ -58,7 +58,7 @@ describe('HuygensObservatory', function() {
 
     TestingUtils.runAllActions(game);
 
-    const tradeDestination = TestingUtils.cast(SelectColony, player.popWaitingFor());
+    const tradeDestination = TestingUtils.cast(player.popWaitingFor(), SelectColony);
 
     expect(tradeDestination.colonies).has.length(5);
 
@@ -79,7 +79,7 @@ describe('HuygensObservatory', function() {
 
     TestingUtils.runAllActions(game);
 
-    const selectColony = TestingUtils.cast(SelectColony, player.popWaitingFor());
+    const selectColony = TestingUtils.cast(player.popWaitingFor(), SelectColony);
     expect(selectColony.colonies).has.length(5);
     expect(selectColony.colonies.map((c) => c.name)).contains(ColonyName.GANYMEDE);
 
@@ -101,7 +101,7 @@ describe('HuygensObservatory', function() {
     TestingUtils.runAllActions(game);
 
     // Go straight to trade
-    const tradeDestination = TestingUtils.cast(SelectColony, player.popWaitingFor());
+    const tradeDestination = TestingUtils.cast(player.popWaitingFor(), SelectColony);
     expect(tradeDestination.title).eq('Select colony tile to trade with for free');
     expect(tradeDestination.colonies).has.length(5);
 
@@ -122,14 +122,14 @@ describe('HuygensObservatory', function() {
     expect(player.getProductionForTest()).deep.eq(Units.EMPTY);
 
     TestingUtils.runAllActions(game);
-    const selectColony = TestingUtils.cast(SelectColony, player.popWaitingFor());
+    const selectColony = TestingUtils.cast(player.popWaitingFor(), SelectColony);
     selectColony.cb(ganymede);
 
     expect(ganymede.visitor).eq(player.id);
 
     TestingUtils.runAllActions(game);
 
-    const recallTradeFleet = TestingUtils.cast(SelectColony, player.popWaitingFor());
+    const recallTradeFleet = TestingUtils.cast(player.popWaitingFor(), SelectColony);
 
     expect(selectColony.colonies).has.length(5);
 
@@ -139,7 +139,7 @@ describe('HuygensObservatory', function() {
 
     TestingUtils.runAllActions(game);
 
-    const tradeDestination = TestingUtils.cast(SelectColony, player.popWaitingFor());
+    const tradeDestination = TestingUtils.cast(player.popWaitingFor(), SelectColony);
 
     expect(tradeDestination.colonies).has.length(4);
     expect(tradeDestination.colonies.map((c) => c.name)).does.not.contain(ColonyName.GANYMEDE);
@@ -157,24 +157,24 @@ describe('HuygensObservatory', function() {
     expect(player.getProductionForTest()).deep.eq(Units.EMPTY);
 
     TestingUtils.runAllActions(game);
-    const selectColony = TestingUtils.cast(SelectColony, player.popWaitingFor());
+    const selectColony = TestingUtils.cast(player.popWaitingFor(), SelectColony);
     selectColony.cb(ganymede);
 
     expect(ganymede.visitor).eq(player.id);
 
     TestingUtils.runAllActions(game);
 
-    const chooseTradeFleet = TestingUtils.cast(OrOptions, player.popWaitingFor());
+    const chooseTradeFleet = TestingUtils.cast(player.popWaitingFor(), OrOptions);
     expect(chooseTradeFleet.options).has.length(2);
 
-    const recallTradeFleet = TestingUtils.cast(SelectColony, chooseTradeFleet.options[0]);
+    const recallTradeFleet = TestingUtils.cast(chooseTradeFleet.options[0], SelectColony);
 
     expect(recallTradeFleet.colonies).has.length(1);
     expect(recallTradeFleet.colonies[0].name).eq(ColonyName.GANYMEDE);
     expect(recallTradeFleet.title).eq('Select a colony tile to recall a trade fleet from');
 
     // Ignored. We know this is the "use an existing unused trade fleet"
-    TestingUtils.cast(SelectOption, chooseTradeFleet.options[1]);
+    TestingUtils.cast(chooseTradeFleet.options[1], SelectOption);
     TestingUtils.runAllActions(game);
   });
 });

--- a/tests/cards/pathfinders/InterplanetaryTransport.spec.ts
+++ b/tests/cards/pathfinders/InterplanetaryTransport.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {InterplanetaryTransport} from '../../../src/cards/pathfinders/InterplanetaryTransport';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {TileType} from '../../../src/TileType';
 import {SpaceName} from '../../../src/SpaceName';
 import {Resources} from '../../../src/Resources';
@@ -15,7 +15,7 @@ describe('InterplanetaryTransport', function() {
   beforeEach(function() {
     card = new InterplanetaryTransport();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
   });
 
   it('play - cities on land yield nothing', function() {

--- a/tests/cards/pathfinders/MartianDustProcessingPlant.spec.ts
+++ b/tests/cards/pathfinders/MartianDustProcessingPlant.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {MartianDustProcessingPlant} from '../../../src/cards/pathfinders/MartianDustProcessingPlant';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {Units} from '../../../src/Units';
 
 describe('MartianDustProcessingPlant', function() {
@@ -13,7 +13,7 @@ describe('MartianDustProcessingPlant', function() {
   beforeEach(function() {
     card = new MartianDustProcessingPlant();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
   });
 
   it('canPlay', function() {

--- a/tests/cards/pathfinders/MartianInsuranceGroup.spec.ts
+++ b/tests/cards/pathfinders/MartianInsuranceGroup.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {MartianInsuranceGroup} from '../../../src/cards/pathfinders/MartianInsuranceGroup';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {CardName} from '../../../src/CardName';
 import {TestingUtils} from '../../TestingUtils';
 import {CardType} from '../../../src/cards/CardType';
@@ -17,8 +17,8 @@ describe('MartianInsuranceGroup', function() {
   beforeEach(function() {
     card = new MartianInsuranceGroup();
     game = newTestGame(2);
-    player = game.getPlayers()[0] as TestPlayer;
-    player2 = game.getPlayers()[1] as TestPlayer;
+    player = getTestPlayer(game, 0);
+    player2 = getTestPlayer(game, 1);
     player.corporationCard = card;
   });
 

--- a/tests/cards/pathfinders/Pollinators.spec.ts
+++ b/tests/cards/pathfinders/Pollinators.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Pollinators} from '../../../src/cards/pathfinders/Pollinators';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {Units} from '../../../src/Units';
 
 describe('Pollinators', function() {
@@ -13,7 +13,7 @@ describe('Pollinators', function() {
   beforeEach(function() {
     card = new Pollinators();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
   });
 
   it('canPlay', function() {

--- a/tests/cards/pathfinders/PublicSponsoredGrant.spec.ts
+++ b/tests/cards/pathfinders/PublicSponsoredGrant.spec.ts
@@ -3,7 +3,7 @@ import {PublicSponsoredGrant} from '../../../src/cards/pathfinders/PublicSponsor
 import {Game} from '../../../src/Game';
 import {Turmoil} from '../../../src/turmoil/Turmoil';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {BiomassCombustors} from '../../../src/cards/base/BiomassCombustors';
 import {SearchForLife} from '../../../src/cards/base/SearchForLife';
 import {ColonizerTrainingCamp} from '../../../src/cards/base/ColonizerTrainingCamp';
@@ -22,9 +22,9 @@ describe('PublicSponsoredGrant', function() {
   beforeEach(function() {
     card = new PublicSponsoredGrant();
     game = newTestGame(3, {turmoilExtension: true});
-    player = game.getPlayers()[0] as TestPlayer;
-    player2 = game.getPlayers()[1] as TestPlayer;
-    player3 = game.getPlayers()[2] as TestPlayer;
+    player = getTestPlayer(game, 0);
+    player2 = getTestPlayer(game, 1);
+    player3 = getTestPlayer(game, 2);
   });
 
   it('canPlay', function() {

--- a/tests/cards/pathfinders/RedCity.spec.ts
+++ b/tests/cards/pathfinders/RedCity.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {RedCity} from '../../../src/cards/pathfinders/RedCity';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {Turmoil} from '../../../src/turmoil/Turmoil';
 import {PartyName} from '../../../src/turmoil/parties/PartyName';
 import {Phase} from '../../../src/Phase';
@@ -22,8 +22,8 @@ describe('RedCity', function() {
   beforeEach(function() {
     card = new RedCity();
     game = newTestGame(2, {pathfindersExpansion: true});
-    player = game.getPlayers()[0] as TestPlayer;
-    player2 = game.getPlayers()[1] as TestPlayer;
+    player = getTestPlayer(game, 0);
+    player2 = getTestPlayer(game, 1);
     turmoil = game.turmoil!;
     board = game.board;
   });

--- a/tests/cards/pathfinders/Ringcom.spec.ts
+++ b/tests/cards/pathfinders/Ringcom.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Ringcom} from '../../../src/cards/pathfinders/Ringcom';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {CardName} from '../../../src/CardName';
 import {TestingUtils} from '../../TestingUtils';
 import {Tags} from '../../../src/cards/Tags';
@@ -16,8 +16,8 @@ describe('Ringcom', function() {
   beforeEach(function() {
     card = new Ringcom();
     game = newTestGame(2);
-    player = game.getPlayers()[0] as TestPlayer;
-    player2 = game.getPlayers()[1] as TestPlayer;
+    player = getTestPlayer(game, 0);
+    player2 = getTestPlayer(game, 1);
     player.corporationCard = card;
   });
 

--- a/tests/cards/pathfinders/SoilDetoxification.spec.ts
+++ b/tests/cards/pathfinders/SoilDetoxification.spec.ts
@@ -3,7 +3,7 @@ import {SoilDetoxification} from '../../../src/cards/pathfinders/SoilDetoxificat
 import {Game} from '../../../src/Game';
 import {Turmoil} from '../../../src/turmoil/Turmoil';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {EcoLine} from '../../../src/cards/corporation/EcoLine';
 import {ConvertPlants} from '../../../src/cards/base/standardActions/ConvertPlants';
 import {Unity} from '../../../src/turmoil/parties/Unity';
@@ -18,7 +18,7 @@ describe('SoilDetoxification', function() {
   beforeEach(function() {
     card = new SoilDetoxification();
     game = newTestGame(1, {turmoilExtension: true});
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
   });
 
   it('canPlay', function() {

--- a/tests/cards/pathfinders/Steelaris.spec.ts
+++ b/tests/cards/pathfinders/Steelaris.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Steelaris} from '../../../src/cards/pathfinders/Steelaris';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {TileType} from '../../../src//TileType';
 import {TestingUtils} from '../../TestingUtils';
 import {EmptyBoard} from '../../ares/EmptyBoard';
@@ -16,8 +16,8 @@ describe('Steelaris', function() {
   beforeEach(function() {
     card = new Steelaris();
     game = newTestGame(2);
-    player = game.getPlayers()[0] as TestPlayer;
-    player2 = game.getPlayers()[1] as TestPlayer;
+    player = getTestPlayer(game, 0);
+    player2 = getTestPlayer(game, 1);
     player.corporationCard = card;
     game.board = EmptyBoard.newInstance();
   });

--- a/tests/cards/pathfinders/TerraformingRobots.spec.ts
+++ b/tests/cards/pathfinders/TerraformingRobots.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {TerraformingRobots} from '../../../src/cards/pathfinders/TerraformingRobots';
 import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {newTestGame} from '../../TestGame';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {IProjectCard} from '../../../src/cards/IProjectCard';
 import {TitanShuttles} from '../../../src/cards/colonies/TitanShuttles';
 import {FloatingHabs} from '../../../src/cards/venusNext/FloatingHabs';
@@ -22,7 +22,7 @@ describe('TerraformingRobots', function() {
   beforeEach(function() {
     card = new TerraformingRobots();
     game = newTestGame(1);
-    player = game.getPlayers()[0] as TestPlayer;
+    player = getTestPlayer(game, 0);
     floater1 = new TitanShuttles();
     floater2 = new FloatingHabs();
     other = new MartianCulture();


### PR DESCRIPTION
TestingUtils.cast() verifies the type being cast, and so throws errors when the type does not match.

Also relied a bit on getTestPlayer.