### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,13 @@
 .github
+.git
+.dockerignore
+Dockerfile
+*.md
+.nvmrc
+LICENSE
+tests
+.gitignore
+.gitattributes
+.env.sample
+.eslintrc.js
+docker-compose.yml


### PR DESCRIPTION
- changes to these files will no longer invalidate the docker cache
- build context will be smaller -> transfer will be shorter