### PR TITLE
Log TR gains and losses for global events.

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -237,8 +237,8 @@ export class Player implements ISerializable<SerializedPlayer> {
     return this.terraformRating;
   }
 
-  public decreaseTerraformRating() {
-    this.terraformRating--;
+  public decreaseTerraformRating(opts: {log?: boolean} = {}) {
+    this.decreaseTerraformRatingSteps(1, opts);
   }
 
   public increaseTerraformRating(opts: {log?: boolean} = {}) {
@@ -275,8 +275,11 @@ export class Player implements ISerializable<SerializedPlayer> {
     }
   }
 
-  public decreaseTerraformRatingSteps(value: number) {
-    this.terraformRating -= value;
+  public decreaseTerraformRatingSteps(steps: number, opts: {log?: boolean} = {}) {
+    this.terraformRating -= steps;
+    if (opts.log === true) {
+      this.game.log('${0} lost ${1} TR', (b) => b.player(this).number(steps));
+    }
   }
 
   public setTerraformRating(value: number) {

--- a/src/turmoil/globalEvents/Election.ts
+++ b/src/turmoil/globalEvents/Election.ts
@@ -30,9 +30,9 @@ export class Election extends GlobalEvent implements IGlobalEvent {
     // Solo
     if (game.isSoloMode()) {
       if (this.getScore(game.getPlayers()[0], turmoil, game) >= 10) {
-        game.getPlayers()[0].increaseTerraformRatingSteps(2);
+        game.getPlayers()[0].increaseTerraformRatingSteps(2, {log: true});
       } else if (this.getScore(game.getPlayers()[0], turmoil, game) >= 1) {
-        game.getPlayers()[0].increaseTerraformRatingSteps(1);
+        game.getPlayers()[0].increaseTerraformRatingSteps(1, {log: true});
       }
     } else {
       const players = [...game.getPlayers()].sort(

--- a/src/turmoil/globalEvents/Revolution.ts
+++ b/src/turmoil/globalEvents/Revolution.ts
@@ -28,8 +28,7 @@ export class Revolution extends GlobalEvent implements IGlobalEvent {
   public resolve(game: Game, turmoil: Turmoil) {
     if (game.isSoloMode()) {
       if (this.getScore(game.getPlayers()[0], turmoil) >= 4 ) {
-        game.getPlayers()[0].decreaseTerraformRating();
-        game.getPlayers()[0].decreaseTerraformRating();
+        game.getPlayers()[0].decreaseTerraformRatingSteps(2, {log: true});
       }
     } else {
       const players = [...game.getPlayers()].sort(
@@ -38,21 +37,21 @@ export class Revolution extends GlobalEvent implements IGlobalEvent {
 
       // We have one rank 1 player
       if (this.getScore(players[0], turmoil) > this.getScore(players[1], turmoil)) {
-        players[0].decreaseTerraformRatingSteps(2);
+        players[0].decreaseTerraformRatingSteps(2, {log: true});
         players.shift();
 
         if (players.length === 1 && this.getScore(players[0], turmoil) > 0) {
-          players[0].decreaseTerraformRating();
+          players[0].decreaseTerraformRating({log: true});
         } else if (players.length > 1) {
           // We have one rank 2 player
           if (this.getScore(players[0], turmoil) > this.getScore(players[1], turmoil)) {
-            players[0].decreaseTerraformRating();
+            players[0].decreaseTerraformRating({log: true});
             // We have at least two rank 2 players
           } else {
             const score = this.getScore(players[0], turmoil);
             while (players.length > 0 && this.getScore(players[0], turmoil) === score) {
               if (this.getScore(players[0], turmoil) > 0) {
-                players[0].decreaseTerraformRating();
+                players[0].decreaseTerraformRating({log: true});
               }
               players.shift();
             }
@@ -63,7 +62,7 @@ export class Revolution extends GlobalEvent implements IGlobalEvent {
         const score = this.getScore(players[0], turmoil);
         while (players.length > 0 && this.getScore(players[0], turmoil) === score) {
           if (this.getScore(players[0], turmoil) > 0) {
-            players[0].decreaseTerraformRatingSteps(2);
+            players[0].decreaseTerraformRatingSteps(2, {log: true});
           }
           players.shift();
         }

--- a/src/turmoil/globalEvents/WarOnEarth.ts
+++ b/src/turmoil/globalEvents/WarOnEarth.ts
@@ -22,7 +22,7 @@ export class WarOnEarth extends GlobalEvent implements IGlobalEvent {
   }
   public resolve(game: Game, turmoil: Turmoil) {
     game.getPlayers().forEach((player) => {
-      player.decreaseTerraformRatingSteps(4 - turmoil.getPlayerInfluence(player));
+      player.decreaseTerraformRatingSteps(4 - turmoil.getPlayerInfluence(player), {log: true});
     });
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/413481/149049927-75f69091-5c8e-410d-b5d2-a8c2d8a9c59f.png)

Fixes #3776