### PR TITLE
This one trick to lower memory for our LogMessage will surprise you.

### DIFF
--- a/src/common/logs/LogMessage.ts
+++ b/src/common/logs/LogMessage.ts
@@ -5,11 +5,19 @@ import {PlayerId} from '../Types';
 
 export class LogMessage implements Message {
   public timestamp = Date.now();
+  public playerId?: PlayerId;
   constructor(
     public type: LogMessageType,
     public message: string,
     public data: Array<LogMessageData>,
     // When set, this message is private for the specifed player.
     // Always filter messages so they're not sent to the wrong player.
-    public playerId?: PlayerId) {}
+    playerId?: PlayerId) {
+    // setting in body to avoid setting property when
+    // argument is undefined for less memory usage
+    if (playerId !== undefined) {
+      this.playerId = playerId;
+    }
+  }
 }
+

--- a/tests/common/logs/LogMessage.spec.ts
+++ b/tests/common/logs/LogMessage.spec.ts
@@ -1,0 +1,12 @@
+import {expect} from 'chai';
+import {LogMessage} from '../../../src/common/logs/LogMessage';
+import {LogMessageType} from '../../../src/common/logs/LogMessageType';
+
+describe('LogMessage', () => {
+  it('does not store playerId when undefined on object', () => {
+    const noPlayerLog = new LogMessage(LogMessageType.DEFAULT, 'foobar', []);
+    expect(noPlayerLog.hasOwnProperty('playerId')).to.be.false;
+    const playerLog = new LogMessage(LogMessageType.DEFAULT, 'foobar', [], 'playerId');
+    expect(playerLog.hasOwnProperty('playerId')).to.be.true;
+  });
+});


### PR DESCRIPTION
This change avoids setting the `playerId` property on the `LogMessage` object when the argument is `undefined`. With less properties used per `LogMessage` less memory will be used. As JSON doesn't store properties with values of `undefined` this should also reflect what we have stored in JSON within the database. I added a regression test to ensure the generated javascript no longer adds the property.


## Before
```js
class LogMessage {
    constructor(type, message, data, playerId) {
        this.type = type;
        this.message = message;
        this.data = data;
        this.playerId = playerId;
        this.timestamp = Date.now();
    }
}
 ```

## After
```js
var LogMessage = (function () {
    function LogMessage(type, message, data, playerId) {
        this.type = type;
        this.message = message;
        this.data = data;
        this.timestamp = Date.now();
        if (playerId !== undefined) {
            this.playerId = playerId;
        }
    }
    return LogMessage;
}());
 ```