### PR TITLE
Fix wrong New Venice tag.

### DIFF
--- a/src/cards/pathfinders/NewVenice.ts
+++ b/src/cards/pathfinders/NewVenice.ts
@@ -16,7 +16,7 @@ export class NewVenice extends Card implements IProjectCard {
     super({
       cardType: CardType.AUTOMATED,
       name: CardName.NEW_VENICE,
-      tags: [Tags.MICROBE, Tags.ENERGY, Tags.BUILDING, Tags.CITY],
+      tags: [Tags.MARS, Tags.ENERGY, Tags.BUILDING, Tags.CITY],
       cost: 21,
       productionBox: Units.of({energy: 1, megacredits: 2}),
 

--- a/tests/cards/pathfinders/MarsDirect.spec.ts
+++ b/tests/cards/pathfinders/MarsDirect.spec.ts
@@ -64,7 +64,7 @@ describe('MarsDirect', () => {
       }
     });
     // When this fails, reduce starting MC by 1.5MC per fail.
-    expect(count).eq(30);
+    expect(count).eq(31);
   });
 });
 


### PR DESCRIPTION
MarsDirect changes, but I won't change the MC in the base card; that adjustment didn't take this card into consideration.