### PR TITLE
catches exception from Notification

### DIFF
--- a/src/client/components/WaitingFor.vue
+++ b/src/client/components/WaitingFor.vue
@@ -113,10 +113,17 @@ export default Vue.extend({
               if (Notification.permission !== 'granted') {
                 Notification.requestPermission();
               } else if (Notification.permission === 'granted') {
-                new Notification(constants.APP_NAME, {
-                  icon: '/favicon.ico',
-                  body: 'It\'s your turn!',
-                });
+                try {
+                  // this needs to be updated to use a serviceWorker
+                  // on browsers where this constructor isn't supported
+                  // the error will be ignored instead of going uncaught
+                  new Notification(constants.APP_NAME, {
+                    icon: '/favicon.ico',
+                    body: 'It\'s your turn!',
+                  });
+                } catch (e) {
+                  console.warn('unable to create notification', e);
+                }
               }
 
               const soundsEnabled = PreferencesManager.load('enable_sounds') === '1';


### PR DESCRIPTION
This is some work that will be needed for #3899 . Eventually we are going to have to create a service worker. Until that time this wraps the call to `Notification` in a try...catch. This will allow unsupported browsers to move past the error. Even with service worker we will still need to wrap this. Both `Notification` and service worker are only supported in secure contexts. Users using `http` to run the game locally will still hit an error in the future.