### PR TITLE
Fallback to windows-2019.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,8 @@ jobs:
     - run: npm test
   build-windows:
 
-    runs-on: windows-latest
+    # TODO(kberg): Move to windows-latest.
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v1
@@ -29,12 +30,12 @@ jobs:
     - run: npm run lint
     - run: npm run build
     - run: npm test
-    
+
   build-docker:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - run: docker build .
-        
+
 


### PR DESCRIPTION
https://github.blog/changelog/2021-11-16-github-actions-windows-server-2022-with-visual-studio-2022-is-now-generally-available-on-github-hosted-runners/

2022 is causing issues. I think.