### PR TITLE
Fix rendering Iapetus card discount.

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -124,7 +124,6 @@ export class Player implements ISerializable<SerializedPlayer> {
   public draftedCards: Array<IProjectCard> = [];
   public cardCost: number = constants.CARD_COST;
   public needsToDraft: boolean | undefined = undefined;
-  public cardDiscount: number = 0;
 
   public timer: Timer = Timer.newInstance();
 
@@ -134,6 +133,7 @@ export class Player implements ISerializable<SerializedPlayer> {
   public colonyTradeOffset: number = 0;
   public colonyTradeDiscount: number = 0;
   public colonyVictoryPoints: number = 0;
+  public cardDiscount: number = 0; // Iapetus Colony
 
   // Turmoil
   public turmoilPolicyActionUsed: boolean = false;

--- a/src/client/components/overview/PlayerTags.vue
+++ b/src/client/components/overview/PlayerTags.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
 
     const x = PLAYER_INTERFACE_TAGS_ORDER.map((key) => [key, {discount: 0, points: 0}]);
     const modifiers: TagModifiers = Object.fromEntries(x);
-    modifiers['all'] = {discount: this.playerView.thisPlayer?.cardDiscount ?? 0, points: 0};
+    modifiers['all'] = {discount: this.player?.cardDiscount ?? 0, points: 0};
 
     const cards = this.player.corporationCard !== undefined ?
       [...this.player.playedCards, this.player.corporationCard] :


### PR DESCRIPTION
By accident, Iapetus card discount was applying active player's discount
to all players. That's because I used `thisPlayer` instead of `player`.

Fixes #4093