### PR TITLE
avoid setting properties to undefined

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -216,11 +216,11 @@ export class Game {
 
   // Card-specific data
   // Mons Insurance promo corp
-  public monsInsuranceOwner: PlayerId | undefined = undefined;
+  public monsInsuranceOwner?: PlayerId;
   // Crash Site promo project
   public someoneHasRemovedOtherPlayersPlants: boolean = false;
   // Syndicate Pirate Raids
-  public syndicatePirateRaider: PlayerId | undefined = undefined;
+  public syndicatePirateRaider?: PlayerId;
 
   private constructor(
     public id: GameId,

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -622,14 +622,16 @@ describe('Game', () => {
   it('serializes properties', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('foobar', [player], player);
+    game.monsInsuranceOwner = undefined;
+    game.syndicatePirateRaider = undefined;
+    game.moonData = undefined;
+    game.pathfindersData = undefined;
     const serialized = game.serialize();
     const serializedKeys = Object.keys(serialized);
     expect(serializedKeys).not.include('rng');
     const gameKeys = Object.keys(game);
-    expect(gameKeys).not.include('moonData');
-    expect(gameKeys).not.include('pathfindersData');
     expect(serializedKeys.concat('rng', 'discardedColonies').sort())
-      .deep.eq(gameKeys.concat('moonData', 'pathfindersData', 'seed', 'currentSeed').sort());
+      .deep.eq(gameKeys.concat('seed', 'currentSeed').sort());
   });
 
   it('deserializing a game without moon data still loads', () => {


### PR DESCRIPTION
This change avoids setting properties to `undefined`. Setting the property to `undefined` creates a key on the `Game` object which will take up memory. This also reflects what the resulting JSON will have as JSON doesn't create keys for properties that are `undefined`.