### PR TITLE
Cards that reduce production should not be playable if the only opponent has Private Security.

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1526,9 +1526,15 @@ export class Game implements ISerializable<SerializedGame> {
     this.gameAge++;
   }
 
-  public someoneHasResourceProduction(resource: Resources, minQuantity: number = 1): boolean {
+  public someoneCanHaveProductionReduced(resource: Resources, minQuantity: number = 1): boolean {
     // in soloMode you don't have to decrease resources
-    return this.getPlayers().some((p) => p.getProduction(resource) >= minQuantity) || this.isSoloMode();
+    if (this.isSoloMode()) return true;
+    return this.getPlayers().some((p) => {
+      if (p.getProduction(resource) < minQuantity) return false;
+      // The pathfindersExpansion test is just an optimization for non-Pathfinders games.
+      if (this.gameOptions.pathfindersExpansion && p.cardIsInEffect(CardName.PRIVATE_SECURITY)) return false;
+      return true;
+    });
   }
 
   public discardForCost(toPlace: TileType) {

--- a/src/cards/base/BiomassCombustors.ts
+++ b/src/cards/base/BiomassCombustors.ts
@@ -34,7 +34,7 @@ export class BiomassCombustors extends Card implements IProjectCard {
   }
 
   public override canPlay(player: Player): boolean {
-    return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+    return player.game.someoneCanHaveProductionReduced(Resources.PLANTS, 1);
   }
 
   public play(player: Player) {

--- a/src/cards/base/Birds.ts
+++ b/src/cards/base/Birds.ts
@@ -43,7 +43,7 @@ export class Birds extends Card implements IActionCard, IProjectCard, IResourceC
     public override resourceCount = 0;
 
     public override canPlay(player: Player): boolean {
-      return player.game.someoneHasResourceProduction(Resources.PLANTS, 2);
+      return player.game.someoneCanHaveProductionReduced(Resources.PLANTS, 2);
     }
     public play(player: Player) {
       player.game.defer(

--- a/src/cards/base/CloudSeeding.ts
+++ b/src/cards/base/CloudSeeding.ts
@@ -29,7 +29,7 @@ export class CloudSeeding extends Card implements IProjectCard {
   }
   public override canPlay(player: Player): boolean {
     return player.getProduction(Resources.MEGACREDITS) > -5 &&
-        player.game.someoneHasResourceProduction(Resources.HEAT, 1);
+        player.game.someoneCanHaveProductionReduced(Resources.HEAT, 1);
   }
 
   public play(player: Player) {

--- a/src/cards/base/Fish.ts
+++ b/src/cards/base/Fish.ts
@@ -44,7 +44,7 @@ export class Fish extends Card implements IActionCard, IProjectCard, IResourceCa
     public override resourceCount: number = 0;
 
     public override canPlay(player: Player): boolean {
-      return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return player.game.someoneCanHaveProductionReduced(Resources.PLANTS, 1);
     }
     public play(player: Player) {
       player.game.defer(

--- a/src/cards/base/HeatTrappers.ts
+++ b/src/cards/base/HeatTrappers.ts
@@ -32,7 +32,7 @@ export class HeatTrappers extends Card implements IProjectCard {
   }
 
   public override canPlay(player: Player): boolean {
-    return player.game.someoneHasResourceProduction(Resources.HEAT, 2);
+    return player.game.someoneCanHaveProductionReduced(Resources.HEAT, 2);
   }
 
   public produce(player: Player) {

--- a/src/cards/base/Herbivores.ts
+++ b/src/cards/base/Herbivores.ts
@@ -49,7 +49,7 @@ export class Herbivores extends Card implements IProjectCard, IResourceCard {
     public override resourceCount: number = 0;
 
     public override canPlay(player: Player): boolean {
-      return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return player.game.someoneCanHaveProductionReduced(Resources.PLANTS, 1);
     }
 
     public onTilePlaced(cardOwner: Player, activePlayer: Player, space: ISpace) {

--- a/src/cards/base/RoboticWorkforce.ts
+++ b/src/cards/base/RoboticWorkforce.ts
@@ -38,10 +38,10 @@ export class RoboticWorkforce extends Card implements IProjectCard {
       return false;
     }
     if (card.name === CardName.BIOMASS_COMBUSTORS) {
-      return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return player.game.someoneCanHaveProductionReduced(Resources.PLANTS, 1);
     }
     if (card.name === CardName.HEAT_TRAPPERS) {
-      return player.game.someoneHasResourceProduction(Resources.HEAT, 2);
+      return player.game.someoneCanHaveProductionReduced(Resources.HEAT, 2);
     }
     if (card.name === CardName.GYROPOLIS) {
       return player.getProduction(Resources.ENERGY) >= 2;

--- a/src/cards/base/SmallAnimals.ts
+++ b/src/cards/base/SmallAnimals.ts
@@ -43,7 +43,7 @@ export class SmallAnimals extends Card implements IActionCard, IProjectCard, IRe
   }
     public override resourceCount = 0;
     public override canPlay(player: Player): boolean {
-      return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return player.game.someoneCanHaveProductionReduced(Resources.PLANTS, 1);
     }
     public play(player: Player) {
       player.game.defer(

--- a/src/cards/colonies/SubZeroSaltFish.ts
+++ b/src/cards/colonies/SubZeroSaltFish.ts
@@ -49,7 +49,7 @@ export class SubZeroSaltFish extends Card implements IProjectCard, IResourceCard
   }
 
   public override canPlay(player: Player): boolean {
-    return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+    return player.game.someoneCanHaveProductionReduced(Resources.PLANTS, 1);
   }
 
   public action(player: Player) {

--- a/tests/cards/pathfinders/PrivateSecurity.spec.ts
+++ b/tests/cards/pathfinders/PrivateSecurity.spec.ts
@@ -1,11 +1,10 @@
 import {expect} from 'chai';
 import {PrivateSecurity} from '../../../src/cards/pathfinders/PrivateSecurity';
-import {Game} from '../../../src/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {TestPlayers} from '../../TestPlayers';
 import {Fish} from '../../../src/cards/base/Fish';
 import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
 import {Resources} from '../../../src/common/Resources';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('PrivateSecurity', function() {
   let card: PrivateSecurity;
@@ -15,10 +14,10 @@ describe('PrivateSecurity', function() {
 
   beforeEach(function() {
     card = new PrivateSecurity();
-    player = TestPlayers.BLUE.newPlayer();
-    opponent1 = TestPlayers.RED.newPlayer();
-    opponent2 = TestPlayers.GREEN.newPlayer();
-    Game.newInstance('id', [player, opponent1, opponent2], player);
+    const game = newTestGame(3, {pathfindersExpansion: true});
+    player = getTestPlayer(game, 0);
+    opponent1 = getTestPlayer(game, 1);
+    opponent2 = getTestPlayer(game, 2);
   });
 
   it('protects against Fish', function() {
@@ -41,5 +40,17 @@ describe('PrivateSecurity', function() {
     expect(action).is.undefined;
     // And it's the one without Private Security.
     expect(opponent1.getProduction(Resources.PLANTS)).to.eq(1);
+  });
+
+  it('Card cannot be played if the only opponent with production has Private Security', () => {
+    opponent1.setProductionForTest({plants: 1});
+    opponent2.setProductionForTest({plants: 0});
+
+    const fish = new Fish();
+
+    opponent2.playedCards = [];
+    expect(fish.canPlay(player)).is.true;
+    opponent1.playedCards = [card];
+    expect(fish.canPlay(player)).is.false;
   });
 });


### PR DESCRIPTION
Fixes #4103