### PR TITLE
Rewrite how sqlite purges unfinished games.

### DIFF
--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -5,6 +5,7 @@ import {IGameData} from '../common/game/IGameData';
 import {SerializedGame} from '../SerializedGame';
 
 import sqlite3 = require('sqlite3');
+import {daysAgoToSeconds} from './utils.ts';
 const path = require('path');
 const fs = require('fs');
 const dbFolder = path.resolve(process.cwd(), './db');
@@ -203,10 +204,11 @@ export class SQLite implements IDatabase {
     }));
   }
 
-  purgeUnfinishedGames(): void {
+  purgeUnfinishedGames(maxGameDays: string | undefined = process.env.MAX_GAME_DAYS): void {
     // Purge unfinished games older than MAX_GAME_DAYS days. If this .env variable is not present, unfinished games will not be purged.
-    if (process.env.MAX_GAME_DAYS) {
-      this.runQuietly(`DELETE FROM games WHERE created_time < strftime('%s',date('now', '-' || ? || ' day')) and status = 'running'`, [process.env.MAX_GAME_DAYS]);
+    if (maxGameDays) {
+      const dateToSeconds = daysAgoToSeconds(maxGameDays, 0);
+      this.runQuietly(`DELETE FROM games WHERE created_time < ? and status = 'running'`, [dateToSeconds]);
     }
   }
 

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -204,11 +204,13 @@ export class SQLite implements IDatabase {
     }));
   }
 
-  purgeUnfinishedGames(maxGameDays: string | undefined = process.env.MAX_GAME_DAYS): void {
+  purgeUnfinishedGames(maxGameDays: string | undefined = process.env.MAX_GAME_DAYS): Promise<void> {
     // Purge unfinished games older than MAX_GAME_DAYS days. If this .env variable is not present, unfinished games will not be purged.
     if (maxGameDays) {
       const dateToSeconds = daysAgoToSeconds(maxGameDays, 0);
-      this.runQuietly(`DELETE FROM games WHERE created_time < ? and status = 'running'`, [dateToSeconds]);
+      return this.runQuietly(`DELETE FROM games WHERE created_time < ? and status = 'running'`, [dateToSeconds]);
+    } else {
+      return Promise.resolve();
     }
   }
 

--- a/src/database/utils.ts.ts
+++ b/src/database/utils.ts.ts
@@ -1,0 +1,16 @@
+export function dayDiff(now: Date, days: number) {
+  const ms = Math.round(now.getTime());
+  const daysInMs = days * 86400 * 1000;
+  return new Date(ms + daysInMs);
+}
+
+export function dateToSeconds(date: Date) {
+  return Math.round(date.getTime() / 1000);
+}
+
+export function daysAgoToSeconds(dayString: string | undefined, defaultValue: number) {
+  const envDays = parseInt(dayString || '');
+  const days = Number.isInteger(envDays) ? envDays : defaultValue;
+  const date = dayDiff(new Date(), -days);
+  return dateToSeconds(date);
+}

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -146,3 +146,9 @@ export class TestingUtils {
     return obj;
   }
 }
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/tests/database/SQLite.spec.ts
+++ b/tests/database/SQLite.spec.ts
@@ -5,6 +5,7 @@ import {TestPlayers} from '../TestPlayers';
 import {IN_MEMORY_SQLITE_PATH, SQLite} from '../../src/database/SQLite';
 import {Database} from '../../src/database/Database';
 import {restoreTestDatabase} from '../utils/setup';
+import {sleep} from '../TestingUtils';
 
 class TestSQLite extends SQLite {
   public saveGamePromise: Promise<void> = Promise.resolve();
@@ -93,14 +94,12 @@ describe('SQLite', () => {
 
     expect(await db.getSaveIds(game.id)).has.members([0, 1, 2, 3]);
 
-    // TODO(kberg): make cleanSaves a promise, too. Beacuse right now
-    // this timeout doesn't participate in automated testing. But for now I can
-    // verify this in the debugger. Next step.
     db.cleanSaves(game.id);
-    setTimeout(async () => {
-      const saveIds = await db.getSaveIds(game.id);
-      expect(saveIds).has.members([0, 3]);
-    }, 1000);
+
+    await sleep(1000);
+
+    const saveIds = await db.getSaveIds(game.id);
+    expect(saveIds).has.members([0, 3]);
   });
 
   it('gets cloneable game by id', async () => {
@@ -126,5 +125,24 @@ describe('SQLite', () => {
       expect(err).to.be.undefined;
       expect(gameData).to.be.undefined;
     });
+  });
+
+  it('purgeUnfinishedGames', async () => {
+    const player = TestPlayers.BLACK.newPlayer();
+    const game = Game.newInstance('game-id-1212', [player], player);
+    await db.saveGamePromise;
+    expect(game.lastSaveId).eq(1);
+
+    await db.saveGame(game);
+    await db.saveGame(game);
+    await db.saveGame(game);
+
+    expect(await db.getSaveIds(game.id)).has.members([0, 1, 2, 3]);
+
+    db.purgeUnfinishedGames('1');
+    expect(await db.getSaveIds(game.id)).has.members([0, 1, 2, 3]);
+    // Doesn't purge until the time has passed.
+    db.purgeUnfinishedGames('0');
+    expect(await db.getSaveIds(game.id)).is.empty;
   });
 });

--- a/tests/database/SQLite.spec.ts
+++ b/tests/database/SQLite.spec.ts
@@ -139,10 +139,10 @@ describe('SQLite', () => {
 
     expect(await db.getSaveIds(game.id)).has.members([0, 1, 2, 3]);
 
-    db.purgeUnfinishedGames('1');
+    await db.purgeUnfinishedGames('1');
     expect(await db.getSaveIds(game.id)).has.members([0, 1, 2, 3]);
     // Doesn't purge until the time has passed.
-    db.purgeUnfinishedGames('0');
+    await db.purgeUnfinishedGames('0');
     expect(await db.getSaveIds(game.id)).is.empty;
   });
 });


### PR DESCRIPTION
First, the code centralizes computing time to seconds, because trusting
sqlite's date math is fine, but putting the complexity in Typescript is
better; we're better in Typescript than SQLite.

Second, type SQLite functions were not computing days ago as if it were
that many seconds ago, but rather some midnight date n days ago. That
means all unfinished games over a 24-hour period are purged at once
rather than over time.

If this same behavior exists with PostgreSQL, it could account for some
of the occasional slow operations, but I doubt it.

Finally, fixing the purge method; async sleep() is kinda better.