### PR TITLE
Fix how colonies render resources.

### DIFF
--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -1011,6 +1011,11 @@ input[type="radio"]:checked + .filterDiv::after {
     text-align: center;
 }
 
+// TODO(kberg): move money, above to megacredits since that's how it's listed as a resource.
+.megacredits {
+    &:extend(.money);
+}
+
 .steel {
     background-image: url(./assets/resources/steel.png);
 }
@@ -1022,6 +1027,11 @@ input[type="radio"]:checked + .filterDiv::after {
 .plant {
     background-image: url(./assets/resources/plant.png);
 }
+// TODO(kberg): move plant, above to plants since that's how it's listed as a resource.
+.plants {
+    &:extend(.plant);
+}
+
 .energy {
     background-image: url(./assets/resources/power.png);
 }


### PR DESCRIPTION
Ideally let's align the resource enums with the css. "money" and "plant" don't actually match.

![image](https://user-images.githubusercontent.com/413481/162070693-e41edfd0-3f74-41d7-b017-26796f0d7dde.png)

![image](https://user-images.githubusercontent.com/413481/162070633-1ffbdbc3-9120-4a36-b4bc-874f313d4305.png)
