### PR TITLE
Adds a "Max" button for Megacredits.

### DIFF
--- a/src/client/components/SelectHowToPay.vue
+++ b/src/client/components/SelectHowToPay.vue
@@ -101,16 +101,23 @@ export default Vue.extend({
       this.$data[target] = qty;
       return contributingValue;
     },
-    setDefaultValues() {
+    setDefaultValues(reserveMegacredits: boolean = false) {
       const cost = this.$data.cost;
 
-      const targets: Array<Unit> = ['seeds', 'data', 'steel', 'titanium', 'heat'];
       const megaCredits = this.getAmount('megaCredits');
-      let amountCovered = 0;
+
+      const targets: Array<Unit> = ['seeds', 'data', 'steel', 'titanium', 'heat'];
+      let amountCovered = reserveMegacredits ? megaCredits : 0;
       for (const target of targets) {
         amountCovered += this.setDefaultValue(amountCovered, target);
       }
-      this.$data.megaCredits = Math.min(megaCredits, Math.max(cost - amountCovered, 0));
+      if (!reserveMegacredits) {
+        this.$data.megaCredits = Math.min(megaCredits, Math.max(cost - amountCovered, 0));
+      }
+    },
+    setMaxMCValue() {
+      this.setMaxValue('megaCredits');
+      this.setDefaultValues(/* reserveMegacredits */ true);
     },
     canAffordWithMcOnly() {
       return this.thisPlayer.megaCredits >= this.$data.cost;
@@ -249,6 +256,7 @@ export default Vue.extend({
       <Button type="minus" @click="reduceValue('megaCredits', 1)" />
       <input class="form-input form-inline payments_input" v-model.number="megaCredits" />
       <Button type="plus" @click="addValue('megaCredits', 1)" />
+      <Button type="max" @click="setMaxMCValue()" title="MAX" />
     </div>
 
     <div v-if="hasWarning()" class="tm-warning">

--- a/tests/client/components/SelectHowToPay.spec.ts
+++ b/tests/client/components/SelectHowToPay.spec.ts
@@ -158,6 +158,53 @@ describe('SelectHowToPay', () => {
     tester.expectValue('megaCredits', 10);
   });
 
+  it('max megacredits', async () => {
+    const wrapper = setupBill(
+      9,
+      {megaCredits: 16, heat: 3},
+      {canUseHeat: true});
+
+    const tester = new PaymentTester(wrapper);
+    await tester.nextTick();
+
+    tester.expectValue('heat', 0);
+    tester.expectValue('megaCredits', 9);
+
+    await tester.clickMax('heat');
+    await tester.nextTick();
+
+    tester.expectValue('heat', 3);
+    tester.expectValue('megaCredits', 6);
+
+    await tester.clickMax('megaCredits');
+    await tester.nextTick();
+
+    tester.expectValue('heat', 0);
+    tester.expectValue('megaCredits', 9);
+  });
+
+  it('max megacredits, 2', async () => {
+    const wrapper = setupBill(
+      10,
+      {megaCredits: 5, titanium: 4, titaniumValue: 4, heat: 3},
+      {canUseTitanium: true, canUseHeat: true});
+
+    const tester = new PaymentTester(wrapper);
+    await tester.nextTick();
+
+    tester.expectValue('titanium', 2);
+    tester.expectValue('heat', 0);
+    tester.expectValue('megaCredits', 2);
+
+    console.log('click');
+    await tester.clickMax('megaCredits');
+    await tester.nextTick();
+
+    tester.expectValue('titanium', 2);
+    tester.expectValue('heat', 0);
+    tester.expectValue('megaCredits', 5);
+  });
+
   const setupBill = function(
     amount: number,
     playerFields: Partial<PublicPlayerModel>,


### PR DESCRIPTION
The SHTP widget doesn't really do much when the megacredit value
changes; it's up to players to change the other units. That can change.

But for now, this will do the bare minimum while generating feedback for
how to refine this.