### PR TITLE
This fixes #3936 - Luna Ecumenopolis placement bug

### DIFF
--- a/src/cards/moon/LunaEcumenopolis.ts
+++ b/src/cards/moon/LunaEcumenopolis.ts
@@ -92,7 +92,7 @@ export class LunaEcumenopolis extends MoonCard {
         // Now go through all the land spaces again (actually as an optimization, just continue with the space after.)
         for (let y = 0; y < len; y++) {
           const second = spaces[y];
-          if(second.id === firstSpaceId) continue;
+          if (second.id === firstSpaceId) continue;
           // Now if it's next to two colonies, it includes the first colony you placed. That's what firstSpaceId is for.
           if (nextToTwoColonies(second) === true) {
             return true;

--- a/src/cards/moon/LunaEcumenopolis.ts
+++ b/src/cards/moon/LunaEcumenopolis.ts
@@ -90,8 +90,9 @@ export class LunaEcumenopolis extends MoonCard {
         // Remember it.
         firstSpaceId = first.id;
         // Now go through all the land spaces again (actually as an optimization, just continue with the space after.)
-        for (let y = x + 1; y < len; y++) {
+        for (let y = 0; y < len; y++) {
           const second = spaces[y];
+          if(second.id === firstSpaceId) continue;
           // Now if it's next to two colonies, it includes the first colony you placed. That's what firstSpaceId is for.
           if (nextToTwoColonies(second) === true) {
             return true;

--- a/tests/cards/moon/LunaEcumenopolis.spec.ts
+++ b/tests/cards/moon/LunaEcumenopolis.spec.ts
@@ -47,6 +47,18 @@ describe('LunaEcumenopolis', () => {
     expect(player.getPlayableCards()).does.not.include(card);
   });
 
+  it('can play when 1st placement enables 2nd placcement', () => {
+    player.cardsInHand = [card];
+    player.megaCredits = card.cost;
+
+    const moon = moonData.moon;
+    moon.getSpace('m18').tile = {tileType: TileType.MOON_COLONY};
+    moon.getSpace('m19').tile = {tileType: TileType.MOON_COLONY};
+
+    player.titanium = 2;
+    expect(player.getPlayableCards()).does.include(card);
+  });
+  
   it('Cannot play: not enough adjacent colony tiles', () => {
     player.titanium = 2;
     moonData.moon.getSpace('m09').tile = {tileType: TileType.MOON_COLONY};

--- a/tests/cards/moon/LunaEcumenopolis.spec.ts
+++ b/tests/cards/moon/LunaEcumenopolis.spec.ts
@@ -58,7 +58,7 @@ describe('LunaEcumenopolis', () => {
     player.titanium = 2;
     expect(player.getPlayableCards()).does.include(card);
   });
-  
+
   it('Cannot play: not enough adjacent colony tiles', () => {
     player.titanium = 2;
     moonData.moon.getSpace('m09').tile = {tileType: TileType.MOON_COLONY};


### PR DESCRIPTION
Checks all spaces for the second placement, not just those that come after the first placement. Additionally adds a test for a case where the first placement allows the placement of a second colony tile with a lower space index.