### PR TITLE
avoid synchronous file access in production

### DIFF
--- a/src/routes/ServeAsset.ts
+++ b/src/routes/ServeAsset.ts
@@ -132,7 +132,7 @@ export class ServeAsset extends Handler {
       }
 
       // Return not-compressed .js files for development mode
-      if (!this.fileApi.existsSync(file)) {
+      if (!isProduction() && !this.fileApi.existsSync(file)) {
         encoding = undefined;
         file = `build/${urlPath}`;
       }

--- a/tests/routes/ServeAsset.spec.ts
+++ b/tests/routes/ServeAsset.spec.ts
@@ -35,6 +35,8 @@ describe('ServeAsset', () => {
   let res: MockResponse;
   let ctx: IContext;
   let fileApi: FileApiMock;
+  // The expected state of call counts in most simple cases in this test. This is a template
+  // used and overridden below. That makes how individual condition changes these calls.
   const primedCache = {
     readFile: 0,
     readFileSync: 3,

--- a/tests/routes/ServeAsset.spec.ts
+++ b/tests/routes/ServeAsset.spec.ts
@@ -35,7 +35,11 @@ describe('ServeAsset', () => {
   let res: MockResponse;
   let ctx: IContext;
   let fileApi: FileApiMock;
-
+  const primedCache = {
+    readFile: 0,
+    readFileSync: 3,
+    existsSync: 0,
+  };
   // Strictly speaking |parameters| can also accept a fragment.
   const setRequest = function(parameters: string, headers: Array<Array<string>> = []) {
     req.url = parameters;
@@ -44,7 +48,7 @@ describe('ServeAsset', () => {
       req.headers[entry[0]] = entry[1];
     });
   };
-
+  const storedNodeEnv = process.env.NODE_ENV;
   beforeEach(() => {
     instance = new ServeAsset(undefined, false);
     req = {headers: {}} as http.IncomingMessage;
@@ -57,7 +61,9 @@ describe('ServeAsset', () => {
       gameLoader: new FakeGameLoader(),
     };
   });
-
+  afterEach(() => {
+    process.env.NODE_ENV = storedNodeEnv;
+  });
   it('bad filename', () => {
     setRequest('goo.goo.gaa.gaa', [['accept-encoding', '']]);
     instance.get(req, res.hide(), ctx);
@@ -88,36 +94,55 @@ describe('ServeAsset', () => {
   it('styles.css: uncached', () => {
     instance = new ServeAsset(undefined, false, fileApi);
     // Primes the cache.
-    expect(fileApi.counts).deep.eq({readFile: 0, readFileSync: 3, existsSync: 0});
+    expect(fileApi.counts).deep.eq(primedCache);
 
     setRequest('/styles.css', [['accept-encoding', '']]);
     instance.get(req, res.hide(), ctx);
 
     expect(res.content).eq('data: build/styles.css');
     expect(fileApi.counts).deep.eq({
+      ...primedCache,
       readFile: 1, // Still read.
-      readFileSync: 3,
-      existsSync: 0,
     });
   });
 
   it('styles.css.gz: cached', () => {
     instance = new ServeAsset(undefined, true, fileApi);
     // Primes the cache.
-    expect(fileApi.counts).deep.eq({readFile: 0, readFileSync: 3, existsSync: 0});
+    expect(fileApi.counts).deep.eq(primedCache);
 
     setRequest('/styles.css', [['accept-encoding', 'gzip']]);
     instance.get(req, res.hide(), ctx);
 
     expect(res.content).eq('data: build/styles.css.gz');
     expect(fileApi.counts).deep.eq({
+      ...primedCache,
       readFile: 0, // Does not change
-      readFileSync: 3,
-      existsSync: 0,
     });
   });
 
+  it('development main.js', () => {
+    instance = new ServeAsset(undefined, false, fileApi);
+    setRequest('/main.js', [['accept-encoding', '']]);
+    instance.get(req, res.hide(), ctx);
+    expect(res.content).eq('data: build/main.js');
+    expect(fileApi.counts).deep.eq({
+      ...primedCache,
+      readFile: 1,
+      existsSync: 1,
+    });
+  });
 
-  // Cached CSS
-  // Uncached CSS
+  it('production main.js', () => {
+    process.env.NODE_ENV = 'production';
+    instance = new ServeAsset(undefined, false, fileApi);
+    setRequest('/main.js', [['accept-encoding', '']]);
+    instance.get(req, res.hide(), ctx);
+    expect(res.content).eq('data: build/main.js');
+    expect(fileApi.counts).deep.eq({
+      ...primedCache,
+      readFile: 1,
+      existsSync: 0,
+    });
+  });
 });


### PR DESCRIPTION
I am putting up a new `sw.js` file in preparation for adding a service worker. While I was looking at `ServeAsset` I saw we were always checking if files exist. This avoids the check for production. Should avoid synchronous file i/o.