### PR TITLE
refactor: remove unused conditionals for src/turmoil

### DIFF
--- a/src/cards/moon/AnOfferYouCantRefuse.ts
+++ b/src/cards/moon/AnOfferYouCantRefuse.ts
@@ -78,7 +78,7 @@ export class AnOfferYouCantRefuse extends ProjectCard {
           const option = new SelectOption(`${party.name} / ${playerName}`, 'Select', () => {
             const source = turmoil.hasDelegatesInReserve(player.id) ? 'reserve' : 'lobby';
             turmoil.replaceDelegateFromParty(delegate, player.id, source, party.name, game);
-            turmoil.checkDominantParty(party); // Check dominance right after replacement (replace doesn't check dominance.)
+            turmoil.checkDominantParty(); // Check dominance right after replacement (replace doesn't check dominance.)
             return this.moveToAnotherParty(game, party.name, player.id);
           });
           orOptions.options.push(option);

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -161,7 +161,7 @@ export class Turmoil {
       }
     }
     party.sendDelegate(playerId, game);
-    this.checkDominantParty(party);
+    this.checkDominantParty();
   }
 
   // Use to remove a delegate from a specific party
@@ -169,7 +169,7 @@ export class Turmoil {
     const party = this.getPartyByName(partyName);
     this.delegateReserve.push(playerId);
     party.removeDelegate(playerId, game);
-    this.checkDominantParty(party);
+    this.checkDominantParty();
   }
 
   // Use to replace a delegate from a specific party with another delegate with NO DOMINANCE CHANGE
@@ -186,7 +186,7 @@ export class Turmoil {
   }
 
   // Check dominant party
