### PR TITLE
Don't log drawn cards in Return to Abandoned Technology.

### DIFF
--- a/src/cards/pathfinders/ReturntoAbandonedTechnology.ts
+++ b/src/cards/pathfinders/ReturntoAbandonedTechnology.ts
@@ -38,7 +38,7 @@ export class ReturntoAbandonedTechnology extends Card implements IProjectCard {
     }
 
     const cardsToKeep = Math.min(2, cards.length);
-    return DrawCards.choose(player, cards, {keepMax: cardsToKeep, logDrawnCard: true});
+    return DrawCards.choose(player, cards, {keepMax: cardsToKeep});
   }
 }
 


### PR DESCRIPTION
I wish the logging option was a little more powerful, but for now, I'm just removing it.