### PR TITLE
Fix SelectProductionToLose parsing for Units

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1116,7 +1116,7 @@ export class Player {
       if (!Units.keys.every((k) => units[k] >= 0)) {
         throw new Error('All units must be positive');
       }
-      if (!this.hasUnits(units)) {
+      if (!this.canAdjustProduction(Units.negative(units))) {
         throw new Error('You do not have those units');
       }
       pi.cb(units);

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1008,6 +1008,18 @@ export class Player {
     }
   }
 
+  private parseUnitsJSON(json: string): Units {
+    try {
+      const units: unknown = JSON.parse(json);
+      if (!Units.isUnits(units)) {
+        throw new Error('not a units object');
+      }
+
+      return units;
+    } catch (err) {
+      throw new Error('Unable to parse Units input ' + err);
+    }
+  }
   protected runInput(input: InputResponse, pi: PlayerInput): void {
     if (pi instanceof AndOptions) {
       this.checkInputLength(input, pi.options.length);
@@ -1099,8 +1111,14 @@ export class Player {
     } else if (pi instanceof SelectHowToPay) {
       this.deferInputCb(pi.process(input, this));
     } else if (pi instanceof SelectProductionToLose) {
-      // TODO(kberg): I'm sure there's some input validation required.
-      const units: Units = JSON.parse(input[0][0]);
+      this.checkInputLength(input, 1, 1);
+      const units: Units = this.parseUnitsJSON(input[0][0]);
+      if (!Units.keys.every((k) => units[k] >= 0)) {
+        throw new Error('All units must be positive');
+      }
+      if (!this.hasUnits(units)) {
+        throw new Error('You do not have those units');
+      }
       pi.cb(units);
     } else if (pi instanceof ShiftAresGlobalParameters) {
       // TODO(kberg): I'm sure there's some input validation required.

--- a/src/common/Units.ts
+++ b/src/common/Units.ts
@@ -43,6 +43,14 @@ export namespace Units {
     },
   };
 
+  export const keys = Object.keys(EMPTY) as (keyof Units)[];
+
+  export function isUnits(arg: any): arg is Units {
+    if (typeof arg !== 'object') return false;
+    return keys.every(key =>
+      typeof arg[key] === 'number' && !isNaN(arg[key]));
+  }
+
   // Converts partial units to a full Units, allowing code to use a Units stricture,
   // reducing the need to check for undefined everywhere.
   export function of(partialUnits: Partial<Units>): Units {

--- a/src/common/Units.ts
+++ b/src/common/Units.ts
@@ -47,7 +47,7 @@ export namespace Units {
 
   export function isUnits(arg: any): arg is Units {
     if (typeof arg !== 'object') return false;
-    return keys.every(key =>
+    return keys.every((key) =>
       typeof arg[key] === 'number' && !isNaN(arg[key]));
   }
 

--- a/src/deferredActions/SelectProductionToLoseDeferred.ts
+++ b/src/deferredActions/SelectProductionToLoseDeferred.ts
@@ -18,6 +18,10 @@ export class SelectProductionToLoseDeferred extends DeferredAction {
       this.unitsToLose,
       this.player,
       (production: Units) => {
+        const total = Units.keys.map((key) => production[key]).reduce((a, c) => a + c, 0);
+        if (total !== this.unitsToLose) {
+          throw new Error(`Expected ${this.unitsToLose} units of production, got ${total}`);
+        }
         this.player.adjustProduction(Units.negative(production), {log: true});
         return undefined;
       },

--- a/tests/deferredActions/SelectProductionToLoseDeferred.spec.ts
+++ b/tests/deferredActions/SelectProductionToLoseDeferred.spec.ts
@@ -21,6 +21,29 @@ describe('SelectProductionToLose', function() {
     expect(player.getProductionForTest()).deep.eq(Units.of({megacredits: -1}));
   });
 
+  it('prevents taking too much production', function() {
+    player.setProductionForTest({megacredits: 5, heat: 10});
+    player.megaCredits = 100;
+    player.heat = 100;
+    expect(() => cb({megacredits: 12}, 12)).to.throw();
+    expect(() => cb({heat: 12, megacredits: 8}, 20)).to.throw();
+  });
+
+  it('prevents negative production', function() {
+    player.setProductionForTest({megacredits: 10, heat: 10});
+    player.megaCredits = 100;
+    player.heat = 100;
+    expect(() => cb({megacredits: 15, heat: 5, steel: -10}, 10)).to.throw();
+  });
+
+  it('allows taking enough production', function() {
+    player.setProductionForTest({megacredits: 10, heat: 10});
+    cb({megacredits: 5}, 5);
+    cb({megacredits: 3, heat: 2}, 5);
+    cb({megacredits: 2, heat: 8}, 10);
+    expect(player.getProductionForTest()).deep.eq(Units.of({}));
+  });
+
   function cb(units: Partial<Units>, count: number) {
     const deferred = new SelectProductionToLoseDeferred(player, count);
     const sptl = deferred.execute();

--- a/tests/deferredActions/SelectProductionToLoseDeferred.spec.ts
+++ b/tests/deferredActions/SelectProductionToLoseDeferred.spec.ts
@@ -1,0 +1,32 @@
+import {expect} from 'chai';
+
+import {SelectProductionToLoseDeferred} from '../../src/deferredActions/SelectProductionToLoseDeferred';
+import {Units} from '../../src/common/Units';
+import {TestPlayer} from '../TestPlayer';
+import {Game} from '../../src/Game';
+import {newTestGame, getTestPlayer} from '../TestGame';
+
+describe('SelectProductionToLose', function() {
+  let game: Game;
+  let player: TestPlayer;
+
+  beforeEach(() => {
+    game = newTestGame(1);
+    player = getTestPlayer(game, 0);
+  });
+
+  it('sanity test', function() {
+    expect(() => cb({}, 1)).to.throw();
+    cb({megacredits: 1}, 1);
+    expect(player.getProductionForTest()).deep.eq(Units.of({megacredits: -1}));
+  });
+
+  function cb(units: Partial<Units>, count: number) {
+    const deferred = new SelectProductionToLoseDeferred(player, count);
+    const sptl = deferred.execute();
+
+    const input = JSON.stringify(Units.of(units));
+    player.runInput([[input]], sptl);
+  }
+});
+


### PR DESCRIPTION
This PR adds validation so that users are not able to specify negative or non-numeric unit amounts. Before this validation, players could make their production massive by "losing" a negative amount of production.