-  public checkDominantParty(party:IParty): void {
+  public checkDominantParty(): void {
     // If there is a dominant party
     const sortParties = [...this.parties].sort(
       (p1, p2) => p2.delegates.length - p1.delegates.length,

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -188,16 +188,12 @@ export class Turmoil {
   // Check dominant party
   public checkDominantParty(party:IParty): void {
     // If there is a dominant party
-    if (this.dominantParty) {
-      const sortParties = [...this.parties].sort(
-        (p1, p2) => p2.delegates.length - p1.delegates.length,
-      );
-      const max = sortParties[0].delegates.length;
-      if (this.dominantParty.delegates.length !== max) {
-        this.setNextPartyAsDominant(this.dominantParty);
-      }
-    } else {
-      this.dominantParty = party;
+    const sortParties = [...this.parties].sort(
+      (p1, p2) => p2.delegates.length - p1.delegates.length,
+    );
+    const max = sortParties[0].delegates.length;
+    if (this.dominantParty.delegates.length !== max) {
+      this.setNextPartyAsDominant(this.dominantParty);
     }
   }
 
@@ -253,9 +249,7 @@ export class Turmoil {
     this.rulingParty = this.dominantParty;
 
     // 3.a - Ruling Policy change
-    if (this.rulingParty) {
-      this.setRulingParty(game);
-    }
+    this.setRulingParty(game);
 
     // 3.b - New dominant party
     this.setNextPartyAsDominant(this.rulingParty!);
@@ -300,44 +294,42 @@ export class Turmoil {
 
   // Ruling Party changes
   public setRulingParty(game: Game): void {
-    if (this.rulingParty !== undefined) {
-      // Cleanup previous party effects
-      game.getPlayers().forEach((player) => player.hasTurmoilScienceTagBonus = false);
+    // Cleanup previous party effects
+    game.getPlayers().forEach((player) => player.hasTurmoilScienceTagBonus = false);
 
-      // Change the chairman
-      if (this.chairman) {
-        this.delegateReserve.push(this.chairman);
-      }
+    // Change the chairman
+    if (this.chairman) {
+      this.delegateReserve.push(this.chairman);
+    }
 
-      this.chairman = this.rulingParty.partyLeader || 'NEUTRAL';
+    this.chairman = this.rulingParty.partyLeader || 'NEUTRAL';
 
-      const index = this.rulingParty.delegates.indexOf(this.rulingParty.partyLeader!);
-      // Remove the party leader from the delegates array
-      this.rulingParty.delegates.splice(index, 1);
-      // Fill the delegate reserve
-      this.delegateReserve = this.delegateReserve.concat(this.rulingParty.delegates);
+    const index = this.rulingParty.delegates.indexOf(this.rulingParty.partyLeader!);
+    // Remove the party leader from the delegates array
+    this.rulingParty.delegates.splice(index, 1);
+    // Fill the delegate reserve
+    this.delegateReserve = this.delegateReserve.concat(this.rulingParty.delegates);
 
-      // Clean the party
-      this.rulingParty.partyLeader = undefined;
-      this.rulingParty.delegates = [];
+    // Clean the party
+    this.rulingParty.partyLeader = undefined;
+    this.rulingParty.delegates = [];
 
-      PoliticalAgendas.setNextAgenda(this, game);
+    PoliticalAgendas.setNextAgenda(this, game);
 
-      // Finally, award Chairman TR
-      if (this.chairman !== 'NEUTRAL') {
-        const player = game.getPlayerById(this.chairman);
-        // Tempest Consultancy Hook (gains an additional TR when they become chairman)
-        const steps = player.corporationCard?.name === CardName.TEMPEST_CONSULTANCY ? 2 :1;
+    // Finally, award Chairman TR
+    if (this.chairman !== 'NEUTRAL') {
+      const player = game.getPlayerById(this.chairman);
+      // Tempest Consultancy Hook (gains an additional TR when they become chairman)
+      const steps = player.corporationCard?.name === CardName.TEMPEST_CONSULTANCY ? 2 :1;
 
-        // Raise TR but after resolving the new policy
-        game.defer(new SimpleDeferredAction(player, () => {
-          player.increaseTerraformRatingSteps(steps);
-          game.log('${0} is the new chairman and gains ${1} TR', (b) => b.player(player).number(steps));
-          return undefined;
-        }));
-      } else {
-        game.log('A neutral delegate is the new chairman.');
-      }
+      // Raise TR but after resolving the new policy
+      game.defer(new SimpleDeferredAction(player, () => {
+        player.increaseTerraformRatingSteps(steps);
+        game.log('${0} is the new chairman and gains ${1} TR', (b) => b.player(player).number(steps));
+        return undefined;
+      }));
+    } else {
+      game.log('A neutral delegate is the new chairman.');
     }
   }
 
@@ -489,9 +481,6 @@ export class Turmoil {
 
     d.parties.forEach((sp) => {
       const tp = turmoil.getPartyByName(sp.name);
-      if (tp === undefined) {
-        throw new Error('huh? unknown party: ' + sp.name);
-      }
       tp.delegates = sp.delegates;
       tp.partyLeader = sp.partyLeader;
     });

--- a/src/turmoil/parties/Party.ts
+++ b/src/turmoil/parties/Party.ts
@@ -23,51 +23,49 @@ export abstract class Party {
   public checkPartyLeader(newPlayer: PlayerId | NeutralPlayer, game: Game): void {
     // If there is a party leader
     if (this.partyLeader) {
-      if (game) {
-        const sortedPlayers = [...this.getPresentPlayers()].sort(
-          (p1, p2) => this.getDelegates(p2) - this.getDelegates(p1),
-        );
-        const max = this.getDelegates(sortedPlayers[0]);
+      const sortedPlayers = [...this.getPresentPlayers()].sort(
+        (p1, p2) => this.getDelegates(p2) - this.getDelegates(p1),
+      );
+      const max = this.getDelegates(sortedPlayers[0]);
 
-        if (this.getDelegates(this.partyLeader) !== max) {
-          let currentIndex = 0;
-          if (this.partyLeader === 'NEUTRAL') {
-            currentIndex = game.getPlayersInGenerationOrder().indexOf(game.getPlayerById(game.activePlayer));
-          } else {
-            currentIndex = game.getPlayersInGenerationOrder().indexOf(game.getPlayerById(this.partyLeader));
-          }
-
-          let playersToCheck: Array<Player | NeutralPlayer> = [];
-
-          // Manage if it's the first player or the last
-          if (game.getPlayersInGenerationOrder().length === 1 || currentIndex === 0) {
-            playersToCheck = game.getPlayersInGenerationOrder();
-          } else if (currentIndex === game.getPlayersInGenerationOrder().length - 1) {
-            playersToCheck = game.getPlayersInGenerationOrder().slice(0, currentIndex);
-            playersToCheck.unshift(game.getPlayersInGenerationOrder()[currentIndex]);
-          } else {
-            const left = game.getPlayersInGenerationOrder().slice(0, currentIndex);
-            const right = game.getPlayersInGenerationOrder().slice(currentIndex);
-            playersToCheck = right.concat(left);
-          }
-
-          // Add NEUTRAL in the list
-          playersToCheck.push('NEUTRAL');
-
-          playersToCheck.some((nextPlayer) => {
-            let nextPlayerId = '';
-            if (nextPlayer === 'NEUTRAL') {
-              nextPlayerId = 'NEUTRAL';
-            } else {
-              nextPlayerId = nextPlayer.id;
-            }
-            if (this.getDelegates(nextPlayerId) === max) {
-              this.partyLeader = nextPlayerId;
-              return true;
-            }
-            return false;
-          });
+      if (this.getDelegates(this.partyLeader) !== max) {
+        let currentIndex = 0;
+        if (this.partyLeader === 'NEUTRAL') {
+          currentIndex = game.getPlayersInGenerationOrder().indexOf(game.getPlayerById(game.activePlayer));
+        } else {
+          currentIndex = game.getPlayersInGenerationOrder().indexOf(game.getPlayerById(this.partyLeader));
         }
+
+        let playersToCheck: Array<Player | NeutralPlayer> = [];
+
+        // Manage if it's the first player or the last
+        if (game.getPlayersInGenerationOrder().length === 1 || currentIndex === 0) {
+          playersToCheck = game.getPlayersInGenerationOrder();
+        } else if (currentIndex === game.getPlayersInGenerationOrder().length - 1) {
+          playersToCheck = game.getPlayersInGenerationOrder().slice(0, currentIndex);
+          playersToCheck.unshift(game.getPlayersInGenerationOrder()[currentIndex]);
+        } else {
+          const left = game.getPlayersInGenerationOrder().slice(0, currentIndex);
+          const right = game.getPlayersInGenerationOrder().slice(currentIndex);
+          playersToCheck = right.concat(left);
+        }
+
+        // Add NEUTRAL in the list
+        playersToCheck.push('NEUTRAL');
+
+        playersToCheck.some((nextPlayer) => {
+          let nextPlayerId = '';
+          if (nextPlayer === 'NEUTRAL') {
+            nextPlayerId = 'NEUTRAL';
+          } else {
+            nextPlayerId = nextPlayer.id;
+          }
+          if (this.getDelegates(nextPlayerId) === max) {
+            this.partyLeader = nextPlayerId;
+            return true;
+          }
+          return false;
+        });
       }
     } else {
       this.partyLeader = newPlayer;

--- a/src/turmoil/parties/PartyHooks.ts
+++ b/src/turmoil/parties/PartyHooks.ts
@@ -32,16 +32,13 @@ export class PartyHooks {
       if (game.phase !== Phase.ACTION) return false;
 
       const rulingParty = turmoil.rulingParty;
-      if (rulingParty === undefined) return false;
 
       // Set the default policy if not given
       if (policyId === undefined) {
         policyId = rulingParty.policies[0].id;
       }
 
-      const currentPolicyId: PolicyId = (turmoil.politicalAgendasData === undefined) ?
-        rulingParty.policies[0].id :
-        PoliticalAgendas.currentAgenda(turmoil).policyId;
+      const currentPolicyId: PolicyId = PoliticalAgendas.currentAgenda(turmoil).policyId;
 
       return rulingParty.name === partyName && currentPolicyId === policyId;
     }, () => false);


### PR DESCRIPTION
I want to enable the [no-unnecessary-condition](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md) linting rule as it can spot code we can remove. These places usually pop up during re-factors when properties that were once optional gain default values. Going to do this change in small pieces to make it easier to review before enabling the rule. The changes in this PR were fixed after eslint found uncessary conditions.

This PR fixes the files in src/turmoil subdirectory.