### PR TITLE
Update make_static_json.js

### DIFF
--- a/make_static_json.js
+++ b/make_static_json.js
@@ -45,8 +45,8 @@ function generateAppVersion() {
   try {
     return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();
   } catch (error) {
-    console.warn('unable to generate app version', error);
-    return 'unknown version';
+    console.error('unable to generate app version', error);
+    throw error;
   }
 }
 


### PR DESCRIPTION
This will cause the build to fail if the git repo is not available. This would have caught the regression in #4015 .

On the flipside this won't allow you to build the project without git which may or may not be an issue.