### PR TITLE
pin nodejs base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:14-alpine3.11
 
 EXPOSE 8080
 


### PR DESCRIPTION
Pin nodejs base image in Dockerfile to allow the docker build not to fail. See https://github.com/terraforming-mars/terraforming-mars/issues/3963