### PR TITLE
Use ~~ES2021~~ ES2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         // ES2020 is very well supported in modern browsers.
         // ES 2021 has a couple of features not supported in Opera, but they're WeakRef and Promise.any.
         // It is safe to assume those features won't be run on a browser.
-        "lib": ["dom", "es2021"],
+        // "lib": ["dom", "es2021"],
+        "lib": ["dom", "es2019"],
         "incremental": true,
         "module": "commonjs",
         "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,12 @@
 {
     // Compiler options are mostly for the sub-configurations
     "compilerOptions": {
-        "lib": ["dom"],
+        // ES2019 support is pretty broad for Browsers, except for Function.prototype.toString, which is just not
+        // likely to be a problem
+        // ES2020 is very well supported in modern browsers.
+        // ES 2021 has a couple of features not supported in Opera, but they're WeakRef and Promise.any.
+        // It is safe to assume those features won't be run on a browser.
+        "lib": ["dom", "es2021"],
         "incremental": true,
         "module": "commonjs",
         "strict": true,


### PR DESCRIPTION
ES2018 seems to already be supported by default.

ES2019 support is pretty broad for Browsers, except for Function.prototype.toString, which is just not likely to be a problem
ES2020 is very well supported in modern browsers.
ES2021 has a couple of features not supported in Opera, but they're WeakRef and Promise.any. It is safe to assume those features won't be run on a browser.

See https://caniuse.com/sr_es10, https://caniuse.com/sr_es11, https://caniuse.com/sr_es12. Click "Feature Support List" for each of those.