### PR TITLE
Add corporation card to list of selectable cards when finding owner. (Also fix BioSol rendering)

### DIFF
--- a/src/cards/pathfinders/BioSol.ts
+++ b/src/cards/pathfinders/BioSol.ts
@@ -5,7 +5,6 @@ import {Player} from '../../Player';
 import {CardName} from '../../common/cards/CardName';
 import {CardType} from '../../common/cards/CardType';
 import {CardRenderer} from '../render/CardRenderer';
-import {played} from '../Options';
 import {IActionCard, VictoryPoints} from '../ICard';
 import {ResourceType} from '../../common/ResourceType';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
@@ -29,7 +28,7 @@ export class BioSol extends Card implements CorporationCard, IActionCard {
           b.megacredits(42).cards(2, {secondaryTag: Tags.MICROBE}).br;
           b.corpBox('action', (corpbox) => corpbox.action(
             'Add 1 microbe to ANY card',
-            (ab) => ab.empty().startAction.microbes(1, {played}).asterix()));
+            (ab) => ab.empty().startAction.microbes(1).asterix()));
         }),
       },
     });

--- a/src/client/components/SelectCard.vue
+++ b/src/client/components/SelectCard.vue
@@ -145,7 +145,7 @@ export default Vue.extend({
     },
     findOwner(card: CardModel): Owner | undefined {
       for (const player of this.playerView.players) {
-        if (player.playedCards.find((c) => c.name === card.name)) {
+        if (player.playedCards.find((c) => c.name === card.name) || player.corporationCard?.name === card.name) {
           return {name: player.name, color: player.color};
         }
       }


### PR DESCRIPTION
Show card owner when selecting targets for Ants

One issue is that the corp card has this padding that I can't find.

![image](https://user-images.githubusercontent.com/413481/153101157-6a45db71-7685-4568-a5af-6e1270bc4a18.png)
