### PR TITLE
Fixed Dockerfile to copy assets from built application, not from sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,13 +45,13 @@ USER tfm
 
 COPY ["package.json", "package-lock.json", "./"]
 
-COPY assets ./assets
-
 # Copy dependencies from intermediate image
 COPY --from=installProd /usr/src/app/node_modules ./node_modules
 
 # Copy built app from intermediate image
 COPY --from=builder /usr/src/app/build ./build
+
+COPY --from=builder /usr/src/app/assets ./assets
 
 # Run command.
 


### PR DESCRIPTION
I've introduced a bug during last Dockerfile refactoring. Assets are copied from clean source files and are missing some files (such as locales directory with translations). Fixed this by copying the assets directory from image with built application and not from clean sources.
Workaround over this bug is to build docker file after building app locally, because assets directory then contains everything docker image needs. Sadly this is why I did not find this bug in the previous PR.