### PR TITLE
ignore tag names from before linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,8 +28,28 @@ module.exports = {
     'require-jsdoc': 'off',
     'no-throw-literal': 'error',
     'no-extra-semi': 'error',
-    // Should turn this back on, but for now, turn it off.
+    // Old modules prior to the linting rule being enabled
+    // Avoid adding tags to this list
+    // Help remove tags from this list
     // https://eslint.vuejs.org/rules/multi-word-component-names.html
-    'vue/multi-word-component-names': 'warn',
+    'vue/multi-word-component-names': ['error', {
+      'ignores': [
+        "Award",
+        "Awards",
+        "agenda",
+        "board",
+        "bonus",
+        "colony",
+        "Milestone",
+        "party",
+        "Party",
+        "sidebar",
+        "Tag",
+        "turmoil",
+        "Card",
+        "Button",
+        "Help"
+      ]
+    }],
   },
 };


### PR DESCRIPTION
Adds the tags used which are not using `multi-word-component-names`. These tags were added prior to the linting rule being enforced. Avoids having warnings on every build.