### PR TITLE
Split out colonies trading details into handlers.

### DIFF
--- a/src/cards/colonies/TitanFloatingLaunchPad.ts
+++ b/src/cards/colonies/TitanFloatingLaunchPad.ts
@@ -103,8 +103,8 @@ export class TradeWithTitanFloatingLaunchPad implements IColonyTrader {
   }
 
   public trade(colony: Colony) {
-    // TODO(kberg): find a way to remove ! or just suck it up and use an if(!undefined)
-    this.titanFloatingLaunchPad!.resourceCount--;
+    // grr I wish there was a simpler syntax.
+    if (this.titanFloatingLaunchPad !== undefined) this.titanFloatingLaunchPad.resourceCount--;
     this.player.addActionThisGeneration(CardName.TITAN_FLOATING_LAUNCHPAD);
     this.player.game.log('${0} spent 1 floater to trade with ${1}', (b) => b.player(this.player).colony(colony));
     colony.trade(this.player);

--- a/src/cards/colonies/TitanFloatingLaunchPad.ts
+++ b/src/cards/colonies/TitanFloatingLaunchPad.ts
@@ -13,6 +13,7 @@ import {DeferredAction} from '../../deferredActions/DeferredAction';
 import {SelectColony} from '../../inputs/SelectColony';
 import {CardRenderer} from '../render/CardRenderer';
 import {Card} from '../Card';
+import {IColonyTrader} from '../../colonies/IColonyTrader';
 
 export class TitanFloatingLaunchPad extends Card implements IProjectCard, IResourceCard {
   constructor() {
@@ -81,5 +82,31 @@ export class TitanFloatingLaunchPad extends Card implements IProjectCard, IResou
   public play(player: Player) {
     player.game.defer(new AddResourcesToCard(player, ResourceType.FLOATER, {count: 2, restrictedTag: Tags.JOVIAN}));
     return undefined;
+  }
+}
+
+export class TradeWithTitanFloatingLaunchPad implements IColonyTrader {
+  private titanFloatingLaunchPad: TitanFloatingLaunchPad | undefined;
+
+  constructor(private player: Player) {
+    const card = player.playedCards.find((card) => card.name === CardName.TITAN_FLOATING_LAUNCHPAD);
+    this.titanFloatingLaunchPad = card === undefined ? undefined : (card as TitanFloatingLaunchPad);
+  }
+
+  public canUse() {
+    return (this.titanFloatingLaunchPad?.resourceCount ?? 0) > 0 &&
+      !this.player.getActionsThisGeneration().has(CardName.TITAN_FLOATING_LAUNCHPAD);
+  }
+
+  public optionText() {
+    return 'Pay 1 Floater (use Titan Floating Launch-pad action)';
+  }
+
+  public trade(colony: Colony) {
+    // TODO(kberg): find a way to remove ! or just suck it up and use an if(!undefined)
+    this.titanFloatingLaunchPad!.resourceCount--;
+    this.player.addActionThisGeneration(CardName.TITAN_FLOATING_LAUNCHPAD);
+    this.player.game.log('${0} spent 1 floater to trade with ${1}', (b) => b.player(this.player).colony(colony));
+    colony.trade(this.player);
   }
 }

--- a/src/colonies/ColoniesHandler.ts
+++ b/src/colonies/ColoniesHandler.ts
@@ -1,6 +1,17 @@
+import {ENERGY_TRADE_COST, MC_TRADE_COST, TITANIUM_TRADE_COST} from '../constants';
 import {Game} from '../Game';
+import {Player} from '../Player';
 import {Colony} from './Colony';
 import {ColonyName} from './ColonyName';
+import {SelectHowToPayDeferred} from '../deferredActions/SelectHowToPayDeferred';
+import {Resources} from '../Resources';
+import {TradeWithTitanFloatingLaunchPad} from '../cards/colonies/TitanFloatingLaunchPad';
+import {PlayerInput} from '../PlayerInput';
+import {OrOptions} from '../inputs/OrOptions';
+import {SelectOption} from '../inputs/SelectOption';
+import {SelectColony} from '../inputs/SelectColony';
+import {AndOptions} from '../inputs/AndOptions';
+import {IColonyTrader} from './IColonyTrader';
 
 export class ColoniesHandler {
   public static getColony(game: Game, colonyName: ColonyName, includeDiscardedColonies: boolean = false): Colony {
@@ -11,5 +22,137 @@ export class ColoniesHandler {
       if (colony !== undefined) return colony;
     }
     throw new Error(`Unknown colony '${colonyName}'`);
+  }
+
+  public static coloniesTradeAction(player: Player) {
+    if (player.game.gameOptions.coloniesExtension) {
+      const openColonies = player.game.colonies.filter((colony) => colony.isActive && colony.visitor === undefined);
+      if (openColonies.length > 0 &&
+        player.getFleetSize() > player.tradesThisGeneration) {
+        return ColoniesHandler.tradeWithColony(player, openColonies);
+      }
+    }
+    return undefined;
+  }
+
+  private static tradeWithColony(player: Player, openColonies: Array<Colony>): PlayerInput | undefined {
+    const handlers = [
+      new TradeWithEnergy(player),
+      new TradeWithTitanium(player),
+      new TradeWithMegacredits(player),
+      new TradeWithTitanFloatingLaunchPad(player),
+    ];
+
+    let selected: IColonyTrader | undefined = undefined;
+
+    const howToPayForTrade = new OrOptions();
+    howToPayForTrade.title = 'Pay trade fee';
+    howToPayForTrade.buttonLabel = 'Pay';
+    handlers.forEach((handler) => {
+      if (handler.canUse()) {
+        howToPayForTrade.options.push(new SelectOption(
+          handler.optionText(), '', () => {
+            selected = handler;
+            return undefined;
+          }));
+      }
+    });
+
+    if (howToPayForTrade.options.length === 0) {
+      return undefined;
+    }
+
+    const selectColony = new SelectColony('Select colony tile for trade', 'trade', openColonies, (colony: Colony) => {
+      if (selected === undefined) {
+        throw new Error('???');
+      }
+      selected.trade(colony);
+      return undefined;
+    });
+
+    const trade = new AndOptions(
+      () => {
+        return undefined;
+      },
+      howToPayForTrade,
+      selectColony,
+    );
+
+    trade.title = 'Trade with a colony tile';
+    trade.buttonLabel = 'Trade';
+
+    return trade;
+  }
+}
+
+export class TradeWithEnergy implements IColonyTrader {
+  private tradeCost;
+
+  constructor(private player: Player) {
+    this.tradeCost = ENERGY_TRADE_COST - player.colonyTradeDiscount;
+  }
+
+  public canUse() {
+    return this.player.energy >= this.tradeCost;
+  }
+  public optionText() {
+    return 'Pay ' + this.tradeCost +' Energy';
+  }
+
+  public trade(colony: Colony) {
+    this.player.deductResource(Resources.ENERGY, this.tradeCost);
+    this.player.game.log('${0} spent ${1} energy to trade with ${2}', (b) => b.player(this.player).number(this.tradeCost).colony(colony));
+    colony.trade(this.player);
+  }
+}
+
+export class TradeWithTitanium implements IColonyTrader {
+  private tradeCost;
+
+  constructor(private player: Player) {
+    this.tradeCost = TITANIUM_TRADE_COST - player.colonyTradeDiscount;
+  }
+
+  public canUse() {
+    return this.player.titanium >= this.tradeCost;
+  }
+  public optionText() {
+    return 'Pay ' + this.tradeCost +' Titanium';
+  }
+
+  public trade(colony: Colony) {
+    this.player.deductResource(Resources.TITANIUM, this.tradeCost);
+    this.player.game.log('${0} spent ${1} titanium to trade with ${2}', (b) => b.player(this.player).number(this.tradeCost).colony(colony));
+    colony.trade(this.player);
+  }
+}
+
+
+export class TradeWithMegacredits implements IColonyTrader {
+  private tradeCost;
+
+  constructor(private player: Player) {
+    this.tradeCost = MC_TRADE_COST- player.colonyTradeDiscount;
+  }
+
+  public canUse() {
+    return this.player.megaCredits >= this.tradeCost;
+  }
+  public optionText() {
+    return 'Pay ' + this.tradeCost +' M€';
+  }
+
+  public trade(colony: Colony) {
+    this.player.game.defer(new SelectHowToPayDeferred(
+      this.player,
+      this.tradeCost,
+      {
+        title: 'Select how to pay ' + this.tradeCost + ' for colony trade',
+        afterPay: () => {
+          this.player.game.log('${0} spent ${1} M€ to trade with ${2}', (b) => b.player(this.player).number(this.tradeCost).colony(colony));
+          colony.trade(this.player);
+        },
+      },
+    ));
   }
 }

--- a/src/colonies/ColoniesHandler.ts
+++ b/src/colonies/ColoniesHandler.ts
@@ -64,7 +64,7 @@ export class ColoniesHandler {
 
     const selectColony = new SelectColony('Select colony tile for trade', 'trade', openColonies, (colony: Colony) => {
       if (selected === undefined) {
-        throw new Error('???');
+        throw new Error(`Unexpected condition: no trade funding source selected when trading with ${colony.name}.`);
       }
       selected.trade(colony);
       return undefined;

--- a/src/colonies/IColonyTrader.ts
+++ b/src/colonies/IColonyTrader.ts
@@ -1,0 +1,8 @@
+import {Colony} from './Colony';
+
+// Something that can pay for trading with colonies.
+export interface IColonyTrader {
+  canUse(): boolean;
+  optionText(): string;
+  trade(colony: Colony): void;
+}


### PR DESCRIPTION
This simplifies the code, and makes it easier to split out
Titan Floating Launch Pad. Another card for Pathfinders will
also allow trading with its resources; this will help.