### PR TITLE
add empty service worker prepping for better mobile notifications

### DIFF
--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -30,6 +30,13 @@ async function bootstrap() {
     componentUpdated: trimEmptyTextNodes,
   });
 
+  if (window.isSecureContext && 'serviceWorker' in navigator) {
+    window.addEventListener('load', function() {
+      navigator.serviceWorker.register('sw.js').then(function(registration) {
+        console.log('registered the service worker', registration);
+      });
+    });
+  }
 
   new Vue(mainAppSettings);
 }

--- a/src/client/sw.ts
+++ b/src/client/sw.ts
@@ -1,0 +1,1 @@
+// service worker, empty for now, needed for client side notifications

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,7 @@ const handlers: Map<string, IHandler> = new Map(
     ['/solo', ServeApp.INSTANCE],
     ['/spectator', ServeApp.INSTANCE],
     ['/styles.css', ServeAsset.INSTANCE],
+    ['/sw.js', ServeAsset.INSTANCE],
     ['/the-end', ServeApp.INSTANCE],
   ],
 );

--- a/tests/routes/ServeAsset.spec.ts
+++ b/tests/routes/ServeAsset.spec.ts
@@ -147,4 +147,16 @@ describe('ServeAsset', () => {
       existsSync: 0,
     });
   });
+
+  it('sw.js', () => {
+    instance = new ServeAsset(undefined, false, fileApi);
+    setRequest('/sw.js', [['accept-encoding', '']]);
+    instance.get(req, res.hide(), ctx);
+    expect(res.content).eq('data: build/src/client/sw.js');
+    expect(fileApi.counts).deep.eq({
+      ...primedCache,
+      readFile: 1,
+      existsSync: 0,
+    });
+  });
 });


### PR DESCRIPTION
For notifications on android the `Notification` constructor can't be used. This adds an empty service worker to allow us to use notifications on android. Once this merges if it doesn't seem to cause any issue I will put up the PR to show notifications.

https://developers.google.com/web/ilt/pwa/introduction-to-push-notifications

Eventually the `WaitingFor` component can be fully updated to utilize these push notifications versus the polling used today.