### PR TITLE
clear customCorporationsList if not selected

### DIFF
--- a/src/client/components/GameHome.vue
+++ b/src/client/components/GameHome.vue
@@ -10,7 +10,7 @@
             <Button title="copy" size="tiny" @click="copyUrl(player.id)"/>
             <span v-if="isPlayerUrlCopied(player.id)" class="copied-notice">Playable link for {{player.name}} copied to clipboard <span class="dismissed" @click="setCopiedIdToDefault" >dismiss</span></span>
           </li>
-          <li v-if="game.spectatorId">
+          <li v-if="game !== undefined && game.spectatorId">
             <p/>
             <span class="turn-order"></span>
             <span class="color-square"></span>

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -894,13 +894,14 @@ export default Vue.extend({
       }
 
       // Check custom corp count
-      if (customCorporationsList.length > 0) {
+      if (component.showCorporationList && customCorporationsList.length > 0) {
         const neededCorpsCount = players.length * startingCorporations;
-
         if (customCorporationsList.length < neededCorpsCount) {
           window.alert(translateTextWithParams('Must select at least ${0} corporations', [neededCorpsCount.toString()]));
           return;
         }
+      } else {
+        customCorporationsList.length = 0;
       }
 
       // Clone game checks


### PR DESCRIPTION
This clears the custom corporations list if the showCorporationList is toggled off. After fixed an issue I saw in console logs where `game` was `undefined` while I was testing this change.

This can close #4046 