### PR TITLE
Fix placeholder for 'Your name' input in game setup, enabling i18n

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -12,7 +12,7 @@
                     <div v-if="isSoloModePage">
                       <div class="create-game-solo-player form-group" v-for="newPlayer in getPlayers()" v-bind:key="newPlayer.index">
                           <div>
-                              <input class="form-input form-inline create-game-player-name" placeholder="Your name" v-model="newPlayer.name" />
+                              <input class="form-input form-inline create-game-player-name" :placeholder="$t('Your name')" v-model="newPlayer.name" />
                           </div>
                           <div class="create-game-colors-wrapper">
                               <label class="form-label form-inline create-game-color-label" v-i18n>Color:</label>


### PR DESCRIPTION
I've adjusted the placeholder for the "Your name" input. The localizations are now correctly applied to the placeholder.

Before:
<img width="856" alt="before" src="https://user-images.githubusercontent.com/16086991/168492479-5b4b84c7-0a1b-43e1-8a98-ae089b99e68c.png">

After:
<img width="824" alt="after" src="https://user-images.githubusercontent.com/16086991/168492483-8d979c5b-14f0-488a-8cf4-f5cf69a8c835.png">

