### PR TITLE
Rising z-index of top bar

### DIFF
--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -938,7 +938,7 @@
     position: sticky;
     margin: -40px 0 0 auto;
     margin-bottom: 15px;
-    z-index: 20;
+    z-index: 105;
     top: -12px;
     display: flex;
 


### PR DESCRIPTION
Rise z-index of top-bar  top 105 in order to be higher than the z-index of a hovered card (100).
This takes care that the hovered card does not show over the top-bar
Old behavior:
![grafik](https://user-images.githubusercontent.com/18309339/172043468-765b3b3c-113e-437c-94e6-81f18288f98b.png)
