### PR TITLE
Make card selection translucent

### DIFF
--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -117,7 +117,6 @@ input[type="radio"]:checked + .filterDiv::after {
     font-size: 36px;
     background: linear-gradient(to right, #c97e23bb, #e28c22bb, #c97e23bb);
     color: black;
-    border-bottom: 1px solid #222;
 }
 
 .filterDiv3 {

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -115,7 +115,7 @@ input[type="radio"]:checked + .filterDiv::after {
     text-align: center;
     font-weight: bold;
     font-size: 36px;
-    background: linear-gradient(to right, #c97e23, #e28c22, #c97e23);
+    background: linear-gradient(to right, #c97e23bb, #e28c22bb, #c97e23bb);
     color: black;
     border-bottom: 1px solid #222;
 }


### PR DESCRIPTION
Reduce the opacity of the card selection, to be able to read all information of the selected card.
This is especially helpful if there is only one card which is directly selected.