### PR TITLE
Market Manipulation Action Changes

### DIFF
--- a/src/cards/colonies/MarketManipulation.ts
+++ b/src/cards/colonies/MarketManipulation.ts
@@ -70,7 +70,7 @@ export class MarketManipulation extends Card implements IProjectCard {
       'Increase',
       increasableColonies,
       (colony: IColony) => {
-        console.log(colony);
+        player.game.log('${0} increased ${1} track', (b) => b.player(player).string(colony.name));
         colony.increaseTrack();
         return undefined;
       },
@@ -80,7 +80,7 @@ export class MarketManipulation extends Card implements IProjectCard {
       'Decrease',
       decreasableColonies,
       (colony: IColony) => {
-        console.log(colony);
+        player.game.log('${0} increased ${1} track', (b) => b.player(player).string(colony.name));
         colony.decreaseTrack();
         return undefined;
       },

--- a/src/cards/colonies/MarketManipulation.ts
+++ b/src/cards/colonies/MarketManipulation.ts
@@ -80,7 +80,7 @@ export class MarketManipulation extends Card implements IProjectCard {
       'Decrease',
       decreasableColonies,
       (colony: IColony) => {
-        player.game.log('${0} increased ${1} track', (b) => b.player(player).string(colony.name));
+        player.game.log('${0} decreased ${1} track', (b) => b.player(player).string(colony.name));
         colony.decreaseTrack();
         return undefined;
       },

--- a/src/cards/colonies/MarketManipulation.ts
+++ b/src/cards/colonies/MarketManipulation.ts
@@ -1,15 +1,15 @@
+import {SimpleDeferredAction} from '../../deferredActions/DeferredAction';
 import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../../common/cards/Tags';
 import {CardType} from '../../common/cards/CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../common/cards/CardName';
 import {Game} from '../../Game';
-import {OrOptions} from '../../inputs/OrOptions';
-import {SelectOption} from '../../inputs/SelectOption';
 import {Card} from '../Card';
 import {Size} from '../../common/cards/render/Size';
 import {CardRenderer} from '../render/CardRenderer';
-import {COLONY_DESCRIPTIONS} from '../../common/colonies/ColonyDescription';
+import {SelectColony} from '../..//inputs/SelectColony';
+import {IColony} from '../../colonies/IColony';
 
 export class MarketManipulation extends Card implements IProjectCard {
   constructor() {
@@ -22,7 +22,11 @@ export class MarketManipulation extends Card implements IProjectCard {
       metadata: {
         cardNumber: 'C23',
         renderData: CardRenderer.builder((b) => {
-          b.text('Increase one colony tile track 1 step. Decrease another colony tile track 1 step.', Size.SMALL, true);
+          b.text(
+            'Increase one colony tile track 1 step. Decrease another colony tile track 1 step.',
+            Size.SMALL,
+            true,
+          );
         }),
       },
     });
@@ -34,7 +38,11 @@ export class MarketManipulation extends Card implements IProjectCard {
 
     if (increasableColonies.length === 0) return false;
     if (decreasableColonies.length === 0) return false;
-    if (increasableColonies.length === 1 && decreasableColonies.length === 1 && increasableColonies[0] === decreasableColonies[0]) {
+    if (
+      increasableColonies.length === 1 &&
+      decreasableColonies.length === 1 &&
+      increasableColonies[0] === decreasableColonies[0]
+    ) {
       return false;
     }
 
@@ -42,42 +50,47 @@ export class MarketManipulation extends Card implements IProjectCard {
   }
 
   private getIncreasableColonies(game: Game) {
-    return game.colonies.filter((colony) => colony.trackPosition < 6 && colony.isActive);
+    return game.colonies.filter(
+      (colony) => colony.trackPosition < 6 && colony.isActive,
+    );
   }
 
   private getDecreasableColonies(game: Game) {
-    return game.colonies.filter((colony) => colony.trackPosition > colony.colonies.length && colony.isActive);
+    return game.colonies.filter(
+      (colony) =>
+        colony.trackPosition > colony.colonies.length && colony.isActive,
+    );
   }
 
   public play(player: Player) {
-    const selectColonies = new OrOptions();
-    selectColonies.title = 'Select colonies to increase and decrease tile track';
-
     const increasableColonies = this.getIncreasableColonies(player.game);
     const decreasableColonies = this.getDecreasableColonies(player.game);
-
-    increasableColonies.forEach(function(c1) {
-      decreasableColonies.forEach(function(c2) {
-        if (c1.name !== c2.name) {
-          const c1Description = COLONY_DESCRIPTIONS.get(c1.name) ?? 'unknown';
-          const c2Description = COLONY_DESCRIPTIONS.get(c2.name) ?? 'unknown';
-          const description = 'Increase ' + c1.name + ' (' + c1Description + ') and decrease ' + c2.name + ' (' + c2Description + ')';
-          const colonySelect = new SelectOption(
-            description,
-            'Select',
-            () => {
-              c1.increaseTrack();
-              c2.decreaseTrack();
-              player.game.log('${0} increased ${1} track and decreased ${2} track', (b) => b.player(player).string(c1.name).string(c2.name));
-              return undefined;
-            },
-          );
-
-          selectColonies.options.push(colonySelect);
-        }
-      });
-    });
-
-    return selectColonies;
+    const increaseColonyTrack = new SelectColony(
+      'Select which colony tile track to increase',
+      'Increase',
+      increasableColonies,
+      (colony: IColony) => {
+        console.log(colony);
+        colony.increaseTrack();
+        return undefined;
+      },
+    );
+    const decreaseColonyTrack = new SelectColony(
+      'Select which colony tile track to decrease',
+      'Decrease',
+      decreasableColonies,
+      (colony: IColony) => {
+        console.log(colony);
+        colony.decreaseTrack();
+        return undefined;
+      },
+    );
+    player.game.defer(
+      new SimpleDeferredAction(player, () => increaseColonyTrack),
+    );
+    player.game.defer(
+      new SimpleDeferredAction(player, () => decreaseColonyTrack),
+    );
+    return undefined;
   }
 }

--- a/tests/cards/colonies/MarketManipulation.spec.ts
+++ b/tests/cards/colonies/MarketManipulation.spec.ts
@@ -1,44 +1,55 @@
+import {SelectColony} from './../../../src/inputs/SelectColony';
 import {expect} from 'chai';
+import {getTestPlayer, newTestGame} from '../../TestGame';
 import {Pets} from '../../../src/cards/base/Pets';
 import {MarketManipulation} from '../../../src/cards/colonies/MarketManipulation';
 import {Enceladus} from '../../../src/colonies/Enceladus';
 import {Luna} from '../../../src/colonies/Luna';
 import {Miranda} from '../../../src/colonies/Miranda';
-import {Triton} from '../../../src/colonies/Triton';
 import {Game} from '../../../src/Game';
-import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Player} from '../../../src/Player';
-import {TestPlayers} from '../../TestPlayers';
+import {ColonyName} from '../../../src/common/colonies/ColonyName';
 
 describe('MarketManipulation', function() {
-  let card : MarketManipulation; let player : Player; let player2: Player; let luna: Luna;
+  let card : MarketManipulation;
+  let player : Player;
+  let game: Game;
 
   beforeEach(function() {
     card = new MarketManipulation();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
-    Game.newInstance('foobar', [player, player2], player);
-    luna = new Luna();
+    game = newTestGame(2, {
+      coloniesExtension: true,
+      customColoniesList: [
+        ColonyName.GANYMEDE,
+        ColonyName.LUNA,
+        ColonyName.PLUTO,
+        ColonyName.CALLISTO,
+        ColonyName.EUROPA],
+    });
+    player = getTestPlayer(game, 0);
   });
 
   it('Should play', function() {
-    const triton = new Triton();
-    player.game.colonies.push(luna, triton);
+    card.play(player);
+    const increaseColonyAction = game.deferredActions.pop()!.execute() as SelectColony;
+    increaseColonyAction.cb(increaseColonyAction.colonies[0]);
+    expect(game.colonies[0].trackPosition).to.eq(2);
+    expect(game.colonies[1].trackPosition).to.eq(1);
+    expect(game.colonies[2].trackPosition).to.eq(1);
 
-    const action = card.play(player) as OrOptions;
-    expect(action).is.not.undefined;
-    expect(action.options[0].title).to.eq('Increase Luna (MegaCredits) and decrease Triton (Titanium)');
-    action.options[0].cb();
-
-    expect(luna.trackPosition).to.eq(2);
-    expect(triton.trackPosition).to.eq(0);
+    const decreaseColonyAction = game.deferredActions.pop()!.execute() as SelectColony;
+    decreaseColonyAction.cb(increaseColonyAction.colonies[1]);
+    expect(game.colonies[0].trackPosition).to.eq(2);
+    expect(game.colonies[1].trackPosition).to.eq(0);
+    expect(game.colonies[2].trackPosition).to.eq(1);
   });
 
   it('Can\'t play', function() {
     const enceladus = new Enceladus();
     const miranda = new Miranda();
+    const luna = new Luna();
 
-    player.game.colonies.push(enceladus, miranda, luna);
+    player.game.colonies = [enceladus, miranda, luna];
     player.game.gameOptions.coloniesExtension = true;
     expect(card.canPlay(player)).is.not.true;
 

--- a/tests/cards/colonies/MarketManipulation.spec.ts
+++ b/tests/cards/colonies/MarketManipulation.spec.ts
@@ -6,6 +6,9 @@ import {MarketManipulation} from '../../../src/cards/colonies/MarketManipulation
 import {Enceladus} from '../../../src/colonies/Enceladus';
 import {Luna} from '../../../src/colonies/Luna';
 import {Miranda} from '../../../src/colonies/Miranda';
+import {Europa} from './../../../src/colonies/Europa';
+import {Pluto} from '../../../src/colonies/Pluto';
+import {Callisto} from '../../../src/colonies/Callisto';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {ColonyName} from '../../../src/common/colonies/ColonyName';
@@ -42,6 +45,33 @@ describe('MarketManipulation', function() {
     expect(game.colonies[0].trackPosition).to.eq(2);
     expect(game.colonies[1].trackPosition).to.eq(0);
     expect(game.colonies[2].trackPosition).to.eq(1);
+  });
+
+  it('Should not allow increase of sole decreasable colony', function() {
+    const pluto = new Pluto();
+    pluto.trackPosition = 0;
+    const callisto = new Callisto();
+    callisto.trackPosition = 0;
+    const europa = new Europa();
+    europa.trackPosition = 1;
+
+    player.game.colonies = [pluto, callisto, europa];
+    player.game.gameOptions.coloniesExtension = true;
+    card.play(player);
+    const increaseColonyAction = game.deferredActions.pop()!.execute() as SelectColony;
+    expect(increaseColonyAction.colonies.length).to.eq(2);
+
+    increaseColonyAction.cb(increaseColonyAction.colonies[0]);
+    expect(game.colonies[0].trackPosition).to.eq(1);
+    expect(game.colonies[1].trackPosition).to.eq(0);
+    expect(game.colonies[2].trackPosition).to.eq(1);
+
+    const decreaseColonyAction = game.deferredActions.pop()!.execute() as SelectColony;
+    expect(decreaseColonyAction.colonies.length).to.eq(1);
+    decreaseColonyAction.cb(decreaseColonyAction.colonies[0]);
+    expect(game.colonies[0].trackPosition).to.eq(1);
+    expect(game.colonies[1].trackPosition).to.eq(0);
+    expect(game.colonies[2].trackPosition).to.eq(0);
   });
 
   it('Can\'t play', function() {


### PR DESCRIPTION
Prompt the user using the `SelectColony` input instead of the checkbox text options.

Issue https://github.com/terraforming-mars/terraforming-mars/issues/4541


Before: 
<img width="769" alt="Screen Shot 2022-06-07 at 1 24 24 AM" src="https://user-images.githubusercontent.com/42753529/172467472-77d59663-7593-4222-889f-2694c0cb1d17.png">

After: Prompts the user to select which colony to increase, then which colony to decrease.
<img width="1352" alt="Screen Shot 2022-06-07 at 12 51 54 AM" src="https://user-images.githubusercontent.com/42753529/172467461-7d9221ed-a14a-462c-a17c-52ff4acb76b9.png">

<img width="1372" alt="Screen Shot 2022-06-07 at 12 52 01 AM" src="https://user-images.githubusercontent.com/42753529/172467474-1f9f96a1-32f1-4f36-8ba9-be505c3dba60.png">
