### PR TITLE
enables i18n of default player names used when creating a game

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -841,9 +841,9 @@ export default (Vue as WithRefs<Refs>).extend({
       component.players.forEach((player) => {
         if (player.name === '') {
           if (isSoloMode) {
-            player.name = 'You';
+            player.name = this.$t('You');
           } else {
-            const defaultPlayerName = player.color.charAt(0).toUpperCase() + player.color.slice(1);
+            const defaultPlayerName = this.$t(player.color.charAt(0).toUpperCase() + player.color.slice(1));
             player.name = defaultPlayerName;
           }
         }


### PR DESCRIPTION
This commit enables translations for default player names when creating a game so there's no longer a player called "Green" when starting a Korean game without entering a name for instance :)

Granted, not the most likely scenario I assume.