### PR TITLE
Proxy cards should not trigger onCardPlayed.

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1612,6 +1612,9 @@ export class Player {
   }
 
   public onCardPlayed(card: IProjectCard) {
+    if (card.cardType === CardType.PROXY) {
+      return;
+    }
     for (const playedCard of this.playedCards) {
       if (playedCard.onCardPlayed !== undefined) {
         const actionFromPlayedCard: OrOptions | void = playedCard.onCardPlayed(this, card);

--- a/tests/cards/base/OlympusConference.spec.ts
+++ b/tests/cards/base/OlympusConference.spec.ts
@@ -3,7 +3,7 @@ import {Bushes} from '../../../src/cards/base/Bushes';
 import {MarsUniversity} from '../../../src/cards/base/MarsUniversity';
 import {OlympusConference} from '../../../src/cards/base/OlympusConference';
 import {Research} from '../../../src/cards/base/Research';
-import {ScienceTagCard} from '../../../src/cards/community/ScienceTagCard';
+import {AdaptationTechnology} from '../../../src//cards/base/AdaptationTechnology';
 import {DeferredActionsQueue} from '../../../src/deferredActions/DeferredActionsQueue';
 import {Game} from '../../../src/Game';
 import {OrOptions} from '../../../src/inputs/OrOptions';
@@ -75,7 +75,7 @@ describe('OlympusConference', function() {
 
   it('Triggers before Mars University', function() {
     const marsUniversity = new MarsUniversity();
-    const scienceTagCard = new ScienceTagCard();
+    const scienceTagCard = new AdaptationTechnology();
 
     // Olypus Conference played before Mars University
     player.playedCards.push(card);

--- a/tests/cards/community/Leavitt.spec.ts
+++ b/tests/cards/community/Leavitt.spec.ts
@@ -1,0 +1,59 @@
+import {expect} from 'chai';
+import {Leavitt} from '../../../src/cards/community/Leavitt';
+import {Vitor} from '../../../src/cards/prelude/Vitor';
+import {Game} from '../../../src/Game';
+import {Player} from '../../../src/Player';
+import {TestPlayers} from '../../TestPlayers';
+// import {TestingUtils} from '../../TestingUtils';
+import {Tags} from '../../../src/common/cards/Tags';
+
+describe('Leavitt', function() {
+  let leavitt: Leavitt;
+  let player: Player;
+  let player2: Player;
+  let game: Game;
+
+  beforeEach(function() {
+    leavitt = new Leavitt();
+    player = TestPlayers.BLUE.newPlayer();
+    player2 = TestPlayers.RED.newPlayer();
+    game = Game.newInstance('foobar', [player, player2], player);
+    game.gameOptions.coloniesExtension = true;
+    game.colonies.push(leavitt);
+  });
+
+  it('Should build', function() {
+    expect(player.getTagCount(Tags.SCIENCE)).to.eq(0);
+    leavitt.addColony(player);
+    expect(player.getTagCount(Tags.SCIENCE)).to.eq(1);
+    leavitt.addColony(player);
+    expect(player.getTagCount(Tags.SCIENCE)).to.eq(2);
+  });
+
+  // TODO(kberg): add trade and trade bonus tests.
+  // it('Should trade', function() {
+  //   leavitt.trade(player);
+  //   expect(player.titanium).to.eq(1);
+  //   expect(player2.titanium).to.eq(0);
+  // });
+
+  // it('Should give trade bonus', function() {
+  //   leavitt.addColony(player);
+
+  //   leavitt.trade(player2);
+  //   TestingUtils.runAllActions(game);
+
+  //   expect(player.titanium).to.eq(4);
+  //   expect(player2.titanium).to.eq(1);
+  // });
+
+  it('Leavitt is compatible with Vitor', () => {
+    // This test verifies that a regression doesn't reoccur.
+    // Merely completing these is sufficient because
+    // it doesn't throw an Error.
+    player.corporationCard = new Vitor();
+    expect(player.getTagCount(Tags.SCIENCE)).to.eq(0);
+    leavitt.addColony(player);
+    expect(player.getTagCount(Tags.SCIENCE)).to.eq(1);
+  });
+});


### PR DESCRIPTION
This is an issue with Leavitt and Vitor compatibility. If a player plays
Vitor, and then puts a colony on Leavitt, it calls onCardPlayed, which
calls Vitor's onCardPlayed, which relies on card.metadata. However the
proxy card's metadata throws an error.

This bug arose when centralizing VP management.