### PR TITLE
Remove Odyssey from the manifest.

### DIFF
--- a/src/cards/pathfinders/PathfindersCardManifest.ts
+++ b/src/cards/pathfinders/PathfindersCardManifest.ts
@@ -64,7 +64,7 @@ import {MindSetMars} from './MindSetMars';
 import {MuseumofEarlyColonisation} from './MuseumofEarlyColonisation';
 import {NewVenice} from './NewVenice';
 import {NobelLabs} from './NobelLabs';
-import {Odyssey} from './Odyssey';
+// import {Odyssey} from './Odyssey';
 import {OrbitalLaboratories} from './OrbitalLaboratories';
 import {OumuamuaTypeObjectSurvey} from './OumuamuaTypeObjectSurvey';
 import {OzoneGenerators} from './OzoneGenerators';
@@ -201,7 +201,7 @@ export const PATHFINDERS_CARD_MANIFEST = new CardManifest({
     {cardName: CardName.AURORAI, Factory: Aurorai},
     {cardName: CardName.COLLEGIUM_COPERNICUS, Factory: CollegiumCopernicus},
     {cardName: CardName.ROBIN_HAULINGS, Factory: RobinHaulings, compatibility: GameModule.Venus},
-    {cardName: CardName.ODYSSEY, Factory: Odyssey},
+    // {cardName: CardName.ODYSSEY, Factory: Odyssey},
     // {cardName: CardName.GAGARIN_MOBILE_BASE, Factory: GagarinMobileBase},
     // {cardName: CardName.MARS_FRONTIER_ALLIANCE, Factory: MarsFrontierAlliance},
     {cardName: CardName.MIND_SET_MARS, Factory: MindSetMars, compatibility: GameModule.Turmoil},


### PR DESCRIPTION
Hopefully it'll come back, but for now, it'll be removed from play. For those
few games that might be using it, it'll break it for the short-term. Sigh.