### PR TITLE
Fixes #3982 by counting all cities not player's cities

### DIFF
--- a/src/cards/base/ImmigrationShuttles.ts
+++ b/src/cards/base/ImmigrationShuttles.ts
@@ -29,7 +29,7 @@ export class ImmigrationShuttles extends Card implements IProjectCard {
     });
   }
   public override getVictoryPoints(player: Player) {
-    return Math.floor(player.game.getCitiesCount(player) / 3);
+    return Math.floor(player.game.getCitiesCount(undefined) / 3);
   }
   public play(player: Player) {
     player.addProduction(Resources.MEGACREDITS, 5);


### PR DESCRIPTION
This fixes a regression where Immigration Shuttles awarded points only for the player's cities. The prior implementation and the intent of the card is to award points for all cities.