### PR TITLE
Fix PORT env var name (for heroku setup)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -128,7 +128,7 @@ Database.getInstance().initialize()
   .then(() => {
     Database.getInstance().purgeUnfinishedGames();
 
-    const port = process.env.port || 8080;
+    const port = process.env.PORT || 8080;
     console.log('Starting server on port ' + port);
     console.log('version 0.X');
 


### PR DESCRIPTION
Hi,
I've noticed that when deploying the latest version on heroku the application no longer binded to $PORT (crashed).
Maybe a dependency update made the variable name case sensitive.
This change is all that was required to work again on my own heroku instance.