### PR TITLE
Lobby Halls was raising the planetary track an additional step.

### DIFF
--- a/src/cards/pathfinders/LobbyHalls.ts
+++ b/src/cards/pathfinders/LobbyHalls.ts
@@ -10,7 +10,6 @@ import {SendDelegateToArea} from '../../deferredActions/SendDelegateToArea';
 import {DeclareCloneTag} from '../../pathfinders/DeclareCloneTag';
 import {ICloneTagCard} from './ICloneTagCard';
 import {Turmoil} from '../../turmoil/Turmoil';
-import {PathfindersExpansion, PlanetaryTag} from '../../pathfinders/PathfindersExpansion';
 
 export class LobbyHalls extends Card implements IProjectCard, ICloneTagCard {
   constructor() {
@@ -38,7 +37,7 @@ export class LobbyHalls extends Card implements IProjectCard, ICloneTagCard {
   }
 
   public play(player: Player) {
-    player.game.defer(new DeclareCloneTag(player, this, (tag: PlanetaryTag) => PathfindersExpansion.raiseTrack(tag, player, 1)));
+    player.game.defer(new DeclareCloneTag(player, this));
     player.adjustProduction(this.productionBox);
     const turmoil = Turmoil.getTurmoil(player.game);
     if (turmoil.getAvailableDelegateCount(player.id, 'reserve') > 0) {

--- a/tests/cards/pathfinders/LobbyHalls.spec.ts
+++ b/tests/cards/pathfinders/LobbyHalls.spec.ts
@@ -6,12 +6,12 @@ import {Units} from '../../../src/common/Units';
 import {Turmoil} from '../../../src/turmoil/Turmoil';
 import {Game} from '../../../src/Game';
 import {DeclareCloneTag} from '../../../src/pathfinders/DeclareCloneTag';
-import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Tags} from '../../../src/common/cards/Tags';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {DeferredAction} from '../../../src//deferredActions/DeferredAction';
 import {SendDelegateToArea} from '../../../src//deferredActions/SendDelegateToArea';
 import {SelectPartyToSendDelegate} from '../../../src//inputs/SelectPartyToSendDelegate';
+import {TestingUtils} from '../../TestingUtils';
 
 describe('LobbyHalls', function() {
   let card: LobbyHalls;
@@ -61,8 +61,7 @@ describe('LobbyHalls', function() {
   });
 
   function assertCloneTagAction(action: DeferredAction) {
-    expect(action).instanceOf(DeclareCloneTag);
-    const options = action!.execute() as OrOptions;
+    const options = TestingUtils.cast(action, DeclareCloneTag).execute();
     options.options[0].cb();
     expect(card.tags).deep.eq([Tags.EARTH, Tags.BUILDING]);
   }


### PR DESCRIPTION
That's because DeclareCloneTag calls onCardPlayed,
which raises the track one space on declaration.

Fixes #4049