### PR TITLE
Restore ColoniesFilter.updateCorporationsByName.

### DIFF
--- a/src/client/components/create/ColoniesFilter.vue
+++ b/src/client/components/create/ColoniesFilter.vue
@@ -65,6 +65,15 @@ export default Vue.extend({
     return data;
   },
   methods: {
+    // Do not delete this method. It's used by CreateGameForm.
+    updateColoniesByNames(colonyNames: Array<ColonyName>) {
+      this.selectedColonies = [];
+      for (const colony of this.allColonies) {
+        if (colonyNames.includes(colony)) {
+          this.selectedColonies.push(colony);
+        }
+      }
+    },
     description(colonyName: ColonyName): string {
       return COLONY_DESCRIPTIONS.get(colonyName) ?? 'unknown';
     },


### PR DESCRIPTION
This is a case where the method, seemingly unused, was deleted. However,
it was used in CreateGameForm, which references it with `(refs.xxx as
any)`. Getting rid of tne 'any' typing would be a big help.