### PR TITLE
bump sqlite version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "mnemonist": "^0.38.1",
         "pg": "^8.2.1",
         "spectre.css": "^0.5.8",
-        "sqlite3": "^5.0.3",
+        "sqlite3": "^5.0.4",
         "vti": "^0.1.3",
         "vue": "2.6.10",
         "vue-template-compiler": "2.6.10",
@@ -7138,9 +7138,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "node_modules/sqlite3": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.3.tgz",
-      "integrity": "sha512-/cDwes7XtTOtKH5zYeJSuiavuaJ6jXxPjebw9lDFxBAwR/DvP0tnJ5MPZQ3zpnNzJBa1G6mPTpB+5O1T+AoSdQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.4.tgz",
+      "integrity": "sha512-ATvAe7JutFv/d+KTbLS58KsKn/t1raL/WGn2qZfZxwsrL/oGSP+0OlbQ2tX5jISvyu6/7JuKze3WkaiP1JAH6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -14287,9 +14287,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sqlite3": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.3.tgz",
-      "integrity": "sha512-/cDwes7XtTOtKH5zYeJSuiavuaJ6jXxPjebw9lDFxBAwR/DvP0tnJ5MPZQ3zpnNzJBa1G6mPTpB+5O1T+AoSdQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.4.tgz",
+      "integrity": "sha512-ATvAe7JutFv/d+KTbLS58KsKn/t1raL/WGn2qZfZxwsrL/oGSP+0OlbQ2tX5jISvyu6/7JuKze3WkaiP1JAH6A==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mnemonist": "^0.38.1",
     "pg": "^8.2.1",
     "spectre.css": "^0.5.8",
-    "sqlite3": "^5.0.3",
+    "sqlite3": "^5.0.4",
     "vti": "^0.1.3",
     "vue": "2.6.10",
     "vue-template-compiler": "2.6.10",


### PR DESCRIPTION
Docker image is failing to start after the latest sqlite update. This is alrady [fixed upstream](https://github.com/TryGhost/node-sqlite3/issues/1576). This PR updates to the later version of sqlite which has this issue fixed.

For reference, the error is:

```text
> terraforming-mars@1.0.0 start
> node build/src/server.js

node:internal/modules/cjs/loader:1183
  return process.dlopen(module, path.toNamespacedPath(filename));
                 ^

Error: Error relocating /usr/src/app/node_modules/sqlite3/lib/binding/napi-v6-linux-x64/node_sqlite3.node: fcntl64: symbol not found
    at Object.Module._extensions..node (node:internal/modules/cjs/loader:1183:18)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/usr/src/app/node_modules/sqlite3/lib/sqlite3-binding.js:4:15)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12) {
  code: 'ERR_DLOPEN_FAILED'
}
```