### PR TITLE
Extra visuzliation for action cards played this generation

### DIFF
--- a/src/client/components/SelectCard.vue
+++ b/src/client/components/SelectCard.vue
@@ -6,7 +6,7 @@
               <input v-if="isSelectOnlyOneCard()" type="radio" v-model="cards" :value="card" />
               <input v-else type="checkbox" v-model="cards" :value="card" :disabled="playerinput.maxCardsToSelect !== undefined && Array.isArray(cards) && cards.length >= playerinput.maxCardsToSelect && cards.includes(card) === false" />
             </template>
-            <Card :card="card">
+            <Card :card="card" :actionUsed="isCardActivated(card)">
               <template v-if="playerinput.showOwner">
                 <div :class="'card-owner-label player_translucent_bg_color_'+ getOwner(card).color">
                   {{getOwner(card).name}}
@@ -160,6 +160,10 @@ export default Vue.extend({
     },
     buttonLabel(): string {
       return this.isSelectOnlyOneCard() ? this.playerinput.buttonLabel : this.playerinput.buttonLabel + ' ' + this.cardsSelected();
+    },
+    isCardActivated(card: CardModel): boolean {
+      // Copied from PlayerMixin.
+      return this.playerView.thisPlayer.actionsThisGeneration?.includes(card.name);
     },
   },
 });

--- a/src/client/components/SelectCard.vue
+++ b/src/client/components/SelectCard.vue
@@ -163,7 +163,7 @@ export default Vue.extend({
     },
     isCardActivated(card: CardModel): boolean {
       // Copied from PlayerMixin.
-      return this.playerView.thisPlayer.actionsThisGeneration?.includes(card.name);
+      return this.playerView.thisPlayer.actionsThisGeneration.includes(card.name);
     },
   },
 });

--- a/src/client/mixins/PlayerMixin.ts
+++ b/src/client/mixins/PlayerMixin.ts
@@ -40,11 +40,8 @@ export const PlayerMixin = {
     getPreludeCardType() {
       return CardType.PRELUDE;
     },
-    isCardActivated(
-      card: CardModel,
-      player: PublicPlayerModel,
-    ): boolean {
-      return player?.actionsThisGeneration?.includes(card.name) || card.isDisabled;
+    isCardActivated(card: CardModel, player: PublicPlayerModel): boolean {
+      return player.actionsThisGeneration.includes(card.name) || card.isDisabled;
     },
   },
 };

--- a/src/client/mixins/PlayerMixin.ts
+++ b/src/client/mixins/PlayerMixin.ts
@@ -44,11 +44,7 @@ export const PlayerMixin = {
       card: CardModel,
       player: PublicPlayerModel,
     ): boolean {
-      return (
-        (player !== undefined &&
-                player.actionsThisGeneration !== undefined &&
-                player.actionsThisGeneration.includes(card.name)) || card.isDisabled
-      );
+      return player?.actionsThisGeneration?.includes(card.name) || card.isDisabled;
     },
   },
 };

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -36,6 +36,9 @@
 
 .card-unavailable {
     filter: brightness(0.55);
+    &:hover {
+        filter: brightness(1.00);
+    }
 }
 
 .card-hide {

--- a/tests/client/components/SelectInitialCards.spec.ts
+++ b/tests/client/components/SelectInitialCards.spec.ts
@@ -109,6 +109,7 @@ function createComponent(corpCards: Array<CardName>, projectCards: Array<CardNam
     propsData: {
       playerView: {
         id: 'foo',
+        thisPlayer: {actionsThisGeneration: []},
       },
       playerinput: {
         title: 'foo',


### PR DESCRIPTION
Two changes:
1. When having to select a card for adding resources, if the card was played this generation, use the dark filter.
2. When hovering over a card with a dark filter, remove the filter, making it easier to see.

This fixes #3046 