### PR TITLE
Fix HowToPay bugs in processInput

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -990,7 +990,7 @@ export class Player {
     if (!u) return false;
     const h = u as {[key in keyof HowToPay]?: any};
     return HowToPay.keys.every((key) =>
-      h.hasOwnProperty(key) && typeof h[key] === 'number' && h[key] >= 0);
+      h.hasOwnProperty(key) && typeof h[key] === 'number' && !isNaN(h[key]));
   }
 
   public parseHowToPayJSON(json: string): HowToPay {
@@ -1855,7 +1855,7 @@ export class Player {
       0 <= howToPay[key] && howToPay[key] <= maxPayable[key]);
   }
 
-  private payingAmount(howToPay: HowToPay, options?: Partial<HowToPay.Options>): number {
+  public payingAmount(howToPay: HowToPay, options?: Partial<HowToPay.Options>): number {
     const mult: {[key in keyof HowToPay]: number} = {
       megaCredits: 1,
       steel: this.getSteelValue(),

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -985,22 +985,19 @@ export class Player {
     }
   }
 
+  public isHowToPay(u: unknown): u is HowToPay {
+    if (typeof u !== 'object') return false;
+    if (!u) return false;
+    const h = u as {[key in keyof HowToPay]?: any};
+    return HowToPay.keys.every((key) =>
+      h.hasOwnProperty(key) && typeof h[key] === 'number' && h[key] >= 0);
+  }
+
   public parseHowToPayJSON(json: string): HowToPay {
-    const defaults: HowToPay = {
-      steel: 0,
-      heat: 0,
-      titanium: 0,
-      megaCredits: 0,
-      microbes: 0,
-      floaters: 0,
-      science: 0,
-      seeds: 0,
-      data: 0,
-    };
     try {
-      const howToPay: HowToPay = JSON.parse(json);
-      if (Object.keys(howToPay).every((key) => key in defaults) === false) {
-        throw new Error('Input contains unauthorized keys');
+      const howToPay: unknown = JSON.parse(json);
+      if (!this.isHowToPay(howToPay)) {
+        throw new Error('does not match interface');
       }
       return howToPay;
     } catch (err) {
@@ -1064,10 +1061,12 @@ export class Player {
     } else if (pi instanceof SelectHowToPayForProjectCard) {
       this.checkInputLength(input, 1, 2);
       const cardName = input[0][0];
-      const _data = PlayerInput.getCard(pi.cards, cardName);
-      const foundCard: IProjectCard = _data.card;
+      const data = PlayerInput.getCard(pi.cards, cardName);
+      const foundCard: IProjectCard = data.card;
       const howToPay: HowToPay = this.parseHowToPayJSON(input[0][1]);
-      const reserveUnits = pi.reserveUnits[_data.idx];
+      const reserveUnits = pi.reserveUnits[data.idx];
+      // These are not used for safety but do help give a better error message
+      // to the user
       if (reserveUnits.steel + howToPay.steel > this.steel) {
         throw new Error(`${reserveUnits.steel} units of steel must be reserved for ${cardName}`);
       }
@@ -1421,66 +1420,40 @@ export class Player {
     );
   }
 
+  private howToPayOptionsForCard(selectedCard: IProjectCard): HowToPay.Options {
+    return {
+      steel: this.canUseSteel(selectedCard),
+      titanium: this.canUseTitanium(selectedCard),
+      seeds: this.canUseSeeds(selectedCard),
+      floaters: this.canUseFloaters(selectedCard),
+      microbes: this.canUseMicrobes(selectedCard),
+      science: this.canUseScience(selectedCard),
+      data: this.canUseData(selectedCard),
+    };
+  }
+
   public checkHowToPayAndPlayCard(selectedCard: IProjectCard, howToPay: HowToPay) {
     const cardCost: number = this.getCardCost(selectedCard);
-    let totalToPay: number = 0;
 
-    const canUseSteel = this.canUseSteel(selectedCard);
-    const canUseTitanium = this.canUseTitanium(selectedCard);
+    const reserved = MoonExpansion.adjustedReserveCosts(this, selectedCard);
 
-    if (canUseSteel && howToPay.steel > 0) {
-      if (howToPay.steel > this.steel) {
-        throw new Error('Do not have enough steel');
+    if (!this.canSpend(howToPay, reserved)) {
+      throw new Error('You do not have that many resources to spend');
+    }
+
+    if (selectedCard.name === CardName.STRATOSPHERIC_BIRDS && howToPay.floaters === this.getFloatersCanSpend()) {
+      const cardsWithFloater = this.getCardsWithResources(CardResource.FLOATER);
+      if (cardsWithFloater.length === 1) {
+        throw new Error('Cannot spend all floaters to play Stratospheric Birds');
       }
-      totalToPay += howToPay.steel * this.getSteelValue();
     }
 
-    if (canUseTitanium && howToPay.titanium > 0) {
-      if (howToPay.titanium > this.titanium) {
-        throw new Error('Do not have enough titanium');
-      }
-      totalToPay += howToPay.titanium * this.getTitaniumValue();
-    }
-
-    if (this.canUseHeatAsMegaCredits && howToPay.heat !== undefined) {
-      totalToPay += howToPay.heat;
-    }
-
-    if (howToPay.microbes !== undefined) {
-      totalToPay += howToPay.microbes * DEFAULT_MICROBES_VALUE;
-    }
-
-    if (howToPay.floaters !== undefined && howToPay.floaters > 0) {
-      if (selectedCard.name === CardName.STRATOSPHERIC_BIRDS && howToPay.floaters === this.getFloatersCanSpend()) {
-        const cardsWithFloater = this.getCardsWithResources(CardResource.FLOATER);
-        if (cardsWithFloater.length === 1) {
-          throw new Error('Cannot spend all floaters to play Stratospheric Birds');
-        }
-      }
-      totalToPay += howToPay.floaters * DEFAULT_FLOATERS_VALUE;
-    }
-
-    if (howToPay.science ?? 0 > 0) {
-      totalToPay += howToPay.science;
-    }
-
-    if (howToPay.seeds ?? 0 > 0) {
-      totalToPay += howToPay.seeds * constants.SEED_VALUE;
-    }
-
-    if (howToPay.megaCredits > this.megaCredits) {
-      throw new Error('Do not have enough M€');
-    }
-
-    if (howToPay.science !== undefined) {
-      totalToPay += howToPay.science;
-    }
-
-    totalToPay += howToPay.megaCredits;
+    const totalToPay = this.payingAmount(howToPay, this.howToPayOptionsForCard(selectedCard));
 
     if (totalToPay < cardCost) {
       throw new Error('Did not spend enough to pay for card');
     }
+
     return this.playCard(selectedCard, howToPay);
   }
 
@@ -1518,35 +1491,39 @@ export class Player {
     return this.corporationCard?.name === CardName.AURORAI ? this.corporationCard.resourceCount : 0;
   }
 
+  public pay(howToPay: HowToPay) {
+    this.deductResource(Resources.STEEL, howToPay.steel);
+    this.deductResource(Resources.TITANIUM, howToPay.titanium);
+    this.deductResource(Resources.MEGACREDITS, howToPay.megaCredits);
+    this.deductResource(Resources.HEAT, howToPay.heat);
+
+    for (const playedCard of this.playedCards) {
+      if (playedCard.name === CardName.PSYCHROPHILES) {
+        this.removeResourceFrom(playedCard, howToPay.microbes);
+      }
+
+      if (playedCard.name === CardName.DIRIGIBLES) {
+        this.removeResourceFrom(playedCard, howToPay.floaters);
+      }
+
+      if (playedCard.name === CardName.LUNA_ARCHIVES) {
+        this.removeResourceFrom(playedCard, howToPay.science);
+      }
+    }
+
+    if (this.corporationCard?.name === CardName.SOYLENT_SEEDLING_SYSTEMS) {
+      this.removeResourceFrom(this.corporationCard, howToPay.seeds);
+    }
+
+    if (this.corporationCard?.name === CardName.AURORAI) {
+      this.removeResourceFrom(this.corporationCard, howToPay.data);
+    }
+  }
+
   public playCard(selectedCard: IProjectCard, howToPay?: HowToPay, addToPlayedCards: boolean = true): undefined {
     // Pay for card
     if (howToPay !== undefined) {
-      this.deductResource(Resources.STEEL, howToPay.steel);
-      this.deductResource(Resources.TITANIUM, howToPay.titanium);
-      this.deductResource(Resources.MEGACREDITS, howToPay.megaCredits);
-      this.deductResource(Resources.HEAT, howToPay.heat);
-
-      for (const playedCard of this.playedCards) {
-        if (playedCard.name === CardName.PSYCHROPHILES) {
-          this.removeResourceFrom(playedCard, howToPay.microbes);
-        }
-
-        if (playedCard.name === CardName.DIRIGIBLES) {
-          this.removeResourceFrom(playedCard, howToPay.floaters);
-        }
-
-        if (playedCard.name === CardName.LUNA_ARCHIVES) {
-          this.removeResourceFrom(playedCard, howToPay.science);
-        }
-
-        if (this.corporationCard?.name === CardName.SOYLENT_SEEDLING_SYSTEMS) {
-          this.removeResourceFrom(this.corporationCard, howToPay.seeds);
-        }
-
-        if (this.corporationCard?.name === CardName.AURORAI) {
-          this.removeResourceFrom(this.corporationCard, howToPay.data);
-        }
-      }
+      this.pay(howToPay);
     }
 
     // Activate some colonies
@@ -1836,13 +1813,7 @@ export class Player {
     const canAfford = this.canAfford(
       baseCost,
       {
-        steel: this.canUseSteel(card),
-        titanium: this.canUseTitanium(card),
-        floaters: this.canUseFloaters(card),
-        microbes: this.canUseMicrobes(card),
-        science: this.canUseScience(card),
-        seeds: this.canUseSeeds(card),
-        data: this.canUseData(card),
+        ...this.howToPayOptionsForCard(card),
         reserveUnits: MoonExpansion.adjustedReserveCosts(this, card),
         tr: card.tr,
       });
@@ -1863,46 +1834,81 @@ export class Player {
     return card.canPlay(this);
   }
 
+  private maxSpendable(reserveUnits: Units = Units.EMPTY): HowToPay {
+    return {
+      megaCredits: this.megaCredits - reserveUnits.megacredits,
+      steel: this.steel - reserveUnits.steel,
+      titanium: this.titanium - reserveUnits.titanium,
+      heat: this.heat - reserveUnits.heat,
+      floaters: this.getFloatersCanSpend(),
+      microbes: this.getMicrobesCanSpend(),
+      science: this.getSpendableScienceResources(),
+      seeds: this.getSpendableSeedResources(),
+      data: this.getSpendableData(),
+    };
+  }
+
+  public canSpend(howToPay: HowToPay, reserveUnits?: Units): boolean {
+    const maxPayable = this.maxSpendable(reserveUnits);
+
+    return HowToPay.keys.every((key) =>
+      0 <= howToPay[key] && howToPay[key] <= maxPayable[key]);
+  }
+
+  private payingAmount(howToPay: HowToPay, options?: Partial<HowToPay.Options>): number {
+    const mult: {[key in keyof HowToPay]: number} = {
+      megaCredits: 1,
+      steel: this.getSteelValue(),
+      titanium: this.getTitaniumValue(),
+      heat: 1,
+      microbes: DEFAULT_MICROBES_VALUE,
+      floaters: DEFAULT_FLOATERS_VALUE,
+      science: 1,
+      seeds: constants.SEED_VALUE,
+      data: constants.DATA_VALUE,
+    };
+
+    const usable: {[key in keyof HowToPay]: boolean} = {
+      megaCredits: true,
+      steel: options?.steel ?? false,
+      titanium: options?.titanium ?? false,
+      heat: this.canUseHeatAsMegaCredits,
+      microbes: options?.microbes ?? false,
+      floaters: options?.floaters ?? false,
+      science: options?.science ?? false,
+      seeds: options?.seeds ?? false,
+      data: options?.data ?? false,
+    };
+
+    let totalToPay = 0;
+    for (const key of HowToPay.keys) {
+      if (usable[key]) totalToPay += howToPay[key] * mult[key];
+    }
+
+    return totalToPay;
+  }
+
   // Checks if the player can afford to pay `cost` mc (possibly replaceable with steel, titanium etc.)
   // and additionally pay the reserveUnits (no replaces here)
-  public canAfford(cost: number, options?: {
-    steel?: boolean,
-    titanium?: boolean,
-    floaters?: boolean,
-    microbes?: boolean,
-    science?: boolean,
-    seeds?: boolean,
-    data?: boolean,
-    reserveUnits?: Units,
-    tr?: TRSource,
-  }) {
+  public canAfford(cost: number, options?: CanAffordOptions) {
     const reserveUnits = options?.reserveUnits ?? Units.EMPTY;
     if (!this.hasUnits(reserveUnits)) {
       return false;
     }
 
+    const maxPayable = this.maxSpendable(reserveUnits);
+
     const redsCost = TurmoilHandler.computeTerraformRatingBump(this, options?.tr) * REDS_RULING_POLICY_COST;
-
-    let availableMegacredits = this.megaCredits;
-    if (this.canUseHeatAsMegaCredits) {
-      availableMegacredits += this.heat;
-      availableMegacredits -= reserveUnits.heat;
-    }
-    availableMegacredits -= reserveUnits.megacredits;
-    availableMegacredits -= redsCost;
-
-    if (availableMegacredits < 0) {
-      return false;
+    if (redsCost > 0) {
+      const usableForRedsCost = this.payingAmount(maxPayable, {});
+      if (usableForRedsCost < redsCost) {
+        return false;
+      }
     }
 
-    if (options?.steel) availableMegacredits += (this.steel - reserveUnits.steel) * this.getSteelValue();
-    if (options?.titanium) availableMegacredits += (this.titanium - reserveUnits.titanium) * this.getTitaniumValue();
-    if (options?.floaters) availableMegacredits += this.getFloatersCanSpend() * 3;
-    if (options?.microbes) availableMegacredits += this.getMicrobesCanSpend() * 2;
-    if (options?.science) availableMegacredits += this.getSpendableScienceResources();
-    if (options?.seeds) availableMegacredits += this.getSpendableSeedResources() * constants.SEED_VALUE;
-    if (options?.data) availableMegacredits += this.getSpendableData() * constants.DATA_VALUE;
-    return cost <= availableMegacredits;
+    const usable = this.payingAmount(maxPayable, options);
+
+    return cost + redsCost <= usable;
   }
 
   private getStandardProjects(): Array<StandardProjectCard> {
@@ -2418,4 +2424,9 @@ export class Player {
     const action = new SimpleDeferredAction(this, () => input, priority);
     this.game.defer(action);
   }
+}
+
+interface CanAffordOptions extends Partial<HowToPay.Options> {
+  reserveUnits?: Units,
+  tr?: TRSource,
 }

--- a/src/common/inputs/HowToPay.ts
+++ b/src/common/inputs/HowToPay.ts
@@ -11,3 +11,33 @@ export interface HowToPay {
   data: number;
 }
 
+export namespace HowToPay {
+  export const EMPTY: Readonly<HowToPay> = {
+    heat: 0, megaCredits: 0, steel: 0, titanium: 0, microbes: 0, floaters: 0, science: 0, seeds: 0, data: 0,
+  };
+  export const keys = Object.keys(EMPTY) as (keyof HowToPay)[];
+
+  export function of(x: Partial<HowToPay>): HowToPay {
+    return {
+      heat: x.heat ?? 0,
+      megaCredits: x.megaCredits ?? 0,
+      steel: x.steel ?? 0,
+      titanium: x.titanium ?? 0,
+      microbes: x.microbes ?? 0,
+      floaters: x.floaters ?? 0,
+      science: x.science ?? 0,
+      seeds: x.seeds ?? 0,
+      data: x.data ?? 0,
+    };
+  }
+
+  export interface Options {
+    steel: boolean,
+    titanium: boolean,
+    floaters: boolean,
+    microbes: boolean,
+    science: boolean,
+    seeds: boolean,
+    data: boolean,
+  }
+}

--- a/src/deferredActions/SelectHowToPayDeferred.ts
+++ b/src/deferredActions/SelectHowToPayDeferred.ts
@@ -48,16 +48,10 @@ export class SelectHowToPayDeferred extends DeferredAction {
       this.options.canUseData || false,
       this.amount,
       (howToPay: HowToPay) => {
-        this.player.deductResource(Resources.STEEL, howToPay.steel);
-        this.player.deductResource(Resources.TITANIUM, howToPay.titanium);
-        this.player.deductResource(Resources.MEGACREDITS, howToPay.megaCredits);
-        this.player.deductResource(Resources.HEAT, howToPay.heat);
-        if (howToPay.seeds > 0 && this.player.corporationCard !== undefined) {
-          this.player.removeResourceFrom(this.player.corporationCard, howToPay.seeds);
+        if (!this.player.canSpend(howToPay)) {
+          throw new Error('You do not have that many resources to spend');
         }
-        if (howToPay.data > 0 && this.player.corporationCard !== undefined) {
-          this.player.removeResourceFrom(this.player.corporationCard, howToPay.data);
-        }
+        this.player.pay(howToPay);
         this.options.afterPay?.();
         return undefined;
       },

--- a/src/deferredActions/SelectHowToPayDeferred.ts
+++ b/src/deferredActions/SelectHowToPayDeferred.ts
@@ -48,6 +48,14 @@ export class SelectHowToPayDeferred extends DeferredAction {
       this.options.canUseData || false,
       this.amount,
       (howToPay: HowToPay) => {
+        if (this.player.payingAmount(howToPay, {
+          steel: this.options.canUseSteel,
+          titanium: this.options.canUseTitanium,
+          seeds: this.options.canUseSeeds,
+          data: this.options.canUseData,
+        }) < this.amount) {
+          throw new Error('You did not spend enough resources');
+        }
         if (!this.player.canSpend(howToPay)) {
           throw new Error('You do not have that many resources to spend');
         }

--- a/src/inputs/SelectHowToPay.ts
+++ b/src/inputs/SelectHowToPay.ts
@@ -27,6 +27,9 @@ export class SelectHowToPay implements PlayerInput {
   public process(input: InputResponse, player: Player) {
     player.checkInputLength(input, 1, 1);
     const howToPay: HowToPay = player.parseHowToPayJSON(input[0][0]);
+    if (!player.canSpend(howToPay)) {
+      throw new Error('You do not have that many resources');
+    }
     return this.cb(howToPay);
   }
 }

--- a/tests/cards/promo/DirectedImpactors.spec.ts
+++ b/tests/cards/promo/DirectedImpactors.spec.ts
@@ -35,7 +35,7 @@ describe('DirectedImpactors', function() {
     card.action(player);
     expect(game.deferredActions).has.lengthOf(1);
     const selectHowToPay = game.deferredActions.peek()!.execute() as SelectHowToPay;
-    selectHowToPay.cb({steel: 0, heat: 0, titanium: 1, megaCredits: 3, microbes: 0, floaters: 0} as HowToPay);
+    selectHowToPay.cb(HowToPay.of({titanium: 1, megaCredits: 3}));
 
     expect(player.megaCredits).to.eq(0);
     expect(player.titanium).to.eq(0);
@@ -68,7 +68,7 @@ describe('DirectedImpactors', function() {
     const selectCard = action.options[1].cb();
     expect(game.deferredActions).has.lengthOf(1);
     const selectHowToPay = game.deferredActions.peek()!.execute() as SelectHowToPay;
-    selectHowToPay.cb({steel: 0, heat: 0, titanium: 1, megaCredits: 3, microbes: 0, floaters: 0} as HowToPay);
+    selectHowToPay.cb(HowToPay.of({titanium: 1, megaCredits: 3}));
 
         selectCard!.cb([card2]);
         expect(card2.resourceCount).to.eq(1);

--- a/tests/cards/venusNext/StratosphericBirds.spec.ts
+++ b/tests/cards/venusNext/StratosphericBirds.spec.ts
@@ -1,3 +1,4 @@
+import {HowToPay} from '../../../src/common/inputs/HowToPay';
 import {expect} from 'chai';
 import {IndenturedWorkers} from '../../../src/cards/base/IndenturedWorkers';
 import {ICard} from '../../../src/cards/ICard';
@@ -9,6 +10,7 @@ import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {Player} from '../../../src/Player';
 import {TestPlayers} from '../../TestPlayers';
+import {SelectHowToPayForProjectCard} from '../../../src/inputs/SelectHowToPayForProjectCard';
 
 describe('StratosphericBirds', () => {
   let card : StratosphericBirds; let player : Player; let game : Game; let deuteriumExport: DeuteriumExport;
@@ -93,16 +95,16 @@ describe('StratosphericBirds', () => {
 
     // 12 M€ + 1 Dirigibles floater: Card is playable
     player.megaCredits = 12;
-    const selectHowToPayForProjectCard = player.playProjectCard();
+    const selectHowToPayForProjectCard = player.playProjectCard() as SelectHowToPayForProjectCard;
     expect(player.canPlayIgnoringCost(card)).is.true;
 
     // Try to spend floater to pay for card: Throw an error
     expect(() => {
-      selectHowToPayForProjectCard.cb(card, {steel: 0, heat: 0, titanium: 0, megaCredits: 9, microbes: 0, floaters: 1});
+      selectHowToPayForProjectCard.cb(card, HowToPay.of({megaCredits: 9, floaters: 1}));
     }).to.throw('Cannot spend all floaters to play Stratospheric Birds');
 
     // Pay with MC only: Can play
-    selectHowToPayForProjectCard.cb(card, {steel: 0, heat: 0, titanium: 0, megaCredits: 12, microbes: 0, floaters: 0});
+    selectHowToPayForProjectCard.cb(card, HowToPay.of({megaCredits: 12}));
         game.deferredActions.pop()!.execute(); // Remove floater
         expect(dirigibles.resourceCount).to.eq(0);
   });
@@ -116,11 +118,11 @@ describe('StratosphericBirds', () => {
     (game as any).venusScaleLevel = 12;
     player.megaCredits = 3;
 
-    const selectHowToPayForCard = player.playProjectCard();
+    const selectHowToPayForCard = player.playProjectCard() as SelectHowToPayForProjectCard;
     expect(player.canPlayIgnoringCost(card)).is.true;
 
     // Spend all 3 floaters from Dirigibles to pay for the card
-    selectHowToPayForCard.cb(card, {steel: 0, heat: 0, titanium: 0, megaCredits: 3, microbes: 0, floaters: 3});
+    selectHowToPayForCard.cb(card, HowToPay.of({megaCredits: 3, floaters: 3}));
         game.deferredActions.pop()!.execute(); // Remove floater
         expect(dirigibles.resourceCount).to.eq(0);
         expect(deuteriumExport.resourceCount).to.eq(0);

--- a/tests/deferredActions/SelectHowToPayDeferred.spec.ts
+++ b/tests/deferredActions/SelectHowToPayDeferred.spec.ts
@@ -1,0 +1,67 @@
+import {expect} from 'chai';
+
+import {TestPlayer} from '../TestPlayer';
+import {Game} from '../../src/Game';
+import {newTestGame, getTestPlayer} from '../TestGame';
+import {SelectHowToPayDeferred} from '../../src/deferredActions/SelectHowToPayDeferred';
+import {HowToPay} from '../../src/common/inputs/HowToPay';
+import {SoylentSeedlingSystems} from '../../src/cards/pathfinders/SoylentSeedlingSystems';
+import {Biofuels} from '../../src/cards/prelude/Biofuels';
+import {EcologyExperts} from '../../src/cards/prelude/EcologyExperts';
+
+describe('SelectHowToPay', function() {
+  let game: Game;
+  let player: TestPlayer;
+
+  beforeEach(() => {
+    game = newTestGame(1);
+    player = getTestPlayer(game, 0);
+    player.megaCredits = 10;
+    player.steel = 10;
+  });
+
+  it('doesn\'t double-spend seeds', () => {
+    player.corporationCard = new SoylentSeedlingSystems();
+    player.playCard(new Biofuels());
+    player.playCard(new EcologyExperts());
+    player.corporationCard.resourceCount = 10;
+    cb(HowToPay.of({seeds: 1}), 1, {canUseSeeds: true});
+    expect(player.corporationCard.resourceCount).eq(9);
+  });
+
+  it('rejects partial inputs', () => {
+    expect(() => cb({megaCredits: 5}, 5, {})).to.throw;
+    expect(() => cb(HowToPay.of({megaCredits: 3}), 5, {})).to.throw;
+  });
+
+  it('rejects negative inputs', () => {
+    player.corporationCard = new SoylentSeedlingSystems();
+    player.corporationCard.resourceCount = 10;
+    expect(() => cb(HowToPay.of({megaCredits: -5, seeds: 10}), 5, {canUseSeeds: true})).to.throw;
+  });
+
+  it('rejects misoptioned inputs', () => {
+    expect(() => cb({megaCredits: 5, steel: 3}, 14, {})).to.throw;
+  });
+
+  it('allows normal inputs', () => {
+    cb(HowToPay.of({megaCredits: 5, steel: 3}), 14, {canUseSteel: true});
+    expect(player.purse()).to.include({megacredits: 5, steel: 7});
+    cb(HowToPay.of({megaCredits: 2}), 2, {});
+    expect(player.purse()).to.include({megacredits: 3});
+  });
+
+  function cb(value: any, count: number, options: SelectHowToPayDeferred.Options) {
+    const deferred = new SelectHowToPayDeferred(player, count, options);
+    const action = deferred.execute();
+
+    if (action === undefined) {
+      expect(value).deep.eq(HowToPay.of({megaCredits: count}));
+      return;
+    }
+
+    const input = JSON.stringify(value);
+    player.runInput([[input]], action);
+  }
+});
+

--- a/tests/deferredActions/SelectHowToPayDeferred.spec.ts
+++ b/tests/deferredActions/SelectHowToPayDeferred.spec.ts
@@ -20,35 +20,40 @@ describe('SelectHowToPay', function() {
     player.steel = 10;
   });
 
+  it('allows normal inputs', () => {
+    cb(HowToPay.of({megaCredits: 5, steel: 3}), 11, {canUseSteel: true});
+    expect(player.purse()).to.include({megacredits: 5, steel: 7});
+    cb(HowToPay.of({megaCredits: 2}), 2, {canUseSteel: true});
+    expect(player.purse()).to.include({megacredits: 3});
+    cb(HowToPay.of({megaCredits: 2}), 2, {});
+    expect(player.purse()).to.include({megacredits: 1});
+  });
+
   it('doesn\'t double-spend seeds', () => {
     player.corporationCard = new SoylentSeedlingSystems();
     player.playCard(new Biofuels());
     player.playCard(new EcologyExperts());
     player.corporationCard.resourceCount = 10;
-    cb(HowToPay.of({seeds: 1}), 1, {canUseSeeds: true});
+    cb(HowToPay.of({seeds: 1}), 5, {canUseSeeds: true});
     expect(player.corporationCard.resourceCount).eq(9);
   });
 
   it('rejects partial inputs', () => {
-    expect(() => cb({megaCredits: 5}, 5, {})).to.throw;
-    expect(() => cb(HowToPay.of({megaCredits: 3}), 5, {})).to.throw;
+    expect(() => cb({megaCredits: 5}, 5, {canUseSteel: true}))
+      .to.throw('Unable to parse HowToPay');
+    expect(() => cb(HowToPay.of({megaCredits: 3}), 5, {canUseSteel: true}))
+      .to.throw('You did not spend enough');
   });
 
   it('rejects negative inputs', () => {
     player.corporationCard = new SoylentSeedlingSystems();
     player.corporationCard.resourceCount = 10;
-    expect(() => cb(HowToPay.of({megaCredits: -5, seeds: 10}), 5, {canUseSeeds: true})).to.throw;
+    expect(() => cb(HowToPay.of({megaCredits: -5, seeds: 10}), 5, {canUseSeeds: true}))
+      .to.throw('You do not have that many');
   });
 
   it('rejects misoptioned inputs', () => {
     expect(() => cb({megaCredits: 5, steel: 3}, 14, {})).to.throw;
-  });
-
-  it('allows normal inputs', () => {
-    cb(HowToPay.of({megaCredits: 5, steel: 3}), 14, {canUseSteel: true});
-    expect(player.purse()).to.include({megacredits: 5, steel: 7});
-    cb(HowToPay.of({megaCredits: 2}), 2, {});
-    expect(player.purse()).to.include({megacredits: 3});
   });
 
   function cb(value: any, count: number, options: SelectHowToPayDeferred.Options) {

--- a/tests/inputs/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/inputs/SelectHowToPayForProjectCard.spec.ts
@@ -1,0 +1,53 @@
+import {expect} from 'chai';
+
+import {TestPlayer} from '../TestPlayer';
+import {Game} from '../../src/Game';
+import {newTestGame, getTestPlayer} from '../TestGame';
+import {HowToPay} from '../../src/common/inputs/HowToPay';
+import {SelectHowToPayForProjectCard} from '../../src/inputs/SelectHowToPayForProjectCard';
+import {IProjectCard} from '../../src/cards/IProjectCard';
+import {Soletta} from '../../src/cards/base/Soletta';
+import {EarthCatapult} from '../../src/cards/base/EarthCatapult';
+import {CardName} from '../../src/common/cards/CardName';
+
+describe('SelectHowToPayForProjectCard', function() {
+  let game: Game;
+  let player: TestPlayer;
+  const cards = [new Soletta(), new EarthCatapult()];
+
+  beforeEach(() => {
+    game = newTestGame(1);
+    player = getTestPlayer(game, 0);
+    player.megaCredits = 100;
+    player.titanium = 10;
+  });
+
+  it('allows normal inputs', () => {
+    cb(CardName.SOLETTA, HowToPay.of({megaCredits: 23, titanium: 4}), cards);
+    expect(player.purse()).to.include({megacredits: 77, titanium: 6});
+    cb(CardName.EARTH_CATAPULT, HowToPay.of({megaCredits: 23}), cards);
+    expect(player.purse()).to.include({megacredits: 54, titanium: 6});
+  });
+
+  it('rejects partial inputs', () => {
+    expect(() => cb(CardName.SOLETTA, {megaCredits: 35}, cards)).to.throw('Unable to parse HowToPay');
+  });
+
+  it('rejects unselectable cards', () => {
+    expect(() => cb(CardName.COMET, HowToPay.of({megaCredits: 35}), cards)).to.throw('not found');
+  });
+
+  it('rejects negative inputs', () => {
+    expect(() => cb(CardName.SOLETTA, HowToPay.of({megaCredits: 50, titanium: -5}), cards))
+      .to.throw('Unable to parse HowToPay');
+  });
+
+  function cb(name: string, value: any, cards: IProjectCard[]) {
+    const action = new SelectHowToPayForProjectCard(player, cards,
+      (...args) => player.checkHowToPayAndPlayCard(...args));
+
+    const input = JSON.stringify(value);
+    player.runInput([[name, input]], action);
+  }
+});
+

--- a/tests/inputs/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/inputs/SelectHowToPayForProjectCard.spec.ts
@@ -39,7 +39,18 @@ describe('SelectHowToPayForProjectCard', function() {
 
   it('rejects negative inputs', () => {
     expect(() => cb(CardName.SOLETTA, HowToPay.of({megaCredits: 50, titanium: -5}), cards))
-      .to.throw('Unable to parse HowToPay');
+      .to.throw('You do not have that many');
+  });
+
+  it('rejects overspending', () => {
+    player.megaCredits = 10;
+    expect(() => cb(CardName.SOLETTA, HowToPay.of({megaCredits: 35}), cards))
+      .to.throw('You do not have that many');
+  });
+
+  it('rejects underspending', () => {
+    expect(() => cb(CardName.SOLETTA, HowToPay.of({megaCredits: 20}), cards))
+      .to.throw('Did not spend enough');
   });
 
   function cb(name: string, value: any, cards: IProjectCard[]) {


### PR DESCRIPTION
This PR validates the amounts specified in HowToPay so that people aren't able to generate free resources by paying negative amounts. 

It shares more of the computation of how much to pay between finding valid cards to play and actually playing the card.