### PR TITLE
Upgrade to Node v16.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '16.x'
     - run: npm ci
     - run: npm run lint
     - run: npm run build
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '16.x'
     - run: npm ci
     - run: npm run lint
     - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "terraforming-mars",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -64,7 +65,7 @@
         "zlib": "^1.0.5"
       },
       "engines": {
-        "node": "14.x"
+        "node": "16.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Terraforming Mars Game",
   "engines": {
-    "node": "14.x"
+    "node": "16.x"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Terraforming Mars Game",
   "engines": {
-    "node": "16.x"
+    "node": ">=14.x <=16.x"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Node version upgrades seem to happen rapidly. The most current version is 17.

To get this to work in an old environment you might need to run `npm rebuild`

A couple of sanity tests passed for me, including deploying to Heroku.