### PR TITLE
rename getPlayers to getPlayersInGenerationOrder

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -350,7 +350,7 @@ export class Game implements ISerializable<SerializedGame> {
     // Initialize each player:
     // Give them their corporation cards, other cards, starting production,
     // handicaps.
-    for (const player of game.getPlayers()) {
+    for (const player of game.getPlayersInGenerationOrder()) {
       player.setTerraformRating(player.getTerraformRating() + player.handicap);
       if (!gameOptions.corporateEra) {
         GameSetup.setStartingProductions(player);
@@ -610,7 +610,7 @@ export class Game implements ISerializable<SerializedGame> {
     player.pickedCorporationCard = corporationCard;
     // if all players picked corporationCard
     if (this.players.every((p) => p.pickedCorporationCard !== undefined)) {
-      for (const somePlayer of this.getPlayers()) {
+      for (const somePlayer of this.getPlayersInGenerationOrder()) {
         this.playCorporationCard(somePlayer, somePlayer.pickedCorporationCard!);
       }
     }
@@ -633,7 +633,7 @@ export class Game implements ISerializable<SerializedGame> {
     this.log('${0} played ${1}', (b) => b.player(player).card(corporationCard));
 
     // trigger other corp's effect, e.g. SaturnSystems,PharmacyUnion,Splice
-    for (const somePlayer of this.getPlayers()) {
+    for (const somePlayer of this.getPlayersInGenerationOrder()) {
       if (somePlayer !== player && somePlayer.corporationCard !== undefined && somePlayer.corporationCard.onCorpCardPlayed !== undefined) {
         this.defer(new DeferredAction(
           player,
@@ -1073,7 +1073,7 @@ export class Game implements ISerializable<SerializedGame> {
 
   public /* for testing */ gotoFinalGreeneryPlacement(): void {
     // this.getPlayers returns in turn order -- a necessary rule for final greenery placement.
-    for (const player of this.getPlayers()) {
+    for (const player of this.getPlayersInGenerationOrder()) {
       if (this.donePlayers.has(player.id)) {
         continue;
       }
@@ -1476,7 +1476,7 @@ export class Game implements ISerializable<SerializedGame> {
   }
 
   // Players returned in play order starting with first player this generation.
-  public getPlayers(): Array<Player> {
+  public getPlayersInGenerationOrder(): Array<Player> {
     // We always return them in turn order
     const ret: Array<Player> = [];
     let insertIdx: number = 0;
@@ -1529,7 +1529,7 @@ export class Game implements ISerializable<SerializedGame> {
   public someoneCanHaveProductionReduced(resource: Resources, minQuantity: number = 1): boolean {
     // in soloMode you don't have to decrease resources
     if (this.isSoloMode()) return true;
-    return this.getPlayers().some((p) => {
+    return this.getPlayersInGenerationOrder().some((p) => {
       if (p.getProduction(resource) < minQuantity) return false;
       // The pathfindersExpansion test is just an optimization for non-Pathfinders games.
       if (this.gameOptions.pathfindersExpansion && p.cardIsInEffect(CardName.PRIVATE_SECURITY)) return false;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1611,7 +1611,7 @@ export class Player implements ISerializable<SerializedPlayer> {
 
     TurmoilHandler.applyOnCardPlayedEffect(this, card);
 
-    for (const somePlayer of this.game.getPlayers()) {
+    for (const somePlayer of this.game.getPlayersInGenerationOrder()) {
       if (somePlayer.corporationCard !== undefined && somePlayer.corporationCard.onCardPlayed !== undefined) {
         const actionFromPlayedCard: OrOptions | void = somePlayer.corporationCard.onCardPlayed(this, card);
         if (actionFromPlayedCard !== undefined) {
@@ -1692,7 +1692,7 @@ export class Player implements ISerializable<SerializedPlayer> {
       // Awards are disabled for 1 player games
       if (this.game.isSoloMode()) return;
 
-      const players: Array<Player> = this.game.getPlayers().slice();
+      const players: Array<Player> = this.game.getPlayersInGenerationOrder().slice();
       players.sort(
         (p1, p2) => fundedAward.award.getScore(p2) - fundedAward.award.getScore(p1),
       );
@@ -2105,7 +2105,7 @@ export class Player implements ISerializable<SerializedPlayer> {
       }
     });
 
-    if (this.game.getPlayers().length > 1 &&
+    if (this.game.getPlayersInGenerationOrder().length > 1 &&
       this.actionsTakenThisRound > 0 &&
       !this.game.gameOptions.fastModeOption &&
       this.allOtherPlayersHavePassed() === false) {
@@ -2152,7 +2152,7 @@ export class Player implements ISerializable<SerializedPlayer> {
   private allOtherPlayersHavePassed(): boolean {
     const game = this.game;
     if (game.isSoloMode()) return true;
-    const players = game.getPlayers();
+    const players = game.getPlayersInGenerationOrder();
     const passedPlayers = game.getPassedPlayers();
     return passedPlayers.length === players.length - 1 && passedPlayers.includes(this.color) === false;
   }

--- a/src/cards/CardRequirement.ts
+++ b/src/cards/CardRequirement.ts
@@ -158,7 +158,7 @@ export class TagCardRequirement extends CardRequirement {
     let tagCount = player.getTagCount(this.tag, mode);
 
     if (this.isAny) {
-      player.game.getPlayers().forEach((p) => {
+      player.game.getPlayersInGenerationOrder().forEach((p) => {
         if (p.id !== player.id) {
           // Don't include opponents' wild tags because they are not performing the action.
           tagCount += p.getTagCount(this.tag, 'raw');

--- a/src/cards/base/HiredRaiders.ts
+++ b/src/cards/base/HiredRaiders.ts
@@ -43,7 +43,7 @@ export class HiredRaiders extends Card implements IProjectCard {
       );
     }
 
-    const availablePlayerTargets = player.game.getPlayers().filter((p) => p.id !== player.id);
+    const availablePlayerTargets = player.game.getPlayersInGenerationOrder().filter((p) => p.id !== player.id);
     const availableActions = new OrOptions();
 
     availablePlayerTargets.forEach((target) => {

--- a/src/cards/base/MediaArchives.ts
+++ b/src/cards/base/MediaArchives.ts
@@ -27,7 +27,7 @@ export class MediaArchives extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    const allPlayedEvents: number = player.game.getPlayers().map((player) => player.getPlayedEventsCount()).reduce((a, c) => a + c, 0);
+    const allPlayedEvents: number = player.game.getPlayersInGenerationOrder().map((player) => player.getPlayedEventsCount()).reduce((a, c) => a + c, 0);
     player.addResource(Resources.MEGACREDITS, allPlayedEvents, {log: true});
     return undefined;
   }

--- a/src/cards/base/Sabotage.ts
+++ b/src/cards/base/Sabotage.ts
@@ -31,7 +31,7 @@ export class Sabotage extends Card implements IProjectCard {
   public play(player: Player) {
     if (player.game.isSoloMode()) return undefined;
 
-    const availablePlayerTargets = player.game.getPlayers().filter((p) => p.id !== player.id);
+    const availablePlayerTargets = player.game.getPlayersInGenerationOrder().filter((p) => p.id !== player.id);
     const availableActions = new OrOptions();
 
     availablePlayerTargets.forEach((target) => {

--- a/src/cards/base/TollStation.ts
+++ b/src/cards/base/TollStation.ts
@@ -28,7 +28,7 @@ export class TollStation extends Card implements IProjectCard {
     });
   }
   public play(player: Player) {
-    const amount = player.game.getPlayers()
+    const amount = player.game.getPlayersInGenerationOrder()
       .filter((aPlayer) => aPlayer !== player)
       .map((opponent) => opponent.getTagCount(Tags.SPACE, 'raw'))
       .reduce((a, c) => a + c, 0);

--- a/src/cards/base/Virus.ts
+++ b/src/cards/base/Virus.ts
@@ -32,7 +32,7 @@ export class Virus extends Card implements IProjectCard {
     });
   }
   public play(player: Player): PlayerInput | undefined {
-    if (player.game.getPlayers().length === 1) {
+    if (player.game.getPlayersInGenerationOrder().length === 1) {
       player.game.someoneHasRemovedOtherPlayersPlants = true;
       return undefined;
     }

--- a/src/cards/colonies/Aridor.ts
+++ b/src/cards/colonies/Aridor.ts
@@ -58,7 +58,7 @@ export class Aridor extends Card implements CorporationCard {
 
   private checkActivation(colony: Colony, game: Game): void {
     if (colony.resourceType === undefined) return;
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       if (player.corporationCard !== undefined && player.corporationCard.resourceType === colony.resourceType) {
         colony.isActive = true;
         return;

--- a/src/cards/colonies/GalileanWaystation.ts
+++ b/src/cards/colonies/GalileanWaystation.ts
@@ -28,7 +28,7 @@ export class GalileanWaystation extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    const amount = player.game.getPlayers()
+    const amount = player.game.getPlayersInGenerationOrder()
       .map((aplayer) => aplayer.getTagCount(Tags.JOVIAN, player.id === aplayer.id ? 'default' : 'raw'))
       .reduce((a, c) => a + c, 0);
     player.addProduction(Resources.MEGACREDITS, amount, {log: true});

--- a/src/cards/community/Playwrights.ts
+++ b/src/cards/community/Playwrights.ts
@@ -55,7 +55,7 @@ export class Playwrights extends Card implements CorporationCard {
   }
 
   public action(player: Player): SelectCard<IProjectCard> | undefined {
-    const players = player.game.getPlayers();
+    const players = player.game.getPlayersInGenerationOrder();
     const replayableEvents = this.getReplayableEvents(player);
 
     return new SelectCard<IProjectCard>(
@@ -85,7 +85,7 @@ export class Playwrights extends Card implements CorporationCard {
                    * Needs to be deferred to happen after Law Suit's `play()` method.
                    */
                 player.game.defer(new DeferredAction(player, () => {
-                  player.game.getPlayers().some((p) => {
+                  player.game.getPlayersInGenerationOrder().some((p) => {
                     const card = p.playedCards[p.playedCards.length - 1];
                     if (card?.name === selectedCard.name) {
                       p.playedCards.pop();
@@ -112,7 +112,7 @@ export class Playwrights extends Card implements CorporationCard {
     const playedEvents : IProjectCard[] = [];
 
     this.checkLoops++;
-    player.game.getPlayers().forEach((p) => {
+    player.game.getPlayersInGenerationOrder().forEach((p) => {
       playedEvents.push(...p.playedCards.filter((card) => {
         return card.cardType === CardType.EVENT &&
             // Can player.canPlay(card) replace this?

--- a/src/cards/corporation/TharsisRepublic.ts
+++ b/src/cards/corporation/TharsisRepublic.ts
@@ -67,7 +67,7 @@ export class TharsisRepublic extends Card implements CorporationCard {
   }
 
   public play(player: Player) {
-    if (player.game.getPlayers().length === 1) {
+    if (player.game.getPlayersInGenerationOrder().length === 1) {
       // Get bonus for 2 neutral cities
       player.addProduction(Resources.MEGACREDITS, 2);
     }

--- a/src/cards/moon/CosmicRadiation.ts
+++ b/src/cards/moon/CosmicRadiation.ts
@@ -32,7 +32,7 @@ export class CosmicRadiation extends Card implements IProjectCard {
 
   public play(player: Player) {
     const mines = MoonExpansion.spaces(player.game, TileType.MOON_MINE);
-    player.game.getPlayers().forEach((mineTileOwner) => {
+    player.game.getPlayersInGenerationOrder().forEach((mineTileOwner) => {
       const owned = mines.filter((mine) => mine.player?.id === mineTileOwner.id).length;
       if (owned > 0) {
         const owes = owned * 4;

--- a/src/cards/moon/LunaSenate.ts
+++ b/src/cards/moon/LunaSenate.ts
@@ -33,7 +33,7 @@ export class LunaSenate extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    let count = player.game.getPlayers().map((p) => p.getTagCount(Tags.MOON, 'raw')).reduce((p, v) => p + v, 0);
+    let count = player.game.getPlayersInGenerationOrder().map((p) => p.getTagCount(Tags.MOON, 'raw')).reduce((p, v) => p + v, 0);
     // Including wild tags here because if it were included above it would count opponents' wild tags.
     count += player.getTagCount(Tags.WILDCARD, 'raw');
     // count + 2 because the 2 moon tags above apply, and this card isn't in played cards yet.

--- a/src/cards/moon/MooncrateConvoysToMars.ts
+++ b/src/cards/moon/MooncrateConvoysToMars.ts
@@ -33,7 +33,7 @@ export class MooncrateConvoysToMars extends Card {
   public play(player: Player) {
     MoonExpansion.raiseLogisticRate(player, 1);
     const game = player.game;
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       game.defer(new SellSteel(player));
     });
     return undefined;

--- a/src/cards/moon/RevoltingColonists.ts
+++ b/src/cards/moon/RevoltingColonists.ts
@@ -32,7 +32,7 @@ export class RevoltingColonists extends Card implements IProjectCard {
 
   public play(player: Player) {
     const colonies = MoonExpansion.spaces(player.game, TileType.MOON_COLONY);
-    player.game.getPlayers().forEach((colonyTileOwner) => {
+    player.game.getPlayersInGenerationOrder().forEach((colonyTileOwner) => {
       const owned = colonies.filter((colony) => colony.player?.id === colonyTileOwner.id).length;
       if (owned > 0) {
         const owes = owned * 3;

--- a/src/cards/pathfinders/CharityDonation.ts
+++ b/src/cards/pathfinders/CharityDonation.ts
@@ -30,7 +30,7 @@ export class CharityDonation extends Card implements IProjectCard {
 
   public play(player: Player) {
     const game = player.game;
-    const players = game.getPlayers();
+    const players = game.getPlayersInGenerationOrder();
     const thisIdx = players.findIndex((p) => p === player);
     const cards = game.dealer.drawProjectCardsByCondition(game, players.length + 1, () => true);
     // TODO(kberg): log the drawn cards after raising the planetary track.

--- a/src/cards/pathfinders/DustStorm.ts
+++ b/src/cards/pathfinders/DustStorm.ts
@@ -30,7 +30,7 @@ export class DustStorm extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    player.game.getPlayers().forEach((p) => p.addResource(Resources.ENERGY, -p.energy, {log: true}));
+    player.game.getPlayersInGenerationOrder().forEach((p) => p.addResource(Resources.ENERGY, -p.energy, {log: true}));
     player.game.increaseTemperature(player, 2);
     return undefined;
   }

--- a/src/cards/pathfinders/PublicSponsoredGrant.ts
+++ b/src/cards/pathfinders/PublicSponsoredGrant.ts
@@ -36,7 +36,7 @@ export class PublicSponsoredGrant extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    player.game.getPlayers().forEach((p) => p.deductResource(Resources.MEGACREDITS, Math.min(p.megaCredits, 2), {log: true}));
+    player.game.getPlayersInGenerationOrder().forEach((p) => p.deductResource(Resources.MEGACREDITS, Math.min(p.megaCredits, 2), {log: true}));
 
     // TODO(kberg): Add a test that fails when a new tag is added.
     const tags = [

--- a/src/cards/pathfinders/Ringcom.ts
+++ b/src/cards/pathfinders/Ringcom.ts
@@ -54,7 +54,7 @@ export class Ringcom extends Card implements CorporationCard {
 
   public onCardPlayed(player: Player, card: IProjectCard): void {
     if (card.tags.includes(Tags.JOVIAN)) {
-      player.game.getPlayers().forEach((p) => {
+      player.game.getPlayersInGenerationOrder().forEach((p) => {
         if (p.corporationCard?.name === this.name) {
           p.addResource(Resources.TITANIUM, 1, {log: true});
         }

--- a/src/cards/pathfinders/SmallComet.ts
+++ b/src/cards/pathfinders/SmallComet.ts
@@ -36,7 +36,7 @@ export class SmallComet extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    player.game.getPlayers().forEach((p) => {
+    player.game.getPlayersInGenerationOrder().forEach((p) => {
       if (!p.plantsAreProtected()) {
         p.deductResource(Resources.PLANTS, 2, {log: true, from: player});
       }

--- a/src/cards/pathfinders/SolarStorm.ts
+++ b/src/cards/pathfinders/SolarStorm.ts
@@ -33,7 +33,7 @@ export class SolarStorm extends Card implements IProjectCard {
 
   public play(player: Player) {
     player.addProduction(Resources.HEAT, 1);
-    player.game.getPlayers().forEach((p) => {
+    player.game.getPlayersInGenerationOrder().forEach((p) => {
       if (!p.plantsAreProtected()) {
         p.deductResource(Resources.PLANTS, 2, {log: true, from: player});
       }

--- a/src/cards/promo/MonsInsurance.ts
+++ b/src/cards/promo/MonsInsurance.ts
@@ -36,7 +36,7 @@ export class MonsInsurance extends Card implements CorporationCard {
 
   public play(player: Player) {
     player.addProduction(Resources.MEGACREDITS, 6);
-    for (const p of player.game.getPlayers()) {
+    for (const p of player.game.getPlayersInGenerationOrder()) {
       p.addProduction(Resources.MEGACREDITS, -2, {log: true});
     }
     player.game.monsInsuranceOwner = player.id;

--- a/src/cards/promo/PharmacyUnion.ts
+++ b/src/cards/promo/PharmacyUnion.ts
@@ -159,7 +159,7 @@ export class PharmacyUnion extends Card implements CorporationCard {
         player,
         () => {
           const microbeTagCount = card.tags.filter((cardTag) => cardTag === Tags.MICROBE).length;
-          const player = game.getPlayers().find((p) => p.isCorporation(this.name))!;
+          const player = game.getPlayersInGenerationOrder().find((p) => p.isCorporation(this.name))!;
           const megaCreditsLost = Math.min(player.megaCredits, microbeTagCount * 4);
           player.addResourceTo(this, microbeTagCount);
           player.megaCredits -= megaCreditsLost;

--- a/src/cards/turmoil/DiasporaMovement.ts
+++ b/src/cards/turmoil/DiasporaMovement.ts
@@ -31,7 +31,7 @@ export class DiasporaMovement extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    const amount = player.game.getPlayers()
+    const amount = player.game.getPlayersInGenerationOrder()
       .map((p) => p.getTagCount(Tags.JOVIAN, p.id === player.id ? 'default' : 'raw'))
       .reduce((a, c) => a + c);
     player.addResource(Resources.MEGACREDITS, amount + 1, {log: true});

--- a/src/cards/venusNext/CometForVenus.ts
+++ b/src/cards/venusNext/CometForVenus.ts
@@ -30,7 +30,7 @@ export class CometForVenus extends Card {
   }
 
   public play(player: Player) {
-    const venusTagPlayers = player.game.getPlayers().filter((otherPlayer) => otherPlayer.id !== player.id && otherPlayer.getTagCount(Tags.VENUS, 'raw') > 0);
+    const venusTagPlayers = player.game.getPlayersInGenerationOrder().filter((otherPlayer) => otherPlayer.id !== player.id && otherPlayer.getTagCount(Tags.VENUS, 'raw') > 0);
 
     if (player.game.isSoloMode()|| venusTagPlayers.length === 0) {
       player.game.increaseVenusScaleLevel(player, 1);

--- a/src/cards/venusNext/SponsoredAcademies.ts
+++ b/src/cards/venusNext/SponsoredAcademies.ts
@@ -36,7 +36,7 @@ export class SponsoredAcademies extends Card {
   public play(player: Player) {
     player.game.defer(new DiscardCards(player), Priority.DISCARD_BEFORE_DRAW);
     player.game.defer(DrawCards.keepAll(player, 3));
-    const otherPlayers = player.game.getPlayers().filter((p) => p.id !== player.id);
+    const otherPlayers = player.game.getPlayersInGenerationOrder().filter((p) => p.id !== player.id);
     for (const p of otherPlayers) {
       player.game.defer(DrawCards.keepAll(p));
     }

--- a/src/colonies/Colony.ts
+++ b/src/colonies/Colony.ts
@@ -97,7 +97,7 @@ export abstract class Colony {
       }
 
       // Poseidon hook
-      const poseidon = player.game.getPlayers().find((player) => player.isCorporation(CardName.POSEIDON));
+      const poseidon = player.game.getPlayersInGenerationOrder().find((player) => player.isCorporation(CardName.POSEIDON));
       if (poseidon !== undefined) {
         poseidon.addProduction(Resources.MEGACREDITS, 1);
       }
@@ -300,7 +300,7 @@ export abstract class Colony {
         action = new DeferredAction(
           player,
           () => {
-            const playersWithCards = game.getPlayers().filter((p) => p.cardsInHand.length > 0);
+            const playersWithCards = game.getPlayersInGenerationOrder().filter((p) => p.cardsInHand.length > 0);
             if (playersWithCards.length === 0) return undefined;
             return new SelectPlayer(
               playersWithCards,

--- a/src/database/GameLoader.ts
+++ b/src/database/GameLoader.ts
@@ -39,7 +39,7 @@ export class GameLoader implements IGameLoader {
       if (game.spectatorId !== undefined) {
         d.participantIds.set(game.spectatorId, game.id);
       }
-      for (const player of game.getPlayers()) {
+      for (const player of game.getPlayersInGenerationOrder()) {
         d.participantIds.set(player.id, game.id);
       }
     });

--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -237,7 +237,7 @@ export class PostgreSQL implements IDatabase {
     const gameJSON = game.toJSON();
     this.client.query(
       'INSERT INTO games (game_id, save_id, game, players) VALUES ($1, $2, $3, $4) ON CONFLICT (game_id, save_id) DO UPDATE SET game = $3',
-      [game.id, game.lastSaveId, gameJSON, game.getPlayers().length], (err) => {
+      [game.id, game.lastSaveId, gameJSON, game.getPlayersInGenerationOrder().length], (err) => {
         if (err) {
           console.error('PostgreSQL:saveGame', err);
           return;

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -209,7 +209,7 @@ export class SQLite implements IDatabase {
     // Insert
     await this.runQuietly(
       'INSERT INTO games (game_id, save_id, game, players) VALUES (?, ?, ?, ?) ON CONFLICT (game_id, save_id) DO UPDATE SET game = ?',
-      [game.id, game.lastSaveId, gameJSON, game.getPlayers().length, gameJSON]);
+      [game.id, game.lastSaveId, gameJSON, game.getPlayersInGenerationOrder().length, gameJSON]);
 
     // This must occur after the save.
     game.lastSaveId++;

--- a/src/deferredActions/ChoosePoliticalAgenda.ts
+++ b/src/deferredActions/ChoosePoliticalAgenda.ts
@@ -17,7 +17,7 @@ export class ChoosePoliticalAgenda implements DeferredAction {
   ) {}
 
   public execute(): PlayerInput {
-    const players = this.player.game.getPlayers();
+    const players = this.player.game.getPlayersInGenerationOrder();
     const bonuses: Array<SelectOption> = this.party.bonuses.map((bonus) => {
       const description = bonus.description + ' (' + players.map((player) => player.name + ': ' + bonus.getScore(player)).join(' / ') + ')';
 

--- a/src/deferredActions/DecreaseAnyProduction.ts
+++ b/src/deferredActions/DecreaseAnyProduction.ts
@@ -24,7 +24,7 @@ export class DecreaseAnyProduction implements DeferredAction {
   public execute() {
     if (this.player.game.isSoloMode()) return undefined;
 
-    let candidates: Array<Player> = this.player.game.getPlayers().filter((p) => !p.productionIsProtected());
+    let candidates: Array<Player> = this.player.game.getPlayersInGenerationOrder().filter((p) => !p.productionIsProtected());
 
     if (this.resource === Resources.MEGACREDITS) {
       candidates = candidates.filter((p) => p.getProduction(this.resource) >= this.options.count - 5);

--- a/src/deferredActions/RemoveAnyPlants.ts
+++ b/src/deferredActions/RemoveAnyPlants.ts
@@ -20,7 +20,7 @@ export class RemoveAnyPlants implements DeferredAction {
       return undefined;
     }
 
-    const candidates = this.player.game.getPlayers().filter((p) => p.id !== this.player.id && !p.plantsAreProtected() && p.plants > 0);
+    const candidates = this.player.game.getPlayersInGenerationOrder().filter((p) => p.id !== this.player.id && !p.plantsAreProtected() && p.plants > 0);
 
     if (candidates.length === 0) {
       return undefined;

--- a/src/deferredActions/RemoveResourcesFromCard.ts
+++ b/src/deferredActions/RemoveResourcesFromCard.ts
@@ -77,7 +77,7 @@ export class RemoveResourcesFromCard implements DeferredAction {
       }
     } else {
       resourceCards = [];
-      player.game.getPlayers().forEach((p) => {
+      player.game.getPlayersInGenerationOrder().forEach((p) => {
         switch (resourceType) {
         case ResourceType.ANIMAL:
           if (p.hasProtectedHabitats() && player.id !== p.id) return;

--- a/src/deferredActions/StealResources.ts
+++ b/src/deferredActions/StealResources.ts
@@ -24,7 +24,7 @@ export class StealResources implements DeferredAction {
       return undefined;
     }
 
-    let candidates: Array<Player> = this.player.game.getPlayers().filter((p) => p.id !== this.player.id && p.getResource(this.resource) > 0);
+    let candidates: Array<Player> = this.player.game.getPlayersInGenerationOrder().filter((p) => p.id !== this.player.id && p.getResource(this.resource) > 0);
     if (this.resource === Resources.PLANTS) {
       candidates = candidates.filter((p) => !p.plantsAreProtected());
     }

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -53,7 +53,7 @@ export class Server {
       activePlayer: game.getPlayerById(game.activePlayer).color,
       id: game.id,
       phase: game.phase,
-      players: game.getPlayers().map((player) => ({
+      players: game.getPlayersInGenerationOrder().map((player) => ({
         color: player.color,
         id: player.id,
         name: player.name,
@@ -98,7 +98,7 @@ export class Server {
   public static getPlayerModel(player: Player): PlayerViewModel {
     const game = player.game;
 
-    const players: Array<PublicPlayerModel> = game.getPlayers().map(this.getPlayer);
+    const players: Array<PublicPlayerModel> = game.getPlayersInGenerationOrder().map(this.getPlayer);
     const thisPlayerIndex: number = players.findIndex((p) => p.color === player.color);
     const thisPlayer: PublicPlayerModel = players[thisPlayerIndex];
 
@@ -123,7 +123,7 @@ export class Server {
       color: Color.NEUTRAL,
       id: game.spectatorId ?? '',
       game: this.getGameModel(game),
-      players: game.getPlayers().map(this.getPlayer),
+      players: game.getPlayersInGenerationOrder().map(this.getPlayer),
       thisPlayer: undefined,
     };
   }
@@ -151,7 +151,7 @@ export class Server {
       );
       const scores: Array<IMilestoneScore> = [];
       if (claimed === undefined && claimedMilestones.length < 3) {
-        game.getPlayers().forEach((player) => {
+        game.getPlayersInGenerationOrder().forEach((player) => {
           scores.push({
             playerColor: player.color,
             playerScore: milestone.getScore(player),
@@ -182,7 +182,7 @@ export class Server {
       );
       const scores: Array<IAwardScore> = [];
       if (fundedAwards.length < 3 || funded !== undefined) {
-        game.getPlayers().forEach((player) => {
+        game.getPlayersInGenerationOrder().forEach((player) => {
           scores.push({
             playerColor: player.color,
             playerScore: award.getScore(player),

--- a/src/models/TurmoilModel.ts
+++ b/src/models/TurmoilModel.ts
@@ -104,7 +104,7 @@ export function getTurmoilModel(game: Game): TurmoilModel | undefined {
     };
 
     const policyActionUsers = Array.from(
-      game.getPlayers(),
+      game.getPlayersInGenerationOrder(),
       (player) => {
         return {
           color: player.color,

--- a/src/pathfinders/PathfindersExpansion.ts
+++ b/src/pathfinders/PathfindersExpansion.ts
@@ -55,7 +55,7 @@ export class PathfindersExpansion {
     // Communication Center hook
     if (card.cardType === CardType.EVENT) {
       let done = false;
-      for (const p of player.game.getPlayers()) {
+      for (const p of player.game.getPlayersInGenerationOrder()) {
         for (const c of p.playedCards) {
           if (c.name === CardName.COMMUNICATION_CENTER) {
             player.addResourceTo(c, {qty: 1, log: true});
@@ -131,14 +131,14 @@ export class PathfindersExpansion {
           });
         }
         rewards.everyone.forEach((reward) => {
-          game.getPlayers().forEach((p) => {
+          game.getPlayersInGenerationOrder().forEach((p) => {
             PathfindersExpansion.grant(reward, p, tag);
           });
         });
         if (rewards.mostTags.length > 0) {
           const players = PathfindersExpansion.playersWithMostTags(
             tag,
-            game.getPlayers(),
+            game.getPlayersInGenerationOrder(),
             (from instanceof Player) ? from : undefined);
           rewards.mostTags.forEach((reward) => {
             players.forEach((p) => {

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -76,7 +76,7 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
     // Init parties
     turmoil.parties = ALL_PARTIES.map((cf) => new cf.Factory());
 
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       // Begin with one delegate in the lobby
       turmoil.lobby.add(player.id);
       // Begin with six delegates in the delegate reserve
@@ -242,7 +242,7 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
   // Launch the turmoil phase
   public endGeneration(game: Game): void {
     // 1 - All player lose 1 TR
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.decreaseTerraformRating();
     });
 
@@ -270,7 +270,7 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
     });
     this.lobby = new Set<string>();
 
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       if (this.hasDelegatesInReserve(player.id)) {
         const index = this.delegateReserve.indexOf(player.id);
         if (index > -1) {
@@ -303,7 +303,7 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
   public setRulingParty(game: Game): void {
     if (this.rulingParty !== undefined) {
       // Cleanup previous party effects
-      game.getPlayers().forEach((player) => player.hasTurmoilScienceTagBonus = false);
+      game.getPlayersInGenerationOrder().forEach((player) => player.hasTurmoilScienceTagBonus = false);
 
       // Change the chairman
       if (this.chairman) {

--- a/src/turmoil/globalEvents/AquiferReleasedByPublicCouncil.ts
+++ b/src/turmoil/globalEvents/AquiferReleasedByPublicCouncil.ts
@@ -22,8 +22,8 @@ export class AquiferReleasedByPublicCouncil extends GlobalEvent implements IGlob
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.defer(new PlaceOceanTile(game.getPlayers()[0], 'Select Ocean for Global Event'));
-    game.getPlayers().forEach((player) => {
+    game.defer(new PlaceOceanTile(game.getPlayersInGenerationOrder()[0], 'Select Ocean for Global Event'));
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.PLANTS, turmoil.getPlayerInfluence(player), {log: true, from: GlobalEventName.CORROSIVE_RAIN});
       player.addResource(Resources.STEEL, turmoil.getPlayerInfluence(player), {log: true, from: GlobalEventName.CORROSIVE_RAIN});
     });

--- a/src/turmoil/globalEvents/AsteroidMining.ts
+++ b/src/turmoil/globalEvents/AsteroidMining.ts
@@ -25,7 +25,7 @@ export class AsteroidMining extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.TITANIUM, Math.min(5, player.getTagCount(Tags.JOVIAN, 'raw')) + turmoil.getPlayerInfluence(player), {log: true, from: this.name});
     });
   }

--- a/src/turmoil/globalEvents/BalancedDevelopment.ts
+++ b/src/turmoil/globalEvents/BalancedDevelopment.ts
@@ -24,7 +24,7 @@ export class BalancedDevelopment extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const tags = player.getTagCount(Tags.MARS, 'raw');
       const total = Math.min(tags, 5) + turmoil.getPlayerInfluence(player);
       player.addResource(Resources.MEGACREDITS, 2 * total, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/CelebrityLeaders.ts
+++ b/src/turmoil/globalEvents/CelebrityLeaders.ts
@@ -25,7 +25,7 @@ export class CelebrityLeaders extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const eventsCards = player.playedCards.filter((card) => card.cardType === CardType.EVENT).length;
       player.addResource(Resources.MEGACREDITS, 2 * (Math.min(5, eventsCards) + turmoil.getPlayerInfluence(player)), {log: true, from: this.name});
     });

--- a/src/turmoil/globalEvents/CloudSocieties.ts
+++ b/src/turmoil/globalEvents/CloudSocieties.ts
@@ -25,7 +25,7 @@ export class CloudSocieties extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const resourceCards = player.getResourceCards(ResourceType.FLOATER);
       resourceCards.forEach((card) => {
         player.addResourceTo(card, 1);

--- a/src/turmoil/globalEvents/CommunicationBoom.ts
+++ b/src/turmoil/globalEvents/CommunicationBoom.ts
@@ -25,7 +25,7 @@ export class CommunicationBoom extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.deductResource(Resources.MEGACREDITS, 10, {log: true, from: this.name});
       player.getResourceCards(ResourceType.DATA).forEach((card) => {
         player.addResourceTo(card, {qty: 2, log: true});

--- a/src/turmoil/globalEvents/ConstantStruggle.ts
+++ b/src/turmoil/globalEvents/ConstantStruggle.ts
@@ -25,7 +25,7 @@ export class ConstantStruggle extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const influence = turmoil.getPlayerInfluence(player);
       const deducted = Math.max(10 - influence, 0);
       player.deductResource(Resources.MEGACREDITS, deducted, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/CorrosiveRain.ts
+++ b/src/turmoil/globalEvents/CorrosiveRain.ts
@@ -22,7 +22,7 @@ export class CorrosiveRain extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.drawCard(turmoil.getPlayerInfluence(player));
       game.defer(new CorrosiveRainDeferredAction(player));
     });

--- a/src/turmoil/globalEvents/Diversity.ts
+++ b/src/turmoil/globalEvents/Diversity.ts
@@ -22,7 +22,7 @@ export class Diversity extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       if (player.getDistinctTagCount(false) + turmoil.getPlayerInfluence(player) >= 9) {
         player.addResource(Resources.MEGACREDITS, 10, {log: true, from: this.name});
       }

--- a/src/turmoil/globalEvents/DryDeserts.ts
+++ b/src/turmoil/globalEvents/DryDeserts.ts
@@ -23,10 +23,10 @@ export class DryDeserts extends GlobalEvent implements IGlobalEvent {
   }
   public resolve(game: Game, turmoil: Turmoil) {
     if (game.canRemoveOcean()) {
-      game.defer(new RemoveOceanTile(game.getPlayers()[0], 'Dry Deserts Global Event - Remove an Ocean tile from the board'));
+      game.defer(new RemoveOceanTile(game.getPlayersInGenerationOrder()[0], 'Dry Deserts Global Event - Remove an Ocean tile from the board'));
     }
 
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const count = turmoil.getPlayerInfluence(player);
       if (count > 0) {
         game.defer(new SelectResourcesDeferred(

--- a/src/turmoil/globalEvents/EcoSabotage.ts
+++ b/src/turmoil/globalEvents/EcoSabotage.ts
@@ -23,7 +23,7 @@ export class EcoSabotage extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const plants = player.plants;
       const maxPlants = 3 + turmoil.getPlayerInfluence(player);
       const plantDecrease = Math.max(0, plants - maxPlants);

--- a/src/turmoil/globalEvents/Election.ts
+++ b/src/turmoil/globalEvents/Election.ts
@@ -29,13 +29,13 @@ export class Election extends GlobalEvent implements IGlobalEvent {
   public resolve(game: Game, turmoil: Turmoil) {
     // Solo
     if (game.isSoloMode()) {
-      if (this.getScore(game.getPlayers()[0], turmoil, game) >= 10) {
-        game.getPlayers()[0].increaseTerraformRatingSteps(2, {log: true});
-      } else if (this.getScore(game.getPlayers()[0], turmoil, game) >= 1) {
-        game.getPlayers()[0].increaseTerraformRatingSteps(1, {log: true});
+      if (this.getScore(game.getPlayersInGenerationOrder()[0], turmoil, game) >= 10) {
+        game.getPlayersInGenerationOrder()[0].increaseTerraformRatingSteps(2, {log: true});
+      } else if (this.getScore(game.getPlayersInGenerationOrder()[0], turmoil, game) >= 1) {
+        game.getPlayersInGenerationOrder()[0].increaseTerraformRatingSteps(1, {log: true});
       }
     } else {
-      const players = [...game.getPlayers()].sort(
+      const players = [...game.getPlayersInGenerationOrder()].sort(
         (p1, p2) => this.getScore(p2, turmoil, game) - this.getScore(p1, turmoil, game),
       );
 

--- a/src/turmoil/globalEvents/GenerousFunding.ts
+++ b/src/turmoil/globalEvents/GenerousFunding.ts
@@ -23,7 +23,7 @@ export class GenerousFunding extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const trSets = Math.max(0, Math.floor((player.getTerraformRating() - 15) / 5));
       const maxTRSets = 5;
       const totalSets = Math.min(maxTRSets, trSets) + turmoil.getPlayerInfluence(player);

--- a/src/turmoil/globalEvents/GlobalDustStorm.ts
+++ b/src/turmoil/globalEvents/GlobalDustStorm.ts
@@ -25,7 +25,7 @@ export class GlobalDustStorm extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil): void {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       if (player.heat > 0) {
         player.deductResource(Resources.HEAT, player.heat, {log: true, from: this.name});
       }

--- a/src/turmoil/globalEvents/HomeworldSupport.ts
+++ b/src/turmoil/globalEvents/HomeworldSupport.ts
@@ -24,7 +24,7 @@ export class HomeworldSupport extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = Math.min(5, player.getTagCount(Tags.EARTH, 'raw')) + turmoil.getPlayerInfluence(player);
       if (amount > 0) {
         player.addResource(Resources.MEGACREDITS, 2 * amount, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/ImprovedEnergyTemplates.ts
+++ b/src/turmoil/globalEvents/ImprovedEnergyTemplates.ts
@@ -24,7 +24,7 @@ export class ImprovedEnergyTemplates extends GlobalEvent implements IGlobalEvent
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addProduction(Resources.ENERGY, Math.floor((player.getTagCount(Tags.ENERGY, 'raw') + turmoil.getPlayerInfluence(player)) / 2), {log: true, from: this.name});
     });
   }

--- a/src/turmoil/globalEvents/InterplanetaryTrade.ts
+++ b/src/turmoil/globalEvents/InterplanetaryTrade.ts
@@ -24,7 +24,7 @@ export class InterplanetaryTrade extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, 2 * (Math.min(5, player.getTagCount(Tags.SPACE, 'raw')) + turmoil.getPlayerInfluence(player)), {log: true, from: this.name});
     });
   }

--- a/src/turmoil/globalEvents/JovianTaxRights.ts
+++ b/src/turmoil/globalEvents/JovianTaxRights.ts
@@ -21,7 +21,7 @@ export class JovianTaxRights extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       let coloniesCount: number = 0;
       game.colonies.forEach((colony) => {
         coloniesCount += colony.colonies.filter((owner) => owner === player.id).length;

--- a/src/turmoil/globalEvents/LeadershipSummit.ts
+++ b/src/turmoil/globalEvents/LeadershipSummit.ts
@@ -20,7 +20,7 @@ export class LeadershipSummit extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const partyLeaderCount = turmoil.parties.filter((party) => party.partyLeader === player.id).length;
       player.drawCard(Math.min(5, partyLeaderCount) + turmoil.getPlayerInfluence(player));
     });

--- a/src/turmoil/globalEvents/MagneticFieldStimulationDelays.ts
+++ b/src/turmoil/globalEvents/MagneticFieldStimulationDelays.ts
@@ -20,7 +20,7 @@ export class MagneticFieldStimulationDelays extends GlobalEvent implements IGlob
   }
 
   public resolve(game: Game) {
-    game.increaseOxygenLevel(game.getPlayers()[0], -2);
-    game.increaseTemperature(game.getPlayers()[0], -2);
+    game.increaseOxygenLevel(game.getPlayersInGenerationOrder()[0], -2);
+    game.increaseTemperature(game.getPlayersInGenerationOrder()[0], -2);
   }
 }

--- a/src/turmoil/globalEvents/MicrogravityHealthProblems.ts
+++ b/src/turmoil/globalEvents/MicrogravityHealthProblems.ts
@@ -22,7 +22,7 @@ export class MicrogravityHealthProblems extends GlobalEvent implements IGlobalEv
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       let coloniesCount: number = 0;
       game.colonies.forEach((colony) => {
         coloniesCount += colony.colonies.filter((owner) => owner === player.id).length;

--- a/src/turmoil/globalEvents/MinersOnStrike.ts
+++ b/src/turmoil/globalEvents/MinersOnStrike.ts
@@ -24,7 +24,7 @@ export class MinersOnStrike extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = Math.min(5, player.getTagCount(Tags.JOVIAN, 'raw')) - turmoil.getPlayerInfluence(player);
       if (amount > 0) {
         player.deductResource(Resources.TITANIUM, amount, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/MudSlides.ts
+++ b/src/turmoil/globalEvents/MudSlides.ts
@@ -23,7 +23,7 @@ export class MudSlides extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const tiles = game.board.spaces.filter(Board.ownedBy(player))
         .filter((space) => space.tile !== undefined &&
           game.board.getAdjacentSpaces(space)

--- a/src/turmoil/globalEvents/Pandemic.ts
+++ b/src/turmoil/globalEvents/Pandemic.ts
@@ -24,7 +24,7 @@ export class Pandemic extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const maxedSteelTags = Math.min(5, player.getTagCount(Tags.BUILDING, 'raw'));
       player.deductResource(Resources.MEGACREDITS, 3 * Math.max(0, maxedSteelTags - turmoil.getPlayerInfluence(player)), {log: true, from: this.name});
     });

--- a/src/turmoil/globalEvents/ParadigmBreakdown.ts
+++ b/src/turmoil/globalEvents/ParadigmBreakdown.ts
@@ -22,7 +22,7 @@ export class ParadigmBreakdown extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       if (player.cardsInHand.length >= 2) {
         game.defer(new DiscardCards(player, 2, 'Global Event - Select 2 cards to discard'));
       } else if (player.cardsInHand.length === 1) {

--- a/src/turmoil/globalEvents/Productivity.ts
+++ b/src/turmoil/globalEvents/Productivity.ts
@@ -22,7 +22,7 @@ export class Productivity extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.STEEL, Math.min(5, player.getProduction(Resources.STEEL)) + turmoil.getPlayerInfluence(player), {log: true, from: this.name});
     });
   }

--- a/src/turmoil/globalEvents/RedInfluence.ts
+++ b/src/turmoil/globalEvents/RedInfluence.ts
@@ -23,7 +23,7 @@ export class RedInfluence extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = Math.floor((player.getTerraformRating() - 10)/5);
       if (amount > 0) {
         player.addResource(Resources.MEGACREDITS, amount * -3, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/Revolution.ts
+++ b/src/turmoil/globalEvents/Revolution.ts
@@ -28,11 +28,11 @@ export class Revolution extends GlobalEvent implements IGlobalEvent {
   }
   public resolve(game: Game, turmoil: Turmoil) {
     if (game.isSoloMode()) {
-      if (this.getScore(game.getPlayers()[0], turmoil) >= 4 ) {
-        game.getPlayers()[0].decreaseTerraformRatingSteps(2, {log: true});
+      if (this.getScore(game.getPlayersInGenerationOrder()[0], turmoil) >= 4 ) {
+        game.getPlayersInGenerationOrder()[0].decreaseTerraformRatingSteps(2, {log: true});
       }
     } else {
-      const players = [...game.getPlayers()].sort(
+      const players = [...game.getPlayersInGenerationOrder()].sort(
         (p1, p2) => this.getScore(p2, turmoil) - this.getScore(p1, turmoil),
       );
 

--- a/src/turmoil/globalEvents/Riots.ts
+++ b/src/turmoil/globalEvents/Riots.ts
@@ -23,7 +23,7 @@ export class Riots extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const city = game.board.spaces.filter(
         (space) => Board.isCitySpace(space) &&
                          space.player === player,

--- a/src/turmoil/globalEvents/Sabotage.ts
+++ b/src/turmoil/globalEvents/Sabotage.ts
@@ -23,7 +23,7 @@ export class Sabotage extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       // This conditional isn't to prevent negative production, but to prevent misleading logging when the production diff is zero.
       if (player.getProduction(Resources.ENERGY) >= 1) {
         player.addProduction(Resources.ENERGY, -1, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/ScientificCommunity.ts
+++ b/src/turmoil/globalEvents/ScientificCommunity.ts
@@ -22,7 +22,7 @@ export class ScientificCommunity extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = player.cardsInHand.length + turmoil.getPlayerInfluence(player);
       player.addResource(Resources.MEGACREDITS, amount, {log: true, from: this.name});
     });

--- a/src/turmoil/globalEvents/SnowCover.ts
+++ b/src/turmoil/globalEvents/SnowCover.ts
@@ -20,9 +20,9 @@ export class SnowCover extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.increaseTemperature(game.getPlayers()[0], -2);
+    game.increaseTemperature(game.getPlayersInGenerationOrder()[0], -2);
 
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.drawCard(turmoil.getPlayerInfluence(player));
     });
   }

--- a/src/turmoil/globalEvents/SolarFlare.ts
+++ b/src/turmoil/globalEvents/SolarFlare.ts
@@ -24,7 +24,7 @@ export class SolarFlare extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = Math.min(5, player.getTagCount(Tags.SPACE, 'raw')) - turmoil.getPlayerInfluence(player);
       if (amount > 0) {
         player.addResource(Resources.MEGACREDITS, amount * -3, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/SolarnetShutdown.ts
+++ b/src/turmoil/globalEvents/SolarnetShutdown.ts
@@ -23,7 +23,7 @@ export class SolarnetShutdown extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = Math.min(5, player.playedCards.filter((card) => card.cardType === CardType.ACTIVE).length) - turmoil.getPlayerInfluence(player);
       if (amount > 0) {
         player.addResource(Resources.MEGACREDITS, amount * -3, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/SpaceRaceToMars.ts
+++ b/src/turmoil/globalEvents/SpaceRaceToMars.ts
@@ -26,7 +26,7 @@ export class SpaceRaceToMars extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const specialTileCount = this.specialTileCount(player);
       const bonus = Math.min(specialTileCount, 5);
       player.addProduction(Resources.MEGACREDITS, bonus, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/SpinoffProducts.ts
+++ b/src/turmoil/globalEvents/SpinoffProducts.ts
@@ -25,7 +25,7 @@ export class SpinoffProducts extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, 2 * (Math.min(5, player.getTagCount(Tags.SCIENCE, 'raw')) + turmoil.getPlayerInfluence(player)), {log: true, from: this.name});
     });
   }

--- a/src/turmoil/globalEvents/SponsoredProjects.ts
+++ b/src/turmoil/globalEvents/SponsoredProjects.ts
@@ -21,7 +21,7 @@ export class SponsoredProjects extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.getCardsWithResources().forEach((card) => card.resourceCount && player.addResourceTo(card));
       player.drawCard(turmoil.getPlayerInfluence(player));
     });

--- a/src/turmoil/globalEvents/StrongSociety.ts
+++ b/src/turmoil/globalEvents/StrongSociety.ts
@@ -22,7 +22,7 @@ export class StrongSociety extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = Math.min(5, player.game.getCitiesCount(player)) + turmoil.getPlayerInfluence(player);
       if (amount > 0) {
         player.addResource(Resources.MEGACREDITS, amount * 2, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/SuccessfulOrganisms.ts
+++ b/src/turmoil/globalEvents/SuccessfulOrganisms.ts
@@ -23,7 +23,7 @@ export class SuccessfulOrganisms extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.PLANTS, Math.min(5, player.getProduction(Resources.PLANTS)) + turmoil.getPlayerInfluence(player), {log: true, from: this.name});
     });
   }

--- a/src/turmoil/globalEvents/TiredEarth.ts
+++ b/src/turmoil/globalEvents/TiredEarth.ts
@@ -24,7 +24,7 @@ export class TiredEarth extends GlobalEvent implements IGlobalEvent {
   }
 
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const tags = player.getTagCount(Tags.EARTH, 'raw');
       const rawTotal = Math.min(tags, 5) - turmoil.getPlayerInfluence(player);
       const total = Math.max(rawTotal, 0);

--- a/src/turmoil/globalEvents/VenusInfrastructure.ts
+++ b/src/turmoil/globalEvents/VenusInfrastructure.ts
@@ -24,7 +24,7 @@ export class VenusInfrastructure extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = Math.min(5, player.getTagCount(Tags.VENUS, 'raw')) + turmoil.getPlayerInfluence(player);
       if (amount > 0) {
         player.addResource(Resources.MEGACREDITS, amount * 2, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/VolcanicEruptions.ts
+++ b/src/turmoil/globalEvents/VolcanicEruptions.ts
@@ -21,8 +21,8 @@ export class VolcanicEruptions extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.increaseTemperature(game.getPlayers()[0], 2);
-    game.getPlayers().forEach((player) => {
+    game.increaseTemperature(game.getPlayersInGenerationOrder()[0], 2);
+    game.getPlayersInGenerationOrder().forEach((player) => {
       const amount = turmoil.getPlayerInfluence(player);
       if (amount > 0) {
         player.addProduction(Resources.HEAT, amount, {log: true, from: this.name});

--- a/src/turmoil/globalEvents/WarOnEarth.ts
+++ b/src/turmoil/globalEvents/WarOnEarth.ts
@@ -21,7 +21,7 @@ export class WarOnEarth extends GlobalEvent implements IGlobalEvent {
     });
   }
   public resolve(game: Game, turmoil: Turmoil) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.decreaseTerraformRatingSteps(4 - turmoil.getPlayerInfluence(player), {log: true});
     });
   }

--- a/src/turmoil/parties/Greens.ts
+++ b/src/turmoil/parties/Greens.ts
@@ -39,7 +39,7 @@ class GreensBonus01 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }
@@ -57,7 +57,7 @@ class GreensBonus02 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }

--- a/src/turmoil/parties/Kelvinists.ts
+++ b/src/turmoil/parties/Kelvinists.ts
@@ -27,7 +27,7 @@ class KelvinistsBonus01 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }
@@ -43,7 +43,7 @@ class KelvinistsBonus02 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.HEAT, this.getScore(player));
     });
   }

--- a/src/turmoil/parties/MarsFirst.ts
+++ b/src/turmoil/parties/MarsFirst.ts
@@ -32,7 +32,7 @@ class MarsFirstBonus01 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }
@@ -49,7 +49,7 @@ class MarsFirstBonus02 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }

--- a/src/turmoil/parties/Party.ts
+++ b/src/turmoil/parties/Party.ts
@@ -32,22 +32,22 @@ export abstract class Party {
         if (this.getDelegates(this.partyLeader) !== max) {
           let currentIndex = 0;
           if (this.partyLeader === 'NEUTRAL') {
-            currentIndex = game.getPlayers().indexOf(game.getPlayerById(game.activePlayer));
+            currentIndex = game.getPlayersInGenerationOrder().indexOf(game.getPlayerById(game.activePlayer));
           } else {
-            currentIndex = game.getPlayers().indexOf(game.getPlayerById(this.partyLeader));
+            currentIndex = game.getPlayersInGenerationOrder().indexOf(game.getPlayerById(this.partyLeader));
           }
 
           let playersToCheck: Array<Player | NeutralPlayer> = [];
 
           // Manage if it's the first player or the last
-          if (game.getPlayers().length === 1 || currentIndex === 0) {
-            playersToCheck = game.getPlayers();
-          } else if (currentIndex === game.getPlayers().length - 1) {
-            playersToCheck = game.getPlayers().slice(0, currentIndex);
-            playersToCheck.unshift(game.getPlayers()[currentIndex]);
+          if (game.getPlayersInGenerationOrder().length === 1 || currentIndex === 0) {
+            playersToCheck = game.getPlayersInGenerationOrder();
+          } else if (currentIndex === game.getPlayersInGenerationOrder().length - 1) {
+            playersToCheck = game.getPlayersInGenerationOrder().slice(0, currentIndex);
+            playersToCheck.unshift(game.getPlayersInGenerationOrder()[currentIndex]);
           } else {
-            const left = game.getPlayers().slice(0, currentIndex);
-            const right = game.getPlayers().slice(currentIndex);
+            const left = game.getPlayersInGenerationOrder().slice(0, currentIndex);
+            const right = game.getPlayersInGenerationOrder().slice(currentIndex);
             playersToCheck = right.concat(left);
           }
 

--- a/src/turmoil/parties/Reds.ts
+++ b/src/turmoil/parties/Reds.ts
@@ -27,7 +27,7 @@ class RedsBonus01 implements Bonus {
 
   getScore(player: Player) {
     const game = player.game;
-    const players = game.getPlayers();
+    const players = game.getPlayersInGenerationOrder();
 
     if (game.isSoloMode() && players[0].getTerraformRating() <= 20) return 1;
 
@@ -39,7 +39,7 @@ class RedsBonus01 implements Bonus {
   }
 
   grant(game: Game) {
-    const players = game.getPlayers();
+    const players = game.getPlayersInGenerationOrder();
     const scores = players.map((player) => this.getScore(player));
 
     players.forEach((player, idx) => {
@@ -55,7 +55,7 @@ class RedsBonus02 implements Bonus {
 
   getScore(player: Player) {
     const game = player.game;
-    const players = game.getPlayers();
+    const players = game.getPlayersInGenerationOrder();
 
     if (game.isSoloMode() && players[0].getTerraformRating() > 20) return -1;
 
@@ -67,7 +67,7 @@ class RedsBonus02 implements Bonus {
   }
 
   grant(game: Game) {
-    const players = game.getPlayers();
+    const players = game.getPlayersInGenerationOrder();
     const scores = players.map((player) => this.getScore(player));
 
     players.forEach((player, idx) => {

--- a/src/turmoil/parties/Scientists.ts
+++ b/src/turmoil/parties/Scientists.ts
@@ -26,7 +26,7 @@ class ScientistsBonus01 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }
@@ -42,7 +42,7 @@ class ScientistsBonus02 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }
@@ -94,7 +94,7 @@ class ScientistsPolicy04 implements Policy {
   isDefault = false;
 
   apply(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.hasTurmoilScienceTagBonus = true;
     });
   }

--- a/src/turmoil/parties/Unity.ts
+++ b/src/turmoil/parties/Unity.ts
@@ -34,7 +34,7 @@ class UnityBonus01 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }
@@ -50,7 +50,7 @@ class UnityBonus02 implements Bonus {
   }
 
   grant(game: Game) {
-    game.getPlayers().forEach((player) => {
+    game.getPlayersInGenerationOrder().forEach((player) => {
       player.addResource(Resources.MEGACREDITS, this.getScore(player));
     });
   }

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -335,7 +335,7 @@ describe('Game', () => {
     const player4 = new Player('p4', Color.RED, false, 0, 'p4-id');
     const game = Game.newInstance('gto', [player1, player2, player3, player4], player3);
 
-    game.getPlayers().forEach((p) => {
+    game.getPlayersInGenerationOrder().forEach((p) => {
       (p as any).waitingFor = undefined;
       p.plants = 8;
     });
@@ -388,7 +388,7 @@ describe('Game', () => {
     const game = Game.newInstance('gto', [player1, player2, player3, player4], player2);
     (game as any).incrementFirstPlayer();
 
-    game.getPlayers().forEach((p) => {
+    game.getPlayersInGenerationOrder().forEach((p) => {
       (p as any).waitingFor = undefined;
     });
 
@@ -428,7 +428,7 @@ describe('Game', () => {
     const player4 = new Player('p4', Color.RED, false, 0, 'p4-id');
     const game = Game.newInstance('gto', [player1, player2, player3, player4], player3);
 
-    let players = game.getPlayers();
+    let players = game.getPlayersInGenerationOrder();
     expect(players[0].name).to.eq('p3');
     expect(players[1].name).to.eq('p4');
     expect(players[2].name).to.eq('p1');
@@ -436,14 +436,14 @@ describe('Game', () => {
 
 
     (game as any).incrementFirstPlayer();
-    players = game.getPlayers();
+    players = game.getPlayersInGenerationOrder();
     expect(players[0].name).to.eq('p4');
     expect(players[1].name).to.eq('p1');
     expect(players[2].name).to.eq('p2');
     expect(players[3].name).to.eq('p3');
 
     (game as any).incrementFirstPlayer();
-    players = game.getPlayers();
+    players = game.getPlayersInGenerationOrder();
     expect(players[0].name).to.eq('p1');
     expect(players[1].name).to.eq('p2');
     expect(players[2].name).to.eq('p3');

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -105,7 +105,7 @@ export class TestingUtils {
 
   public static forceGenerationEnd(game: Game) {
     while (game.deferredActions.pop() !== undefined) {}
-    game.getPlayers().forEach((player) => player.pass());
+    game.getPlayersInGenerationOrder().forEach((player) => player.pass());
     game.playerIsFinishedTakingActions();
   }
 

--- a/tests/cards/base/LavaFlows.spec.ts
+++ b/tests/cards/base/LavaFlows.spec.ts
@@ -38,7 +38,7 @@ describe('LavaFlows', function() {
   it('All land spaces are available on Hellas', function() {
     // With two players, there's no solo setup, so all spaces will be available.
     const game = newTestGame(2, {boardName: BoardName.HELLAS});
-    const player = game.getPlayers()[0];
+    const player = game.getPlayersInGenerationOrder()[0];
 
     const action = card.play(player);
     expect(action.availableSpaces).deep.eq(game.board.getAvailableSpacesOnLand(player));

--- a/tests/cards/base/NoctisCity.spec.ts
+++ b/tests/cards/base/NoctisCity.spec.ts
@@ -26,7 +26,7 @@ describe('NoctisCity', function() {
   it('All land spaces are available on Hellas', function() {
     // With two players, there's no solo setup, so all spaces will be available.
     const game = newTestGame(2, {boardName: BoardName.HELLAS});
-    const player = game.getPlayers()[0];
+    const player = game.getPlayersInGenerationOrder()[0];
 
     const action = card.play(player);
     expect(action!.availableSpaces).deep.eq(game.board.getAvailableSpacesForCity(player));

--- a/tests/cards/moon/LunaProjectOffice.spec.ts
+++ b/tests/cards/moon/LunaProjectOffice.spec.ts
@@ -181,7 +181,7 @@ describe('LunaProjectOffice', () => {
 
 function finishGeneration(game: Game): void {
   const priorGeneration = game.generation;
-  game.getPlayers().forEach((player) => {
+  game.getPlayersInGenerationOrder().forEach((player) => {
     game.playerHasPassed(player);
     game.playerIsFinishedTakingActions();
   });

--- a/tests/database/Cloner.spec.ts
+++ b/tests/database/Cloner.spec.ts
@@ -25,7 +25,7 @@ describe('Cloner', function() {
     expect(() => newGame!.getPlayerById('old-player1-id')).to.throw();
     expect(newGame!.getPlayerById('new-player1-id')).is.not.undefined;
 
-    const newPlayerZero = newGame!.getPlayers()[0];
+    const newPlayerZero = newGame!.getPlayersInGenerationOrder()[0];
     expect(newPlayerZero.color).eq(Color.RED);
     expect(newPlayerZero.beginner).is.true;
 

--- a/tests/database/GameLoader.spec.ts
+++ b/tests/database/GameLoader.spec.ts
@@ -118,7 +118,7 @@ describe('GameLoader', function() {
       }, asyncTestDelay);
     };
     (GameLoader.getInstance() as GameLoader).reset();
-    GameLoader.getInstance().getByPlayerId(game.getPlayers()[0].id, (game1) => {
+    GameLoader.getInstance().getByPlayerId(game.getPlayersInGenerationOrder()[0].id, (game1) => {
       try {
         expect(game1).is.not.undefined;
         done();
@@ -156,7 +156,7 @@ describe('GameLoader', function() {
   });
 
   it('gets player when it exists in database', function(done) {
-    const players = game.getPlayers();
+    const players = game.getPlayersInGenerationOrder();
     GameLoader.getInstance().getByPlayerId(players[Math.floor(Math.random() * players.length)].id, (game1) => {
       try {
         expect(game1!.id).to.eq(game.id);
@@ -183,7 +183,7 @@ describe('GameLoader', function() {
   });
 
   it('gets player when added and not in database', function(done) {
-    const players = game.getPlayers();
+    const players = game.getPlayersInGenerationOrder();
     GameLoader.getInstance().add(game);
     GameLoader.getInstance().getByPlayerId(players[Math.floor(Math.random() * players.length)]!.id, (game1) => {
       try {
@@ -272,7 +272,7 @@ describe('GameLoader', function() {
       try {
         expect(game1).is.not.undefined;
         expect(game1!.id).to.eq('foobar');
-        GameLoader.getInstance().getByPlayerId(game.getPlayers()[0].id, (game1) => {
+        GameLoader.getInstance().getByPlayerId(game.getPlayersInGenerationOrder()[0].id, (game1) => {
           try {
             expect(game1!.id).to.eq('foobar');
             done();

--- a/tests/routes/FakeGameLoader.ts
+++ b/tests/routes/FakeGameLoader.ts
@@ -18,7 +18,7 @@ export class FakeGameLoader implements IGameLoader {
   }
   getByPlayerId(playerId: string, cb: (game: Game | undefined) => void): void {
     for (const game of Array.from(this.games.values())) {
-      for (const player of game.getPlayers()) {
+      for (const player of game.getPlayersInGenerationOrder()) {
         if (player.id === playerId) {
           cb(game);
           return;


### PR DESCRIPTION
A function way back when was hastily named `getPlayers`. This function returns the players in generation order which was needed for early usage. By now most callers don't need the players in generation order. After this change will introduce a `getPlayers` that doesn't order the players and use it where appropriate.