### PR TITLE
performance improvements to getAdjacentSpaces

### DIFF
--- a/src/boards/Board.ts
+++ b/src/boards/Board.ts
@@ -86,8 +86,8 @@ export abstract class Board {
       const spaces: Array<ISpace> = [];
       for (const [x, y] of coords) {
         const adj = this.spaces.find((adj) =>
-          space !== adj && adj.spaceType !== SpaceType.COLONY &&
-            adj.x === x && adj.y === y,
+          adj.x === x && adj.y === y &&
+          space !== adj && adj.spaceType !== SpaceType.COLONY,
         );
         if (adj !== undefined) {
           spaces.push(adj);
@@ -99,13 +99,12 @@ export abstract class Board {
   }
 
   // Returns adjacent spaces in clockwise order starting from the top left.
-  public getAdjacentSpaces(space: ISpace): Array<ISpace> {
+  public getAdjacentSpaces(space: ISpace): ReadonlyArray<ISpace> {
     const spaces = this.adjacentSpaces.get(space.id);
     if (spaces === undefined) {
       throw new Error(`Unexpected space ID ${space.id}`);
     }
-    // Clone so that callers can't mutate our arrays
-    return [...spaces];
+    return spaces;
   }
 
   public getSpaceByTileCard(cardName: CardName): ISpace | undefined {


### PR DESCRIPTION
[One of the unit tests](https://github.com/terraforming-mars/terraforming-mars/blob/main/tests/boards/Board.spec.ts#L302) can sometimes run over 2 seconds when I run `test:server`. This test creates 4000 board instances. I started to look into how this could be optimized. 

Noticed a minor change to our check for computing adjacent spaces that should help a bit. We would check for the x and y coordinate of the space last when that is the check that is more likely to fail. Moving these up front helped this unit test in question run 30% faster for me when ran in isolation with `it.only`.

The other change avoids duplicating the array and instead uses `ReadonlyArray` so that readonly is enforced at compile time versus having to copy the array each time using CPU.