### PR TITLE
Only check for multiple tags when there are many tags.

### DIFF
--- a/src/cards/CardRequirements.ts
+++ b/src/cards/CardRequirements.ts
@@ -32,7 +32,7 @@ export class CardRequirements implements ICardRequirements {
         tags.push((requirement as TagCardRequirement).tag);
       }
     });
-    if (!player.checkMultipleTagPresence(tags)) {
+    if (tags.length > 1 && !player.checkMultipleTagPresence(tags)) {
       return false;
     }
     return this.requirements.every((requirement: CardRequirement) => requirement.satisfies(player));

--- a/tests/cards/moon/EarthEmbassy.spec.ts
+++ b/tests/cards/moon/EarthEmbassy.spec.ts
@@ -5,10 +5,8 @@ import {TestPlayer} from '../../TestPlayer';
 import {EarthEmbassy} from '../../../src/cards/moon/EarthEmbassy';
 import {expect} from 'chai';
 import {Tags} from '../../../src/common/cards/Tags';
-import {CardType} from '../../../src/common/cards/CardType';
-import {CardName} from '../../../src/common/cards/CardName';
-import {IProjectCard} from '../../../src/cards/IProjectCard';
-import {ICardMetadata} from '../../../src/common/cards/ICardMetadata';
+import {LunaGovernor} from '../../../src/cards/colonies/LunaGovernor';
+import {BusinessNetwork} from '../../../src/cards/base/BusinessNetwork';
 
 const MOON_OPTIONS = TestingUtils.setCustomGameOptions({moonExpansion: true});
 
@@ -23,18 +21,7 @@ describe('EarthEmbassy', () => {
   });
 
   it('play', () => {
-    const tags: Array<Tags> = [Tags.EARTH, Tags.MOON, Tags.MOON];
-    const fakeCard: IProjectCard = {
-      cost: 0,
-      cardType: CardType.AUTOMATED,
-      name: CardName.ZEPPELINS,
-      tags: tags,
-      metadata: {} as ICardMetadata,
-      canPlay: () => true,
-      play: () => undefined,
-      getVictoryPoints: () => 0,
-      resourceCount: 0,
-    };
+    const fakeCard = TestingUtils.fakeCard({tags: [Tags.EARTH, Tags.MOON, Tags.MOON]});
 
     player.playedCards = [fakeCard];
     expect(player.getTagCount(Tags.EARTH, 'raw')).eq(1);
@@ -45,6 +32,15 @@ describe('EarthEmbassy', () => {
     player.playedCards.push(earthEmbassy);
     expect(player.getTagCount(Tags.EARTH, 'raw')).eq(2);
     expect(player.getTagCount(Tags.EARTH, 'default')).eq(5);
+  });
+
+  it('Works for Luna Governor', () => {
+    // Luna Governor requires 3 earth tags.
+    const lunaGovernor = new LunaGovernor();
+    // Earth Embassy has an earth tag and a moon tag.
+    // Business Contacts has an earth tag.
+    player.playedCards.push(earthEmbassy, new BusinessNetwork());
+    expect(player.canPlayIgnoringCost(lunaGovernor)).is.true;
   });
 });
 

--- a/tests/cards/pathfinders/HabitatMarte.spec.ts
+++ b/tests/cards/pathfinders/HabitatMarte.spec.ts
@@ -7,6 +7,7 @@ import {TestingUtils} from '../../TestingUtils';
 import {Tags} from '../../../src/common/cards/Tags';
 import {ValleyTrust} from '../../../src/cards/prelude/ValleyTrust';
 import {OlympusConference} from '../../../src/cards/base/OlympusConference';
+import {InterstellarColonyShip} from '../../../src/cards/base/InterstellarColonyShip';
 
 describe('HabitatMarte', () => {
   let card: HabitatMarte;
@@ -26,7 +27,7 @@ describe('HabitatMarte', () => {
   });
 
   it('card cost', () => {
-    player.playedCards.push(new ValleyTrust()); // -2 per science tag
+    player.playedCards.push(new ValleyTrust()); // -2 per science tag (This is hilarious because Valley Trust is actually a corp card.)
     player.corporationCard = undefined;
     expect(player.getCardCost(TestingUtils.fakeCard({cost: 10, tags: [Tags.MARS]}))).eq(10);
     expect(player.getCardCost(TestingUtils.fakeCard({cost: 10, tags: [Tags.SCIENCE]}))).eq(8);
@@ -36,6 +37,35 @@ describe('HabitatMarte', () => {
     expect(player.getCardCost(TestingUtils.fakeCard({cost: 10, tags: [Tags.MARS]}))).eq(8);
     expect(player.getCardCost(TestingUtils.fakeCard({cost: 10, tags: [Tags.SCIENCE]}))).eq(8);
     expect(player.getCardCost(TestingUtils.fakeCard({cost: 10, tags: [Tags.MARS, Tags.MARS]}))).eq(6);
+  });
+
+  it('card requirements', () => {
+    player.corporationCard = undefined;
+    const fourScienceTags = TestingUtils.fakeCard({tags: [Tags.SCIENCE, Tags.SCIENCE, Tags.SCIENCE, Tags.SCIENCE]});
+    const oneMarsTag = TestingUtils.fakeCard({tags: [Tags.MARS]});
+    const fiveMarsTags = TestingUtils.fakeCard({tags: [Tags.MARS, Tags.MARS, Tags.MARS, Tags.MARS, Tags.MARS]});
+
+    // Requires five science tags
+    const interstellar = new InterstellarColonyShip();
+    player.playedCards.push(fourScienceTags);
+    player.megaCredits = interstellar.cost;
+
+    expect(player.canPlay(interstellar)).is.false;
+
+    player.playedCards.push(oneMarsTag);
+
+    expect(player.canPlay(interstellar)).is.false;
+
+    player.corporationCard = card;
+    expect(player.canPlay(interstellar)).is.true;
+
+    player.playedCards = [fiveMarsTags];
+
+    expect(player.canPlay(interstellar)).is.true;
+
+    player.corporationCard = undefined;
+
+    expect(player.canPlay(interstellar)).is.false;
   });
 
   it('Olympus Conference', () => {


### PR DESCRIPTION
Besides probably reducing computation time, this also fixes an edge case
with fan expansion cards that implement tag substitutions.

This will not fix an edge case that doesn't exist yet, where a card
requires a Moon and 2 Earth tags, and the player has played Earth Embassy.