### PR TITLE
Fix synchronicity errors with end games.

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1039,7 +1039,7 @@ export class Game implements ISerializable<SerializedGame> {
       this.log('This game id was ' + this.id);
     }
 
-    Database.getInstance().cleanSaves(this.id, this.lastSaveId);
+    Database.getInstance().cleanSaves(this.id);
     const scores: Array<Score> = [];
     this.players.forEach((player) => {
       let corponame: string = '';

--- a/src/database/IDatabase.ts
+++ b/src/database/IDatabase.ts
@@ -135,7 +135,7 @@ export interface IDatabase {
      * A maintenance task on a single game to close it out upon its completion.
      * It will:
      *
-     * * Purge all saves between `(0, save_id]`.
+     * * Purge all saves between `(0, last save]`.
      * * Mark the game as finished.
      * * It also participates in purging abandoned solo games older
      *   than a given date range, regardless of the supplied `game_id`.
@@ -144,7 +144,7 @@ export interface IDatabase {
     // TODO(kberg): rename to represent that it's closing out
     // this game. Also consider not needing the save_id, and
     // also to make the maintenance behavior a first-class method.
-    cleanSaves(game_id: GameId, save_id: number): void;
+    cleanSaves(game_id: GameId): void;
 
     /**
      * A maintenance task that purges abandoned solo games older

--- a/src/database/LocalFilesystem.ts
+++ b/src/database/LocalFilesystem.ts
@@ -117,7 +117,7 @@ export class Localfilesystem implements IDatabase {
     // Not implemented
   }
 
-  cleanSaves(_gameId: GameId, _save_id: number): void {
+  cleanSaves(_gameId: GameId): void {
     // Not implemented here.
   }
 

--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -162,11 +162,11 @@ export class PostgreSQL implements IDatabase {
   }
 
   getMaxSaveId(game_id: GameId, cb: DbLoadCallback<number>): void {
-    this.client.query('SELECT MAX(save_id) FROM games WHERE game_id = $1', [game_id], (err: Error | null, res: QueryResult<any>) => {
+    this.client.query('SELECT MAX(save_id) as save_id FROM games WHERE game_id = $1', [game_id], (err: Error | null, res: QueryResult<any>) => {
       if (err) {
         return cb(err ?? undefined, undefined);
       }
-      cb(undefined, res.rows[0]);
+      cb(undefined, res.rows[0].save_id);
     });
   }
 
@@ -180,6 +180,7 @@ export class PostgreSQL implements IDatabase {
   cleanSaves(game_id: GameId): void {
     this.getMaxSaveId(game_id, ((err, save_id) => {
       this.throwIf(err, 'cleanSaves0');
+      if (save_id === undefined) throw new Error('saveId is undefined for ' + game_id);
       // DELETE all saves except initial and last one
       this.client.query('DELETE FROM games WHERE game_id = $1 AND save_id < $2 AND save_id > 0', [game_id, save_id], (err) => {
         this.throwIf(err, 'cleanSaves1');

--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -161,22 +161,36 @@ export class PostgreSQL implements IDatabase {
     });
   }
 
-  cleanSaves(game_id: GameId, save_id: number): void {
-    // DELETE all saves except initial and last one
-    this.client.query('DELETE FROM games WHERE game_id = $1 AND save_id < $2 AND save_id > 0', [game_id, save_id], (err) => {
+  getMaxSaveId(game_id: GameId, cb: DbLoadCallback<number>): void {
+    this.client.query('SELECT MAX(save_id) FROM games WHERE game_id = $1', [game_id], (err: Error | null, res: QueryResult<any>) => {
       if (err) {
-        console.error('PostgreSQL:cleanSaves', err);
-        throw err;
+        return cb(err ?? undefined, undefined);
       }
-      // Flag game as finished
-      this.client.query('UPDATE games SET status = \'finished\' WHERE game_id = $1', [game_id], (err2) => {
-        if (err2) {
-          console.error('PostgreSQL:cleanSaves2', err2);
-          throw err2;
-        }
-      });
+      cb(undefined, res.rows[0]);
     });
-    this.purgeUnfinishedGames();
+  }
+
+  throwIf(err: any, condition: string) {
+    if (err) {
+      console.error('PostgreSQL', condition, err);
+      throw err;
+    }
+  }
+
+  cleanSaves(game_id: GameId): void {
+    this.getMaxSaveId(game_id, ((err, save_id) => {
+      this.throwIf(err, 'cleanSaves0');
+      // DELETE all saves except initial and last one
+      this.client.query('DELETE FROM games WHERE game_id = $1 AND save_id < $2 AND save_id > 0', [game_id, save_id], (err) => {
+        this.throwIf(err, 'cleanSaves1');
+        // Flag game as finished
+        this.client.query('UPDATE games SET status = \'finished\' WHERE game_id = $1', [game_id], (err2) => {
+          this.throwIf(err2, 'cleanSaves2');
+          // Purge after setting the status as finished so it does not delete the game.
+          this.purgeUnfinishedGames();
+        });
+      });
+    }));
   }
 
   // Purge unfinished games older than MAX_GAME_DAYS days. If this environment variable is absent, it uses the default of 10 days.

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -163,6 +163,7 @@ export class SQLite implements IDatabase {
         console.warn('SQLite: cleansaves0:', err.message);
         return;
       }
+      if (save_id === undefined) throw new Error('saveId is undefined for ' + game_id);
       // Purges isn't used yet
       this.runQuietly('INSERT into purges (game_id, last_save_id) values (?, ?)', [game_id, save_id]);
       // DELETE all saves except initial and last one

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -148,22 +148,33 @@ export class SQLite implements IDatabase {
     });
   }
 
-  cleanSaves(game_id: GameId, save_id: number): void {
-    // Purges isn't used yet
-    this.runQuietly('INSERT into purges (game_id, last_save_id) values (?, ?)', [game_id, save_id]);
-    // DELETE all saves except initial and last one
-    this.db.run('DELETE FROM games WHERE game_id = ? AND save_id < ? AND save_id > 0', [game_id, save_id], function(err: Error | null) {
+  getMaxSaveId(game_id: GameId, cb: DbLoadCallback<number>): void {
+    this.db.get('SELECT MAX(save_id) AS save_id FROM games WHERE game_id = ?', [game_id], (err: Error | null, row: { save_id: number; }) => {
       if (err) {
-        return console.warn(err.message);
+        return cb(err ?? undefined, undefined);
       }
+      cb(undefined, row.save_id);
     });
-    // Flag game as finished
-    this.db.run('UPDATE games SET status = \'finished\' WHERE game_id = ?', [game_id], function(err: Error | null) {
+  }
+
+  cleanSaves(game_id: GameId): void {
+    this.getMaxSaveId(game_id, ((err, save_id) => {
       if (err) {
-        return console.warn(err.message);
+        console.warn('SQLite: cleansaves0:', err.message);
+        return;
       }
-    });
-    this.purgeUnfinishedGames();
+      // Purges isn't used yet
+      this.runQuietly('INSERT into purges (game_id, last_save_id) values (?, ?)', [game_id, save_id]);
+      // DELETE all saves except initial and last one
+      this.db.run('DELETE FROM games WHERE game_id = ? AND save_id < ? AND save_id > 0', [game_id, save_id], (err) => {
+        if (err) console.warn('SQLite: cleansaves1: ', err.message);
+        // Flag game as finished
+        this.db.run('UPDATE games SET status = \'finished\' WHERE game_id = ?', [game_id], (err) => {
+          if (err) console.warn('SQLite: cleansaves2: ', err.message);
+          this.purgeUnfinishedGames();
+        });
+      });
+    }));
   }
 
   purgeUnfinishedGames(): void {

--- a/tests/database/SQLite.spec.ts
+++ b/tests/database/SQLite.spec.ts
@@ -97,7 +97,7 @@ describe('SQLite', () => {
     // TODO(kberg): make cleanSaves a promise, too. Beacuse right now
     // this timeout doesn't participate in automated testing. But for now I can
     // verify this in the debugger. Next step.
-    db.cleanSaves(game.id, 3);
+    db.cleanSaves(game.id);
     setTimeout(async () => {
       const saveIds = await db.getSaveIds(game.id);
       expect(saveIds).has.members([0, 3]);


### PR DESCRIPTION
The use of await in Postgres seems to have changed the lastSaveID, resulting in production games' last ID being lost forever. Rather than just fix that, I resolved a couple of other synchronicity errors, too.

1. Make sure that lastSaveId is correct by reading the last save ID from
the database rather than trusting the game.
2. Don't purge games until the current game is marked as finished, so it
doesn't accidentally get deleted.
3. Don't mark the game as finished until the game is truncated. It's
more efficient.