### PR TITLE
Isolate fetching cards to one place on the client

### DIFF
--- a/src/CardFinder.ts
+++ b/src/CardFinder.ts
@@ -4,109 +4,80 @@ import {IProjectCard} from './cards/IProjectCard';
 import {CardManifest} from './cards/CardManifest';
 import {CardName} from './CardName';
 import {CorporationCard} from './cards/corporation/CorporationCard';
-import {COLONIES_CARD_MANIFEST} from './cards/colonies/ColoniesCardManifest';
-import {PRELUDE_CARD_MANIFEST} from './cards/prelude/PreludeCardManifest';
-import {PROMO_CARD_MANIFEST} from './cards/promo/PromoCardManifest';
-import {BASE_CARD_MANIFEST, CORP_ERA_CARD_MANIFEST} from './cards/StandardCardManifests';
-import {TURMOIL_CARD_MANIFEST} from './cards/turmoil/TurmoilCardManifest';
-import {VENUS_CARD_MANIFEST} from './cards/venusNext/VenusCardManifest';
-import {COMMUNITY_CARD_MANIFEST} from './cards/community/CommunityCardManifest';
-import {ARES_CARD_MANIFEST} from './cards/ares/AresCardManifest';
-import {MOON_CARD_MANIFEST} from './cards/moon/MoonCardManifest';
 import {Deck} from './Deck';
-import {PATHFINDERS_CARD_MANIFEST} from './cards/pathfinders/PathfindersCardManifest';
 import {PreludeCard} from './cards/prelude/PreludeCard';
