### PR TITLE
remove unnecessary pretest:server script

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "test": "npm run test:server && npm run test:client",
     "test:server": "ts-mocha -p tests/tsconfig.json -r tests/utils/setup.ts \"tests/*.spec.ts\" \"tests/!(client|integration)/**/*.spec.ts\"",
     "test:integration": "ts-mocha -p tests/tsconfig.json \"tests/integration/**/*.spec.ts\"",
-    "pretest:server": "npx tsc --build tests/tsconfig.json",
     "test:client": "cross-env NODE_ENV=development mochapack --require tests/client/components/setup.ts \"tests/client/**/*.spec.ts\"",
     "test:client:watch": "cross-env NODE_ENV=development mochapack --watch --require tests/client/components/setup.ts \"tests/client/**/*.spec.ts\"",
     "cover": "nyc ts-mocha -p tests/tsconfig.json -r tests/utils/setup.ts \"tests/*.spec.ts\" \"tests/!(client)/**/*.spec.ts\"",


### PR DESCRIPTION
Since we are using `ts-mocha` we shouldn't need to transpile the typescript to javacript anymore. This will speed up the build.