### PR TITLE
Make Corroder Suits compatible with Floater Urbanism.

### DIFF
--- a/src/cards/venusNext/CorroderSuits.ts
+++ b/src/cards/venusNext/CorroderSuits.ts
@@ -2,7 +2,6 @@ import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Resources} from '../../Resources';
-import {ResourceType} from '../../ResourceType';
 import {SelectCard} from '../../inputs/SelectCard';
 import {ICard} from '../ICard';
 import {CardName} from '../../CardName';
@@ -51,9 +50,6 @@ export class CorroderSuits extends Card {
     );
   }
   public static getVenusResCards(player: Player): ICard[] {
-    let resourceCards = player.getResourceCards(ResourceType.FLOATER);
-    resourceCards = resourceCards.concat(player.getResourceCards(ResourceType.MICROBE));
-    resourceCards = resourceCards.concat(player.getResourceCards(ResourceType.ANIMAL));
-    return resourceCards.filter((card) => card.tags.includes(Tags.VENUS));
+    return player.getResourceCards().filter((card) => card.tags.includes(Tags.VENUS));
   }
 }

--- a/tests/cards/venusNext/CorroderSuits.spec.ts
+++ b/tests/cards/venusNext/CorroderSuits.spec.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import {AerialMappers} from '../../../src/cards/venusNext/AerialMappers';
 import {CorroderSuits} from '../../../src/cards/venusNext/CorroderSuits';
 import {Dirigibles} from '../../../src/cards/venusNext/Dirigibles';
+import {FloaterUrbanism} from '../../../src/cards/pathfinders/FloaterUrbanism';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {Player} from '../../../src/Player';
@@ -43,5 +44,14 @@ describe('CorroderSuits', function() {
         action!.cb([card2]);
         expect(player.getResourcesOnCard(card2)).to.eq(1);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
+  });
+
+  it('Should play - specialized resource type', function() {
+    const card2 = new FloaterUrbanism();
+    player.playedCards.push(card2);
+
+    card.play(player);
+    expect(player.getResourcesOnCard(card2)).to.eq(1);
+    expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
   });
 });


### PR DESCRIPTION
This is done by just removing its resource type constraints, which
were probably put there at a time when getResourceCards required
a resource type.