### PR TITLE
Update Earth Office card text.

### DIFF
--- a/src/cards/base/EarthOffice.ts
+++ b/src/cards/base/EarthOffice.ts
@@ -19,7 +19,7 @@ export class EarthOffice extends Card implements IProjectCard {
       metadata: {
         cardNumber: '105',
         renderData: CardRenderer.builder((b) => {
-          b.effect('When you play an Earth card, you pay 3 M€ less for it.', (eb) => {
+          b.effect('When you play an Earth tag, you pay 3 M€ less for it.', (eb) => {
             eb.earth(1, {played}).startEffect.megacredits(-3);
           });
         }),
@@ -30,6 +30,7 @@ export class EarthOffice extends Card implements IProjectCard {
   public getCardDiscount(_player: Player, card: IProjectCard) {
     return card.tags.filter((tag) => tag === Tags.EARTH).length * 3;
   }
+
 
   public play() {
     return undefined;

--- a/src/locales/br/base_cards.json
+++ b/src/locales/br/base_cards.json
@@ -367,8 +367,8 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "Ação: gaste 4 de energia para ganhar 1 de titânio e aumentar o oxigênio 1 nível.",
 
     "Earth Office": "Escritório na Terra",
-    "Effect: When you play an Earth card, you pay 3 M€ less for it.": "Efeito: quando você joga um ícone de Terra, pague 3 M€ a menos.",
-    "When you play an Earth card, you pay 3 M€ less for it.": "Quando você joga um ícone de Terra, pague 3 M€ a menos.",
+    "Effect: When you play an Earth tag, you pay 3 M€ less for it.": "Efeito: quando você joga um ícone de Terra, pague 3 M€ a menos.",
+    "When you play an Earth tag, you pay 3 M€ less for it.": "Quando você joga um ícone de Terra, pague 3 M€ a menos.",
 
     "Acquired Company": "Aquisição de Companhia",
 

--- a/src/locales/cn/cards.json
+++ b/src/locales/cn/cards.json
@@ -338,7 +338,7 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "行动： 花费4个电力资源，获得1个钛资源和提升氧气1级。",
 
     "Earth Office": "地球办公室",
-    "(Effect: When you play an Earth card, you pay 3 M€ less for it.)": "（效果： 每当你打出一张地球标志卡，你可以少花费3 M€）",
+    "(Effect: When you play an Earth tag, you pay 3 M€ less for it.)": "（效果： 每当你打出一张地球标志卡，你可以少花费3 M€）",
 
     "Acquired Company": "并购公司",
 

--- a/src/locales/es/base_cards.json
+++ b/src/locales/es/base_cards.json
@@ -372,8 +372,8 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "Acción: gasta 4 de energía para obtener 1 de titanio e incrementar el oxígeno 1 nivel.",
 
     "Earth Office": "Sucursal en la Tierra",
-    "Effect: When you play an Earth card, you pay 3 M€ less for it.": "Efecto: al jugar una carta tipo Tierra, paga 3 M€ menos por ella.",
-    "When you play an Earth card, you pay 3 M€ less for it.": "al jugar una carta tipo Tierra, paga 3 M€ menos por ella.",
+    "Effect: When you play an Earth tag, you pay 3 M€ less for it.": "Efecto: al jugar una carta tipo Tierra, paga 3 M€ menos por ella.",
+    "When you play an Earth tag, you pay 3 M€ less for it.": "al jugar una carta tipo Tierra, paga 3 M€ menos por ella.",
 
     "Acquired Company": "Adquisición de Empresa",
 

--- a/src/locales/it/cards.json
+++ b/src/locales/it/cards.json
@@ -21,7 +21,7 @@
 
     "Martian Rails": "Ferrovie Marziane",
     "Action: Spend 1 Energy to gain 1 M€ for each City tile ON MARS.": "Azione: spendi una risorsa Energia per ottenere 1 M€ per ogni tessera Città SU MARTE.",
-    
+
     "Asteroid": "Asteroide",
     "Raise temperature 1 step and gain 2 titanium. Remove up to 3 Plants from any player.": "Incrementa la Temperatura di 1 livello e ottieni 2 risorse Titanio. Rimuovi fino a 3 Piante da un qualunque giocatore.",
 
@@ -323,7 +323,7 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "Azione: spendi 4 risorse Energia per ottenere 1 risorsa Titanio e incrementare l'Ossigeno di 1 livello.",
 
     "Earth Office": "Ufficio Terrestre",
-    "(Effect: When you play an Earth card, you pay 3 M€ less for it.)": "(Effetto: quando giochi una carta con un simbolo Terra, la paghi 3 M€ in meno.)",
+    "(Effect: When you play an Earth tag, you pay 3 M€ less for it.)": "(Effetto: quando giochi una carta con un simbolo Terra, la paghi 3 M€ in meno.)",
 
     "Acquired Company": "Compagnia Acquisita",
 
@@ -610,7 +610,7 @@
   "Immigration Shuttles": "Navette per l'Immigrazione",
   "(Increase your M€ production 5 steps.)": "(Incrementa la tua Produzione di M€ di 5 livelli.)",
   "1 VP for every 3rd City in play.": "1 PV per ogni terna di Città in gioco.",
- 
+
   "Place this tile.": "Colloca questa tessera",
 
   "Immigrant City": "Città degli Immigrati",

--- a/src/locales/pl/cards.json
+++ b/src/locales/pl/cards.json
@@ -337,7 +337,7 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "Akcja: Wydaj 4 jednostki energii, żeby otrzymać 1 jednostkę tytanu i podnieść Poziom Tlenu o 1%.",
 
     "Earth Office": "Biuro na Ziemi",
-    "Effect: When you play an Earth card, you pay 3 M€ less for it.": "Efekt trwały: Gdy zagrywasz kartę z symbolem Ziemi, płacisz za nią o 3 M€ mniej.",
+    "Effect: When you play an Earth tag, you pay 3 M€ less for it.": "Efekt trwały: Gdy zagrywasz kartę z symbolem Ziemi, płacisz za nią o 3 M€ mniej.",
 
     "Acquired Company": "Przejęcie Firmy",
     "Increase your M€ production 3 steps.": "Podnieś swoją produkcję M€ o 3 poziomy.",

--- a/src/locales/ru/cards.json
+++ b/src/locales/ru/cards.json
@@ -341,7 +341,7 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "Действие: потратьте 4 энергии, чтобы получить 1 титан и повысить уровень кислорода на 1.",
 
     "Earth Office": "Офис на Земле",
-    "Effect: When you play an Earth card, you pay 3 M€ less for it.": "Свойство: когда вы играете карту с символом Земли, вы платите на 3 M€ меньше.",
+    "Effect: When you play an Earth tag, you pay 3 M€ less for it.": "Свойство: когда вы играете карту с символом Земли, вы платите на 3 M€ меньше.",
 
     "Acquired Company": "Приобретённая компания",
 


### PR DESCRIPTION
Unofficial FAQ says that earlier versions of Earth Office had the text
"play an earth card" but was updated to "play an earth tag."