### PR TITLE
Simplify Robotic Workforce test.

### DIFF
--- a/tests/cards/base/RoboticWorkforce.spec.ts
+++ b/tests/cards/base/RoboticWorkforce.spec.ts
@@ -27,6 +27,9 @@ import {SolarWindPower} from '../../../src/cards/base/SolarWindPower';
 import {MarsUniversity} from '../../../src/cards/base/MarsUniversity';
 import {Gyropolis} from '../../../src/cards/venusNext/Gyropolis';
 import {VenusGovernor} from '../../../src/cards/venusNext/VenusGovernor';
+import {CardType} from '../../../src/cards/CardType';
+import {CorporationCard} from '../../../src/cards/corporation/CorporationCard';
+import {IProjectCard} from '../../../src/cards/IProjectCard';
 
 describe('RoboticWorkforce', () => {
   let card : RoboticWorkforce; let player : TestPlayer; let game : Game;
@@ -233,19 +236,18 @@ describe('RoboticWorkforce', () => {
           game.moonData!.moon.spaces[4].player = player;
         }
 
-        const action = card.play(player);
-        if (action !== undefined) {
-          if (action instanceof SelectSpace) {
-            action.cb(action.availableSpaces[0]);
-          }
+        if (card.cardType === CardType.CORPORATION) {
+          (game as any).playCorporationCard(player, card as CorporationCard);
+        } else {
+          player.playCard(card as IProjectCard);
         }
 
+        // SelectSpace will trigger production changes in the right cards (e.g. Mining Rights)
         while (game.deferredActions.length) {
-          const defAction = game.deferredActions.pop()!.execute();
-          if (defAction !== undefined) {
-            if (defAction instanceof SelectSpace) {
-              defAction.cb(defAction.availableSpaces[0]);
-            }
+          TestingUtils.runNextAction(game);
+          const waitingFor = player.popWaitingFor();
+          if (waitingFor instanceof SelectSpace) {
+            waitingFor.cb(waitingFor.availableSpaces[0]);
           }
         }
 


### PR DESCRIPTION
Also rely on existing behavior to simulate these cards. An upcoming card
relies on the card being placed in hand before running deferred actions,
and this is pretty normal behavior. That this test did it itself, means
that it was using abnormal behavior. Not to mention it was doing more
work that way.

(Edited to add: in retrospect, this doesn't look smaller, does it? But it's certainly more standard.