### PR TITLE
Fixed polish translation of Recyclon corp

### DIFF
--- a/src/locales/pl/promo.json
+++ b/src/locales/pl/promo.json
@@ -145,5 +145,5 @@
   "Action: Increase your energy production 1 step IF YOU HAVE NO ENERGY RESOURCES, or spend 3M€ to draw a building card.": "JEŚLI NIE POSIADASZ JEDNOSTEK ENERGII, podnieś swoją produkcję energii o 1 poziom ALBO wydaj 3 M€, aby dobrać pierwszą z odkrywanych kart z symbolem budowli z talii projektów (pozostałe odrzuć).",
 
   "You start with 38 M€ and 1 steel production.": "Rozpoczynasz grę z 38 M€ i 1 dodatkowym poziomem produkcji stali.",
-  "Effect: When you play a building tag, including this, gain 1 microbe to this card, or remove 2 microbes here and raise your plant production 1 step.": "Efekt trwały: Gdy zagrywasz kartę z symbolem budowli (z tą włącznie), umieść na tej karcie 1 jednostkę mikrobów i podnieś swoją produkcję zieleni o 1 poziom za każdy symbol budowli na zagranej karcie."
+  "Effect: When you play a building tag, including this, gain 1 microbe to this card, or remove 2 microbes here and raise your plant production 1 step.": "Efekt trwały: Gdy zagrywasz kartę z symbolem budowli (z tą włącznie), umieść na tej karcie 1 jednostkę mikrobów albo usuń z tej karty 2 jednostki mikrobów i podnieś swoją produkcję zieleni o 1 poziom za każdy symbol budowli na zagranej karcie."
 }


### PR DESCRIPTION
Polish translation wrongly stated, that you should place a microbe and increase greenery production for every played building tag.