+import {ALL_CARD_MANIFESTS} from './cards/AllCards';
 
 export class CardFinder {
-    private static decks: undefined | Array<CardManifest>;
-    private static getDecks(): Array<CardManifest> {
-      if (CardFinder.decks === undefined) {
-        CardFinder.decks = [
-          BASE_CARD_MANIFEST,
-          CORP_ERA_CARD_MANIFEST,
-          PROMO_CARD_MANIFEST,
-          VENUS_CARD_MANIFEST,
-          COLONIES_CARD_MANIFEST,
-          PRELUDE_CARD_MANIFEST,
-          TURMOIL_CARD_MANIFEST,
-          ARES_CARD_MANIFEST,
-          COMMUNITY_CARD_MANIFEST,
-          MOON_CARD_MANIFEST,
-          PATHFINDERS_CARD_MANIFEST,
-        ];
-      }
-      return CardFinder.decks;
-    }
-
-    public getCardByName<T extends ICard>(cardName: CardName, decks: (manifest: CardManifest) => Array<Deck<T>>): T | undefined {
-      let found : (ICardFactory<T> | undefined);
-      CardFinder.getDecks().some((manifest) => {
-        decks(manifest).some((deck) => {
-          found = deck.findByCardName(cardName);
-          return found;
-        });
+  private getCardByName<T extends ICard>(cardName: CardName, decks: (manifest: CardManifest) => Array<Deck<T>>): T | undefined {
+    let found : (ICardFactory<T> | undefined);
+    ALL_CARD_MANIFESTS.some((manifest) => {
+      decks(manifest).some((deck) => {
+        found = deck.findByCardName(cardName);
         return found;
       });
-      if (found !== undefined) {
-        return new found.Factory();
+      return found;
+    });
+    if (found !== undefined) {
+      return new found.Factory();
+    }
+    console.warn(`card not found ${cardName}`);
+    return undefined;
+  }
+
+  public getCorporationCardByName(cardName: CardName): CorporationCard | undefined {
+    return this.getCardByName(cardName, (manifest) => [manifest.corporationCards]);
+  }
+
+  // Function to return a card object by its name
+  // NOTE(kberg): This replaces a larger function which searched for both Prelude cards amidst project cards
+  // TODO(kberg): Find the use cases where this is used to find Prelude cards and filter them out to
+  //              another function, perhaps?
+  public getProjectCardByName(cardName: CardName): IProjectCard | undefined {
+    return this.getCardByName(cardName, (manifest) => [manifest.projectCards, manifest.preludeCards]);
+  }
+
+  public getPreludeByName(cardName: CardName): PreludeCard | undefined {
+    return this.getCardByName(cardName, (manifest) => [manifest.preludeCards]);
+  }
+
+  public cardsFromJSON(cards: Array<ICard | CardName>): Array<IProjectCard> {
+    if (cards === undefined) {
+      console.warn('missing cards calling cardsFromJSON');
+      return [];
+    }
+    const result: Array<IProjectCard> = [];
+    cards.forEach((element: ICard | CardName) => {
+      if (typeof element !== 'string') {
+        element = element.name;
       }
-      console.warn(`card not found ${cardName}`);
-      return undefined;
-    }
-
-    public getCorporationCardByName(cardName: CardName): CorporationCard | undefined {
-      return this.getCardByName(cardName, (manifest) => [manifest.corporationCards]);
-    }
-
-    // Function to return a card object by its name
-    // NOTE(kberg): This replaces a larger function which searched for both Prelude cards amidst project cards
-    // TODO(kberg): Find the use cases where this is used to find Prelude cards and filter them out to
-    //              another function, perhaps?
-    public getProjectCardByName(cardName: CardName): IProjectCard | undefined {
-      return this.getCardByName(cardName, (manifest) => [manifest.projectCards, manifest.preludeCards]);
-    }
-
-    public getPreludeByName(cardName: CardName): PreludeCard | undefined {
-      return this.getCardByName(cardName, (manifest) => [manifest.preludeCards]);
-    }
-
-    public cardsFromJSON(cards: Array<ICard | CardName>): Array<IProjectCard> {
-      if (cards === undefined) {
-        console.warn('missing cards calling cardsFromJSON');
-        return [];
+      const card = this.getProjectCardByName(element);
+      if (card !== undefined) {
+        result.push(card);
+      } else {
+        console.warn(`card ${element} not found while loading game.`);
       }
-      const result: Array<IProjectCard> = [];
-      cards.forEach((element: ICard | CardName) => {
-        if (typeof element !== 'string') {
-          element = element.name;
-        }
-        const card = this.getProjectCardByName(element);
-        if (card !== undefined) {
-          result.push(card);
-        } else {
-          console.warn(`card ${element} not found while loading game.`);
-        }
-      });
-      return result;
-    }
+    });
+    return result;
+  }
 
-    public corporationCardsFromJSON(cards: Array<ICard | CardName>): Array<CorporationCard> {
-      if (cards === undefined) {
-        console.warn('missing cards calling corporationCardsFromJSON');
-        return [];
-      }
-      const result: Array<CorporationCard> = [];
-      cards.forEach((element: ICard | CardName) => {
-        if (typeof element !== 'string') {
-          element = element.name;
-        }
-        const card = this.getCorporationCardByName(element);
-        if (card !== undefined) {
-          result.push(card);
-        } else {
-          console.warn(`corporation ${element} not found while loading game.`);
-        }
-      });
-      return result;
+  public corporationCardsFromJSON(cards: Array<ICard | CardName>): Array<CorporationCard> {
+    if (cards === undefined) {
+      console.warn('missing cards calling corporationCardsFromJSON');
+      return [];
     }
+    const result: Array<CorporationCard> = [];
+    cards.forEach((element: ICard | CardName) => {
+      if (typeof element !== 'string') {
+        element = element.name;
+      }
+      const card = this.getCorporationCardByName(element);
+      if (card !== undefined) {
+        result.push(card);
+      } else {
+        console.warn(`corporation ${element} not found while loading game.`);
+      }
+    });
+    return result;
+  }
 }

--- a/src/Deck.ts
+++ b/src/Deck.ts
@@ -3,7 +3,7 @@ import {ICard} from './cards/ICard';
 import {ICardFactory} from './cards/ICardFactory';
 
 const CARD_RENAMES = new Map<string, CardName>([
-  // When renaming a card, add the rename here (like the example below), and add a TODO (like the example below)
+  // When renaming a card, add the old name here (like the example below), and add a TODO (like the example below)
   // And remember to add a test in Deck.spec.ts.
 
   // TODO(yournamehere): remove after 2021-04-05

--- a/src/cards/AllCards.ts
+++ b/src/cards/AllCards.ts
@@ -45,9 +45,6 @@ export const MANIFEST_BY_MODULE: Map<GameModule, CardManifest> =
 export const ALL_PROJECT_DECKS = ALL_CARD_MANIFESTS.map(
   (deck) => deck.projectCards,
 );
-const ALL_CORPORATION_DECKS = ALL_CARD_MANIFESTS.map(
-  (deck) => deck.corporationCards,
-);
 export const ALL_PRELUDE_DECKS = ALL_CARD_MANIFESTS.map(
   (deck) => deck.preludeCards,
 );
@@ -56,9 +53,5 @@ export const ALL_STANDARD_PROJECT_DECKS = ALL_CARD_MANIFESTS.map(
 );
 
 export const ALL_PROJECT_CARD_NAMES = allCardNames(ALL_PROJECT_DECKS);
-export const ALL_STANDARD_PROJECT_CARD_NAMES = allCardNames(ALL_STANDARD_PROJECT_DECKS);
 
-export const ALL_CORPORATION_CARD_NAMES = allCardNames(
-  ALL_CORPORATION_DECKS,
-);
 export const ALL_PRELUDE_CARD_NAMES = allCardNames(ALL_PRELUDE_DECKS);

--- a/src/cards/AllCards.ts
+++ b/src/cards/AllCards.ts
@@ -1,11 +1,7 @@
-import {CardName} from '../CardName';
-import {Deck} from '../Deck';
 import {ARES_CARD_MANIFEST} from './ares/AresCardManifest';
-import {GameModule} from '../GameModule';
 import {CardManifest} from './CardManifest';
 import {COLONIES_CARD_MANIFEST} from './colonies/ColoniesCardManifest';
 import {COMMUNITY_CARD_MANIFEST} from './community/CommunityCardManifest';
-import {ICard} from './ICard';
 import {PRELUDE_CARD_MANIFEST} from './prelude/PreludeCardManifest';
 import {PROMO_CARD_MANIFEST} from './promo/PromoCardManifest';
 import {
@@ -30,28 +26,3 @@ export const ALL_CARD_MANIFESTS: Array<CardManifest> = [
   MOON_CARD_MANIFEST,
   PATHFINDERS_CARD_MANIFEST,
 ];
-
-function allCardNames(decks: Array<Deck<ICard>>): Array<CardName> {
-  const cardNames: Array<CardName> = [];
-  for (const deck of decks) {
-    deck.factories.forEach((cf) => cardNames.push(cf.cardName));
-  }
-  return cardNames;
-}
-
-export const MANIFEST_BY_MODULE: Map<GameModule, CardManifest> =
-    new Map(ALL_CARD_MANIFESTS.map((manifest) => [manifest.module, manifest]));
-
-export const ALL_PROJECT_DECKS = ALL_CARD_MANIFESTS.map(
-  (deck) => deck.projectCards,
-);
-export const ALL_PRELUDE_DECKS = ALL_CARD_MANIFESTS.map(
-  (deck) => deck.preludeCards,
-);
-export const ALL_STANDARD_PROJECT_DECKS = ALL_CARD_MANIFESTS.map(
-  (deck) => deck.standardProjects,
-);
-
-export const ALL_PROJECT_CARD_NAMES = allCardNames(ALL_PROJECT_DECKS);
-
-export const ALL_PRELUDE_CARD_NAMES = allCardNames(ALL_PRELUDE_DECKS);

--- a/src/client/cards/ClientCardManifest.ts
+++ b/src/client/cards/ClientCardManifest.ts
@@ -1,0 +1,38 @@
+import {CardName} from '@/CardName';
+import {ALL_CARD_MANIFESTS} from '@/cards/AllCards';
+import {CardType} from '@/cards/CardType';
+import {ICard} from '@/cards/ICard';
+import {ICardFactory} from '@/cards/ICardFactory';
+import {GameModule} from '@/GameModule';
+
+export type CardAndModule = {card: ICard, module: GameModule};
+const cards: Map<CardName, CardAndModule> = new Map();
+const cardArray: Array<CardAndModule> = [];
+ALL_CARD_MANIFESTS.forEach((manifest) => {
+  const module = manifest.module;
+  [
+    manifest.projectCards,
+    manifest.corporationCards,
+    manifest.preludeCards,
+    manifest.standardProjects].forEach((deck) => {
+    deck.factories.forEach((cf: ICardFactory<ICard>) => {
+      const card: ICard = new cf.Factory();
+      const cam = {card, module};
+      cards.set(card.name, cam);
+      cardArray.push(cam);
+    });
+  });
+});
+console.log(cardArray.map((cam) => cam.card.name));
+
+export function getCard(cardName: CardName): CardAndModule | undefined {
+  return cards.get(cardName);
+}
+
+export function getCards(filter: (card: CardAndModule) => boolean): Array<CardAndModule> {
+  return cardArray.filter(filter);
+}
+
+export function getCardsByType(cardType: CardType): Array<CardAndModule> {
+  return getCards((cam) => cam.card.cardType === cardType);
+}

--- a/src/client/cards/ClientCardManifest.ts
+++ b/src/client/cards/ClientCardManifest.ts
@@ -23,7 +23,6 @@ ALL_CARD_MANIFESTS.forEach((manifest) => {
     });
   });
 });
-console.log(cardArray.map((cam) => cam.card.name));
 
 export function getCard(cardName: CardName): CardAndModule | undefined {
   return cards.get(cardName);
@@ -33,6 +32,12 @@ export function getCards(filter: (card: CardAndModule) => boolean): Array<CardAn
   return cardArray.filter(filter);
 }
 
-export function getCardsByType(cardType: CardType): Array<CardAndModule> {
-  return getCards((cam) => cam.card.cardType === cardType);
+export function byType(cardType: CardType): (cam: CardAndModule) => boolean {
+  return (cam) => cam.card.cardType === cardType;
 }
+
+export function byModule(module: GameModule): (cam: CardAndModule) => boolean {
+  return (cam) => cam.module === module;
+}
+
+export const toName = (cam: CardAndModule) => cam.card.name;

--- a/src/client/components/DebugUI.vue
+++ b/src/client/components/DebugUI.vue
@@ -143,7 +143,7 @@ import {GlobalEventModel} from '@/models/TurmoilModel';
 import {PartyName} from '@/turmoil/parties/PartyName';
 import {ALL_EVENTS, getGlobalEventByName} from '@/turmoil/globalEvents/GlobalEventDealer';
 import GlobalEvent from '@/client/components/GlobalEvent.vue';
-import {getCard, getCardsByType} from '../cards/ClientCardManifest';
+import {byType, getCard, getCards, toName} from '../cards/ClientCardManifest';
 
 const MODULE_BASE = 'b';
 const MODULE_CORP = 'c';
@@ -328,22 +328,22 @@ export default Vue.extend({
       }
     },
     getAllStandardProjectCards() {
-      const names = getCardsByType(CardType.STANDARD_PROJECT).map((cam) => cam.card.name);
+      const names = getCards(byType(CardType.STANDARD_PROJECT)).map(toName);
       return this.sort(names);
     },
     getAllProjectCards() {
       const names: Array<CardName> = [];
-      names.push(...getCardsByType(CardType.AUTOMATED).map((cam) => cam.card.name));
-      names.push(...getCardsByType(CardType.ACTIVE).map((cam) => cam.card.name));
-      names.push(...getCardsByType(CardType.EVENT).map((cam) => cam.card.name));
+      names.push(...getCards(byType(CardType.AUTOMATED)).map(toName));
+      names.push(...getCards(byType(CardType.ACTIVE)).map(toName));
+      names.push(...getCards(byType(CardType.EVENT)).map(toName));
       return this.sort(names);
     },
     getAllCorporationCards() {
-      const names = getCardsByType(CardType.CORPORATION).map((cam) => cam.card.name);
+      const names = getCards(byType(CardType.CORPORATION)).map(toName);
       return this.sort(names);
     },
     getAllPreludeCards() {
-      const names = getCardsByType(CardType.PRELUDE).map((cam) => cam.card.name);
+      const names = getCards(byType(CardType.PRELUDE)).map(toName);
       return this.sort(names);
     },
     getAllGlobalEvents() {

--- a/src/client/components/DebugUI.vue
+++ b/src/client/components/DebugUI.vue
@@ -134,41 +134,16 @@
 
 import Vue from 'vue';
 import Card from '@/client/components/card/Card.vue';
-import {
-  ALL_CARD_MANIFESTS,
-  ALL_CORPORATION_CARD_NAMES,
-  ALL_PRELUDE_CARD_NAMES,
-  ALL_PROJECT_CARD_NAMES,
-  ALL_STANDARD_PROJECT_CARD_NAMES,
-} from '@/cards/AllCards';
 import {GameModule} from '@/GameModule';
-import {ICard} from '@/cards/ICard';
 import {CardType} from '@/cards/CardType';
 import {CardName} from '@/CardName';
-import {ICardFactory} from '@/cards/ICardFactory';
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 import {GlobalEventName} from '@/turmoil/globalEvents/GlobalEventName';
 import {GlobalEventModel} from '@/models/TurmoilModel';
 import {PartyName} from '@/turmoil/parties/PartyName';
 import {ALL_EVENTS, getGlobalEventByName} from '@/turmoil/globalEvents/GlobalEventDealer';
 import GlobalEvent from '@/client/components/GlobalEvent.vue';
-
-const cards: Map<CardName, {card: ICard, module: GameModule, cardNumber: string}> = new Map();
-
-ALL_CARD_MANIFESTS.forEach((manifest) => {
-  const module = manifest.module;
-  [
-    manifest.projectCards,
-    manifest.corporationCards,
-    manifest.preludeCards,
-    manifest.standardProjects].forEach((deck) => {
-    deck.factories.forEach((cf: ICardFactory<ICard>) => {
-      const card: ICard = new cf.Factory();
-      const cardNumber = card.metadata.cardNumber;
-      cards.set(card.name, {card, module, cardNumber});
-    });
-  });
-});
+import {getCard, getCardsByType} from '../cards/ClientCardManifest';
 
 const MODULE_BASE = 'b';
 const MODULE_CORP = 'c';
@@ -344,25 +319,32 @@ export default Vue.extend({
       const copy = [...names];
       if (this.$data.sortById) {
         return copy.sort((a: CardName, b: CardName) => {
-          const an = cards.get(a)?.cardNumber || '';
-          const bn = cards.get(b)?.cardNumber || '';
+          const an = getCard(a)?.card.metadata.cardNumber || '';
+          const bn = getCard(b)?.card.metadata.cardNumber || '';
           return an.localeCompare(bn);
         });
       } else {
-        return copy.sort();
+        return copy.sort((a, b) => a.localeCompare(b));
       }
     },
     getAllStandardProjectCards() {
-      return this.sort(ALL_STANDARD_PROJECT_CARD_NAMES);
+      const names = getCardsByType(CardType.STANDARD_PROJECT).map((cam) => cam.card.name);
+      return this.sort(names);
     },
     getAllProjectCards() {
-      return this.sort(ALL_PROJECT_CARD_NAMES);
+      const names: Array<CardName> = [];
+      names.push(...getCardsByType(CardType.AUTOMATED).map((cam) => cam.card.name));
+      names.push(...getCardsByType(CardType.ACTIVE).map((cam) => cam.card.name));
+      names.push(...getCardsByType(CardType.EVENT).map((cam) => cam.card.name));
+      return this.sort(names);
     },
     getAllCorporationCards() {
-      return this.sort(ALL_CORPORATION_CARD_NAMES);
+      const names = getCardsByType(CardType.CORPORATION).map((cam) => cam.card.name);
+      return this.sort(names);
     },
     getAllPreludeCards() {
-      return this.sort(ALL_PRELUDE_CARD_NAMES);
+      const names = getCardsByType(CardType.PRELUDE).map((cam) => cam.card.name);
+      return this.sort(names);
     },
     getAllGlobalEvents() {
       return ALL_EVENTS.keys();
@@ -386,7 +368,7 @@ export default Vue.extend({
       };
     },
     filtered(cardName: CardName): boolean {
-      const card = cards.get(cardName);
+      const card = getCard(cardName);
       if (card === undefined) {
         return false;
       }

--- a/src/client/components/LogPanel.vue
+++ b/src/client/components/LogPanel.vue
@@ -42,8 +42,6 @@ import {LogMessageData} from '@/LogMessageData';
 import {LogMessageDataType} from '@/LogMessageDataType';
 import {PublicPlayerModel} from '@/models/PlayerModel';
 import Card from '@/client/components/card/Card.vue';
-import {CardFinder} from '@/CardFinder';
-import {ICard} from '@/cards/ICard';
 import {CardName} from '@/CardName';
 import {TileType} from '@/TileType';
 import {playerColorClass} from '@/utils/utils';
@@ -57,6 +55,7 @@ import {GlobalEventModel} from '@/models/TurmoilModel';
 import {PartyName} from '@/turmoil/parties/PartyName';
 import Button from '@/client/components/common/Button.vue';
 import {Log} from '@/Log';
+import {getCard} from '@/client/cards/ClientCardManifest';
 
 let logRequest: XMLHttpRequest | undefined;
 
@@ -165,14 +164,9 @@ export default Vue.extend({
             }
           }
         }
-        const card = new CardFinder().getCardByName<ICard>(cardName, (manifest) => [
-          manifest.projectCards,
-          manifest.preludeCards,
-          manifest.standardProjects,
-          manifest.standardActions,
-        ]);
-        if (card && card.cardType) {
-          return this.cardToHtml(card.cardType, data.value);
+        const card = getCard(cardName);
+        if (card && card.card.cardType) {
+          return this.cardToHtml(card.card.cardType, data.value);
         }
         break;
 

--- a/src/client/components/SelectHowToPayForProjectCard.vue
+++ b/src/client/components/SelectHowToPayForProjectCard.vue
@@ -4,7 +4,7 @@ import Button from '@/client/components/common/Button.vue';
 
 import {HowToPay} from '@/inputs/HowToPay';
 import Card from '@/client/components/card/Card.vue';
-import {CardFinder} from '@/CardFinder';
+import {getCard} from '@/client/cards/ClientCardManifest';
 import {CardModel} from '@/models/CardModel';
 import {CardOrderStorage} from '@/client/utils/CardOrderStorage';
 import {PaymentWidgetMixin, SelectHowToPayForProjectCardModel, unit} from '@/client/mixins/PaymentWidgetMixin';
@@ -96,11 +96,11 @@ export default Vue.extend({
       return card;
     },
     getCardTags() {
-      const card = new CardFinder().getProjectCardByName(this.cardName);
-      if (card === undefined) {
+      const cam = getCard(this.cardName);
+      if (cam === undefined) {
         throw new Error(`card not found ${this.cardName}`);
       }
-      return card.tags;
+      return cam.card.tags;
     },
     setDefaultValues() {
       this.microbes = 0;

--- a/src/client/components/SelectInitialCards.vue
+++ b/src/client/components/SelectInitialCards.vue
@@ -18,7 +18,7 @@
 import Vue from 'vue';
 
 import Button from '@/client/components/common/Button.vue';
-import {CardFinder} from '@/CardFinder';
+import {getCard} from '@/client/cards/ClientCardManifest';
 import {CardName} from '@/CardName';
 import * as constants from '@/constants';
 import {CorporationCard} from '@/cards/corporation/CorporationCard';
@@ -28,6 +28,7 @@ import SelectCard from '@/client/components/SelectCard.vue';
 import ConfirmDialog from '@/client/components/common/ConfirmDialog.vue';
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 import {Tags} from '@/cards/Tags';
+import {PreludeCard} from '@/cards/prelude/PreludeCard';
 
 export default Vue.extend({
   name: 'SelectInitialCards',
@@ -67,11 +68,12 @@ export default Vue.extend({
     getAfterPreludes() {
       let result = 0;
       for (const prelude of this.selectedPreludes) {
-        const card = new CardFinder().getPreludeByName(prelude);
-        if (card === undefined) {
+        const cam = getCard(prelude);
+        if (cam === undefined) {
           throw new Error(`Prelude ${prelude} not found`);
         }
-        result += card?.startingMegaCredits ?? 0;
+        const card = cam.card as PreludeCard;
+        result += card.startingMegaCredits ?? 0;
 
         switch (this.selectedCorporation?.name) {
         // For each step you increase the production of a resource ... you also gain that resource.
@@ -185,7 +187,7 @@ export default Vue.extend({
       this.selectedCards = cards;
     },
     corporationChanged(cards: Array<CardName>) {
-      this.selectedCorporation = new CardFinder().getCorporationCardByName(cards[0]);
+      this.selectedCorporation = getCard(cards[0])?.card as CorporationCard;
     },
     preludesChanged(cards: Array<CardName>) {
       this.selectedPreludes = cards;

--- a/src/client/components/card/Card.vue
+++ b/src/client/components/card/Card.vue
@@ -33,11 +33,10 @@ import {CardType} from '@/cards/CardType';
 import CardContent from './CardContent.vue';
 import {ICardMetadata} from '@/cards/ICardMetadata';
 import {Tags} from '@/cards/Tags';
-import {ALL_CARD_MANIFESTS} from '@/cards/AllCards';
-import {GameModule} from '@/GameModule';
 import {CardRequirements} from '@/cards/CardRequirements';
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 import {ResourceType} from '@/ResourceType';
+import {getCard} from '@/client/cards/ClientCardManifest';
 
 export default Vue.extend({
   name: 'Card',
@@ -63,37 +62,15 @@ export default Vue.extend({
     },
   },
   data() {
-    let cardInstance: ICard | undefined;
     const cardName = this.card.name;
-    let expansion: GameModule | undefined;
-    for (const manifest of ALL_CARD_MANIFESTS) {
-      const decks = [
-        manifest.corporationCards,
-        manifest.projectCards,
-        manifest.preludeCards,
-        manifest.standardProjects,
-        manifest.standardActions,
-      ];
-      for (const deck of decks) {
-        const factory = deck.findByCardName(cardName);
-        if (factory !== undefined) {
-          cardInstance = new factory.Factory();
-          expansion = manifest.module;
-          break;
-        }
-      }
-      if (expansion !== undefined) {
-        break;
-      }
-    }
-
-    if (cardInstance === undefined || expansion === undefined) {
+    const cam = getCard(cardName);
+    if (cam === undefined) {
       throw new Error(`Can't find card ${cardName}`);
     }
 
     return {
-      cardInstance,
-      expansion,
+      cardInstance: cam.card,
+      expansion: cam.module,
     };
   },
   methods: {

--- a/src/client/components/create/CardsFilter.vue
+++ b/src/client/components/create/CardsFilter.vue
@@ -26,10 +26,17 @@
 <script lang="ts">
 import Vue from 'vue';
 import {CardName} from '@/CardName';
-import {ALL_PRELUDE_CARD_NAMES, ALL_PROJECT_CARD_NAMES} from '@/cards/AllCards';
 import Button from '@/client/components/common/Button.vue';
+import {byType, getCard, getCards, toName} from '@/client/cards/ClientCardManifest';
+import {CardType} from '@/cards/CardType';
 
-const allItems: Array<CardName> = ALL_PROJECT_CARD_NAMES.concat(ALL_PRELUDE_CARD_NAMES).sort();
+const allItems: Array<CardName> = [
+  ...getCards(byType(CardType.AUTOMATED)),
+  ...getCards(byType(CardType.ACTIVE)),
+  ...getCards(byType(CardType.EVENT)),
+  ...getCards(byType(CardType.PRELUDE)),
+].map(toName)
+  .sort((a, b) => a.localeCompare(b));
 
 interface CardsFilterModel {
     selectedCardNames: Array<CardName>;
@@ -50,7 +57,7 @@ export default Vue.extend({
   components: {Button},
   methods: {
     isPrelude(cardName: CardName) {
-      return ALL_PRELUDE_CARD_NAMES.includes(cardName);
+      return getCard(cardName)?.card.cardType === CardType.PRELUDE;
     },
     removeCard(cardNameToRemove: CardName) {
       this.selectedCardNames = this.selectedCardNames.filter((curCardName) => curCardName !== cardNameToRemove).sort();

--- a/src/client/components/create/CorporationsFilter.vue
+++ b/src/client/components/create/CorporationsFilter.vue
@@ -45,10 +45,6 @@ function corpCardNames(module: GameModule): Array<CardName> {
     .filter((name) => name !== CardName.BEGINNER_CORPORATION);
 }
 
-function iterator(mm: MultiMap<GameModule, CardName>) {
-  return Array.from(mm.associations());
-}
-
 export default Vue.extend({
   name: 'CorporationsFilter',
   props: {
@@ -87,7 +83,6 @@ export default Vue.extend({
         cardsByModule.set(cam.module, cam.card.name);
       }
     });
-    console.log(iterator(cardsByModule));
 
     return {
       cardsByModule: cardsByModule,
@@ -116,7 +111,7 @@ export default Vue.extend({
       return [];
     },
     getItemsByGroup(group: string): Array<CardName> {
-      if (group === 'All') return Array.from(this.cardsByModule.values()).slice();
+      if (group === 'All') return Array.from(this.cardsByModule.values());
 
       const corps = this.cardsByModule.get(group as GameModule);
       if (corps === undefined) {

--- a/src/client/components/create/CorporationsFilter.vue
+++ b/src/client/components/create/CorporationsFilter.vue
@@ -9,7 +9,7 @@
             </div>
         </div>
         <br/>
-          <div class="corporations-filter-group" v-for="entry in corpsByModule" v-bind:key="entry[0]">
+          <div class="corporations-filter-group" v-for="entry in cardsByModule.associations()" v-bind:key="entry[0]">
             <div v-if="entry[1].length > 0">
               <div class="corporations-filter-toolbox-cont">
                   <div class="corporations-filter-toolbox">
@@ -33,31 +33,21 @@
 import Vue from 'vue';
 
 import {CardName} from '@/CardName';
-import {ALL_CARD_MANIFESTS, MANIFEST_BY_MODULE} from '@/cards/AllCards';
 import {GameModule} from '@/GameModule';
+import {byModule, byType, getCards, toName} from '@/client/cards/ClientCardManifest';
+import {CardType} from '@/cards/CardType';
+import {MultiMap} from 'mnemonist';
 
 function corpCardNames(module: GameModule): Array<CardName> {
-  const manifest = MANIFEST_BY_MODULE.get(module);
-  if (manifest === undefined) {
-    console.log('manifest %s not found', manifest);
-    return [];
-  } else {
-    const cards: Array<CardName> = [];
-    manifest.corporationCards.factories.forEach((cf) => {
-      if (cf.cardName !== CardName.BEGINNER_CORPORATION) {
-        cards.push(cf.cardName);
-      }
-    });
-    return cards;
-  }
+  return getCards(byModule(module))
+    .filter(byType(CardType.CORPORATION))
+    .map(toName)
+    .filter((name) => name !== CardName.BEGINNER_CORPORATION);
 }
 
-const allItems: Array<CardName> = [];
-ALL_CARD_MANIFESTS.forEach((manifest) => {
-  manifest.corporationCards.factories.forEach((cf) => {
-    allItems.push(cf.cardName);
-  });
-});
+function iterator(mm: MultiMap<GameModule, CardName>) {
+  return Array.from(mm.associations());
+}
 
 export default Vue.extend({
   name: 'CorporationsFilter',
@@ -86,25 +76,35 @@ export default Vue.extend({
     moonExpansion: {
       type: Boolean,
     },
+    pathfindersExpansion: {
+      type: Boolean,
+    },
   },
   data() {
-    const cardsByModuleMap: Map<GameModule, Array<CardName>> =
-            new Map(ALL_CARD_MANIFESTS.map((m) => [m.module, corpCardNames(m.module)]));
+    const cardsByModule: MultiMap<GameModule, CardName> = new MultiMap();
+    getCards(byType(CardType.CORPORATION)).forEach((cam) => {
+      if (cam.card.name !== CardName.BEGINNER_CORPORATION) {
+        cardsByModule.set(cam.module, cam.card.name);
+      }
+    });
+    console.log(iterator(cardsByModule));
+
     return {
-      cardsByModuleMap: cardsByModuleMap,
+      cardsByModule: cardsByModule,
       customCorporationsList: false,
       selectedCorporations: [
-        ...cardsByModuleMap.get(GameModule.Base)!,
-        ...this.corporateEra ? cardsByModuleMap.get(GameModule.CorpEra)! : [],
-        ...this.prelude ? cardsByModuleMap.get(GameModule.Prelude)! : [],
-        ...this.venusNext ? cardsByModuleMap.get(GameModule.Venus)! : [],
-        ...this.colonies ? cardsByModuleMap.get(GameModule.Colonies)! : [],
-        ...this.turmoil ? cardsByModuleMap.get(GameModule.Turmoil)! : [],
-        ...this.promoCardsOption ? cardsByModuleMap.get(GameModule.Promo)! : [],
-        ...this.communityCardsOption ? cardsByModuleMap.get(GameModule.Community)! : [],
-        ...this.moonExpansion ? cardsByModuleMap.get(GameModule.Moon)! : [],
-      ] as Array<CardName> | boolean /* v-model thinks this can be boolean */,
-      corpsByModule: Array.from(cardsByModuleMap),
+        // A bit sloppy since map is just above, but it will do.
+        ...corpCardNames(GameModule.Base)!,
+        ...this.corporateEra ? corpCardNames(GameModule.CorpEra) : [],
+        ...this.prelude ? corpCardNames(GameModule.Prelude) : [],
+        ...this.venusNext ? corpCardNames(GameModule.Venus) : [],
+        ...this.colonies ? corpCardNames(GameModule.Colonies) : [],
+        ...this.turmoil ? corpCardNames(GameModule.Turmoil) : [],
+        ...this.promoCardsOption ? corpCardNames(GameModule.Promo) : [],
+        ...this.communityCardsOption ? corpCardNames(GameModule.Community) : [],
+        ...this.moonExpansion ? corpCardNames(GameModule.Moon) : [],
+        ...this.pathfindersExpansion ? corpCardNames(GameModule.Pathfinders) : [],
+      ],
     };
   },
   methods: {
@@ -116,9 +116,9 @@ export default Vue.extend({
       return [];
     },
     getItemsByGroup(group: string): Array<CardName> {
-      if (group === 'All') return allItems.slice();
+      if (group === 'All') return Array.from(this.cardsByModule.values()).slice();
 
-      const corps = this.cardsByModuleMap.get(group as GameModule);
+      const corps = this.cardsByModule.get(group as GameModule);
       if (corps === undefined) {
         console.log('module %s not found', group);
         return [];

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -415,6 +415,7 @@
                   v-bind:promoCardsOption="promoCardsOption"
                   v-bind:communityCardsOption="communityCardsOption"
                   v-bind:moonExpansion="moonExpansion"
+                  v-bind:pathfindersExpansion="pathfindersExpansion"
               ></CorporationsFilter>
             </div>
 

--- a/tests/cards/pathfinders/SoylentSeedlingSystems.spec.ts
+++ b/tests/cards/pathfinders/SoylentSeedlingSystems.spec.ts
@@ -7,9 +7,9 @@ import {CardName} from '../../../src/CardName';
 import {TestingUtils} from '../../TestingUtils';
 import {Tags} from '../../../src/cards/Tags';
 import {Celestic} from '../../../src/cards/venusNext/Celestic';
-import {ALL_PROJECT_CARD_NAMES} from '../../../src/cards/AllCards';
 import {fail} from 'assert';
 import {GreeneryStandardProject} from '../../../src/cards/base/standardProjects/GreeneryStandardProject';
+import {PATHFINDERS_CARD_MANIFEST} from '../../../src/cards/pathfinders/PathfindersCardManifest';
 
 describe('SoylentSeedlingSystems', function() {
   let card: SoylentSeedlingSystems;
@@ -83,7 +83,7 @@ describe('SoylentSeedlingSystems', function() {
 
   // This test will fail if/when Wetlands gets introduced
   it('on wetlands placed', () => {
-    if (ALL_PROJECT_CARD_NAMES.includes(CardName.WETLANDS)) {
+    if (PATHFINDERS_CARD_MANIFEST.projectCards.findByCardName(CardName.WETLANDS) !== undefined) {
       fail('Make sure Wetlands works with this, too.');
     }
   });

--- a/tests/cards/venusNext/Celestic.spec.ts
+++ b/tests/cards/venusNext/Celestic.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {ALL_PROJECT_DECKS} from '../../../src/cards/AllCards';
+import {ALL_CARD_MANIFESTS} from '../../../src/cards/AllCards';
 import {Celestic} from '../../../src/cards/venusNext/Celestic';
 import {Game} from '../../../src/Game';
 import {TestPlayers} from '../../TestPlayers';
@@ -27,8 +27,8 @@ describe('Celestic', function() {
 
   it('Ensure static list contains all cards that mention floaters', function() {
     const found: Array<CardName> = [];
-    ALL_PROJECT_DECKS.forEach((deck) => {
-      deck.factories.forEach((factory) => {
+    ALL_CARD_MANIFESTS.forEach((manifest) => {
+      manifest.projectCards.factories.forEach((factory) => {
         const card = new factory.Factory();
 
         // Only looking for cards that mention floaters in the metadata


### PR DESCRIPTION
This will make it far easier to find a replacement that doesn't import actual card instances. Plus by doing this all the code uses the same API, making things so much simpler! Look at how small `AllCards.ts` is. I already see new minor things that can change and improve.