### PR TITLE
only store property when not LogMessageType.DEFAULT

### DIFF
--- a/src/client/components/LogPanel.vue
+++ b/src/client/components/LogPanel.vue
@@ -213,7 +213,7 @@ export default Vue.extend({
           const icon = message.playerId === undefined ? '&#x1f551;' : '&#x1f4ac;';
           logEntryBullet = `<span title="${when}">${icon}</span>`;
         }
-        if (message.type !== undefined && message.message !== undefined) {
+        if (message.message !== undefined) {
           message.message = this.$t(message.message);
           return logEntryBullet + Log.applyData(message, this.messageDataToHTML);
         }

--- a/src/common/logs/LogMessage.ts
+++ b/src/common/logs/LogMessage.ts
@@ -4,10 +4,11 @@ import {Message} from './Message';
 import {PlayerId} from '../Types';
 
 export class LogMessage implements Message {
-  public timestamp = Date.now();
   public playerId?: PlayerId;
+  public timestamp = Date.now();
+  public type?: LogMessageType;
   constructor(
-    public type: LogMessageType,
+    type: LogMessageType,
     public message: string,
     public data: Array<LogMessageData>,
     // When set, this message is private for the specifed player.
@@ -17,6 +18,12 @@ export class LogMessage implements Message {
     // argument is undefined for less memory usage
     if (playerId !== undefined) {
       this.playerId = playerId;
+    }
+    // only store property if not default
+    // for less memory usage. majority
+    // of messages are default
+    if (type !== LogMessageType.DEFAULT) {
+      this.type = type;
     }
   }
 }

--- a/tests/common/logs/LogMessage.spec.ts
+++ b/tests/common/logs/LogMessage.spec.ts
@@ -8,5 +8,12 @@ describe('LogMessage', () => {
     expect(noPlayerLog.hasOwnProperty('playerId')).to.be.false;
     const playerLog = new LogMessage(LogMessageType.DEFAULT, 'foobar', [], 'playerId');
     expect(playerLog.hasOwnProperty('playerId')).to.be.true;
+    expect(playerLog.playerId).to.eql('playerId');
+  });
+  it('does not store type when LogMessageType.DEFAULT', () => {
+    const defaultLog = new LogMessage(LogMessageType.DEFAULT, 'foobar', []);
+    expect(defaultLog.hasOwnProperty('type')).to.be.false;
+    const newGenerationLog = new LogMessage(LogMessageType.NEW_GENERATION, 'foobar', []);
+    expect(newGenerationLog.type).to.eql(LogMessageType.NEW_GENERATION);
   });
 });


### PR DESCRIPTION
This change only stores the `type` property when the value is not `LogMessageType.DEFAULT`. The only messages that have a different type are the new generation log messages. This should remove this property from a large percentage of log messages. With the property not applied less memory will be consumed on the server as well as in the database. Performed quick sanity check locally and still saw generation messages appear and survive server reboot.