### PR TITLE
Make getPlayerCount async

### DIFF
--- a/src/database/IDatabase.ts
+++ b/src/database/IDatabase.ts
@@ -79,10 +79,8 @@ export interface IDatabase {
      * Get the player count for a game.
      *
      * @param game_id the game id to search for
-     * @param cb a callback either returning either an error or the game's player count.
-     * if the game is not found then undefined.
      */
-    getPlayerCount(game_id: GameId, cb: (err: Error | undefined, playerCount: number | undefined) => void): void;
+    getPlayerCount(game_id: GameId): Promise<number>;
 
     /**
      * Saves the current state of the game. at a supplied save point. Used for

--- a/src/database/LocalFilesystem.ts
+++ b/src/database/LocalFilesystem.ts
@@ -77,16 +77,15 @@ export class Localfilesystem implements IDatabase {
     throw new Error('Not implemented');
   }
 
-  getPlayerCount(gameId: GameId, cb: (err: Error | undefined, playerCount: number | undefined) => void) {
-    this.getGames().then((gameIds) => {
+  getPlayerCount(gameId: GameId): Promise<number> {
+    return this.getGames().then((gameIds) => {
       const found = gameIds.find((gId) => gId === gameId && fs.existsSync(this._historyFilename(gameId, 0)));
       if (found === undefined) {
-        cb(new Error('not found'), undefined);
-        return;
+        throw new Error(`${gameId} not found`);
       }
       const text = fs.readFileSync(this._historyFilename(gameId, 0));
       const serializedGame = JSON.parse(text) as SerializedGame;
-      cb(new Error('not found'), serializedGame.players.length);
+      return serializedGame.players.length;
     });
   }
 

--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -51,21 +51,16 @@ export class PostgreSQL implements IDatabase {
       });
   }
 
-  getPlayerCount(game_id: GameId, cb: (err: Error | undefined, playerCount: number | undefined) => void) {
+  getPlayerCount(game_id: GameId): Promise<number> {
     const sql = 'SELECT players FROM games WHERE save_id = 0 AND game_id = $1 LIMIT 1';
 
-    this.client.query(sql, [game_id], (err, res) => {
-      if (err) {
-        console.error('PostgreSQL:getPlayerCount', err);
-        cb(err, undefined);
-        return;
-      }
-      if (res.rows.length === 0) {
-        cb(undefined, undefined);
-        return;
-      }
-      cb(undefined, res.rows[0].players);
-    });
+    return this.client.query(sql, [game_id])
+      .then((res) => {
+        if (res.rows.length === 0) {
+          throw new Error(`no rows found for game id ${game_id}`);
+        }
+        return res.rows[0].players;
+      });
   }
 
   getGames(): Promise<Array<GameId>> {

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -54,17 +54,19 @@ export class SQLite implements IDatabase {
     });
   }
 
-  getPlayerCount(gameId: GameId, cb: (err: Error | undefined, playerCount: number | undefined) => void) {
-    const sql = 'SELECT players FROM games WHERE save_id = 0 AND game_id = ? LIMIT 1';
+  getPlayerCount(gameId: GameId): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const sql = 'SELECT players FROM games WHERE save_id = 0 AND game_id = ? LIMIT 1';
 
-    this.db.get(sql, [gameId], (err, row) => {
-      if (err) {
-        cb(err, undefined);
-      } else if (row) {
-        cb(undefined, row.players);
-      } else {
-        cb(undefined, undefined);
-      }
+      this.db.get(sql, [gameId], (err, row) => {
+        if (err) {
+          reject(err);
+        } else if (row) {
+          resolve(row.players);
+        } else {
+          reject(new Error(`unknown error loadign player count for ${gameId}`));
+        }
+      });
     });
   }
 

--- a/src/routes/ApiCloneableGame.ts
+++ b/src/routes/ApiCloneableGame.ts
@@ -1,31 +1,27 @@
 import * as http from 'http';
-import {Handler} from './Handler';
+import {AsyncHandler} from './Handler';
 import {IContext} from './IHandler';
 import {Database} from '../database/Database';
 
-export class ApiCloneableGame extends Handler {
+export class ApiCloneableGame extends AsyncHandler {
   public static readonly INSTANCE = new ApiCloneableGame();
   private constructor() {
     super();
   }
 
-  public override get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
+  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): Promise<void> {
     const gameId = ctx.url.searchParams.get('id');
     if (!gameId) {
       ctx.route.badRequest(req, res, 'id parameter missing');
       return;
     }
-    Database.getInstance().getPlayerCount(gameId, function(err, playerCount) {
-      if (err) {
+    await Database.getInstance().getPlayerCount(gameId)
+      .then((playerCount) => {
+        ctx.route.writeJson(res, {gameId, playerCount});
+      })
+      .catch((err) => {
         console.warn('Could not load cloneable game: ', err);
-        ctx.route.internalServerError(req, res, err);
-        return;
-      }
-      if (playerCount === undefined) {
         ctx.route.notFound(req, res);
-        return;
-      }
-      ctx.route.writeJson(res, {gameId, playerCount});
-    });
+      });
   }
 }

--- a/src/routes/Handler.ts
+++ b/src/routes/Handler.ts
@@ -44,13 +44,28 @@ export abstract class Handler implements IHandler {
     }
   }
 
-  get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
+  get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void | Promise<void> {
     ctx.route.notFound(req, res);
   }
-  put(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
+  put(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void | Promise<void> {
     ctx.route.notFound(req, res);
   }
-  post(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
+  post(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void | Promise<void> {
     ctx.route.notFound(req, res);
+  }
+}
+
+export abstract class AsyncHandler extends Handler {
+  public override get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): Promise<void> {
+    ctx.route.notFound(req, res);
+    return Promise.resolve();
+  }
+  public override put(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): Promise<void> {
+    ctx.route.notFound(req, res);
+    return Promise.resolve();
+  }
+  public override post(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): Promise<void> {
+    ctx.route.notFound(req, res);
+    return Promise.resolve();
   }
 }

--- a/tests/integration/PostgreSQL.spec.ts
+++ b/tests/integration/PostgreSQL.spec.ts
@@ -6,8 +6,7 @@ use(chaiAsPromised);
 import {Game} from '../../src/Game';
 import {TestPlayers} from '../TestPlayers';
 import {PostgreSQL} from '../../src/database/PostgreSQL';
-import {Database} from '../../src/database/Database';
-import {restoreTestDatabase} from '../utils/setup';
+import {restoreTestDatabase, setTestDatabase} from '../utils/setup';
 import {sleep} from '../TestingUtils';
 
 /*
@@ -51,7 +50,7 @@ describe('PostgreSQL', () => {
 
   beforeEach(async () => {
     db = new TestPostgreSQL();
-    Database.getInstance = () => db;
+    setTestDatabase(db);
     await db.initialize();
   });
 
@@ -107,10 +106,7 @@ describe('PostgreSQL', () => {
     await db.saveGamePromise;
     expect(game.lastSaveId).eq(1);
 
-    db.getPlayerCount(game.id, (err, playerCount) => {
-      expect(err).to.be.undefined;
-      expect(playerCount).to.eq(1);
-    });
+    expect(db.getPlayerCount(game.id)).become(1);
   });
 
   it('does not find player count for game by id', async () => {
@@ -119,10 +115,7 @@ describe('PostgreSQL', () => {
     await db.saveGamePromise;
     expect(game.lastSaveId).eq(1);
 
-    db.getPlayerCount('notfound', (err, playerCount) => {
-      expect(err).to.be.undefined;
-      expect(playerCount).to.be.undefined;
-    });
+    expect(db.getPlayerCount('notfound')).is.rejected;
   });
 
   it('cleanSaves', async () => {

--- a/tests/routes/ApiCloneableGame.spec.ts
+++ b/tests/routes/ApiCloneableGame.spec.ts
@@ -7,15 +7,16 @@ import {RouteTestScaffolding} from './RouteTestScaffolding';
 describe('ApiCloneableGame', () => {
   let scaffolding: RouteTestScaffolding;
   let res: MockResponse;
-  const origgetPlayerCount = Database.getInstance().getPlayerCount;
+  let originalGetPlayerCount: (gameId: string) => Promise<number>;
 
   beforeEach(() => {
     scaffolding = new RouteTestScaffolding();
     res = new MockResponse();
+    originalGetPlayerCount = Database.getInstance().getPlayerCount;
   });
 
   afterEach(() => {
-    Database.getInstance().getPlayerCount = origgetPlayerCount;
+    Database.getInstance().getPlayerCount = originalGetPlayerCount;
   });
 
   it('no parameter', () => {
@@ -25,34 +26,22 @@ describe('ApiCloneableGame', () => {
     expect(res.content).eq('Bad request: id parameter missing');
   });
 
-  it('has error while loading', () => {
-    Database.getInstance().getPlayerCount = (gameId, cb) => {
-      expect(gameId).eq('invalidId');
-      cb(new Error('Segmentation fault'), undefined);
+  it('has error while loading', async () => {
+    Database.getInstance().getPlayerCount = (_gameId) => {
+      return new Promise((_resolve, reject) => {
+        reject(new Error('Segmentation fault'));
+      });
     };
     scaffolding.url = '/api/cloneablegames?id=invalidId';
-    scaffolding.get(ApiCloneableGame.INSTANCE, res);
-    expect(res.statusCode).eq(500);
-    expect(res.content).eq('Internal server error: Segmentation fault');
-  });
-
-  it('does not find game', () => {
-    Database.getInstance().getPlayerCount = (gameId, cb) => {
-      expect(gameId).eq('notfound');
-      cb(undefined, undefined);
-    };
-    scaffolding.url = '/api/cloneablegames?id=notfound';
-    scaffolding.get(ApiCloneableGame.INSTANCE, res);
+    await scaffolding.asyncGet(ApiCloneableGame.INSTANCE, res);
     expect(res.statusCode).eq(404);
     expect(res.content).eq('Not found');
   });
 
-  it('finds game', () => {
-    Database.getInstance().getPlayerCount = (_gameId, cb) => {
-      cb(undefined, 2);
-    };
+  it('finds game', async () => {
+    Database.getInstance().getPlayerCount = (_gameId) => Promise.resolve(2);
     scaffolding.url = '/api/cloneablegames?id=g456';
-    scaffolding.get(ApiCloneableGame.INSTANCE, res);
+    await scaffolding.asyncGet(ApiCloneableGame.INSTANCE, res);
     expect(res.statusCode).eq(200);
     expect(res.content).eq(JSON.stringify({
       gameId: 'g456',

--- a/tests/routes/RouteTestScaffolding.ts
+++ b/tests/routes/RouteTestScaffolding.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import {IContext} from '../../src/routes/IHandler';
-import {Handler} from '../../src/routes/Handler';
+import {AsyncHandler, Handler} from '../../src/routes/Handler';
 import {Route} from '../../src/routes/Route';
 import {FakeGameLoader} from './FakeGameLoader';
 import {MockResponse} from './HttpMocks';
@@ -32,6 +32,10 @@ export class RouteTestScaffolding {
   public get(handler: Handler, res: MockResponse) {
     handler.get(this.req, res.hide(), this.ctx);
   }
+  public async asyncGet(handler: AsyncHandler, res: MockResponse) {
+    return handler.get(this.req, res.hide(), this.ctx);
+  }
+
   public post(handler: Handler, res: MockResponse) {
     handler.post(this.req, res.hide(), this.ctx);
   }

--- a/tests/utils/setup.ts
+++ b/tests/utils/setup.ts
@@ -5,14 +5,15 @@ import {SerializedGame} from '../../src/SerializedGame';
 const FAKE_DATABASE: IDatabase = {
   cleanSaves: () => {},
   deleteGameNbrSaves: () => {},
-  getPlayerCount: () => {},
+  getPlayerCount: () => Promise.resolve(0),
   getGame: () => {},
   getGameId: () => {},
   getGameVersion: () => Promise.resolve({} as SerializedGame),
   getGames: () => Promise.resolve([]),
+  getSaveIds: () => Promise.resolve([]),
   initialize: () => Promise.resolve(),
   restoreGame: () => {},
-  loadCloneableGame: () => {},
+  loadCloneableGame: () => Promise.resolve({} as SerializedGame),
   saveGameResults: () => {},
   saveGame: () => Promise.resolve(),
   purgeUnfinishedGames: () => {},
@@ -22,11 +23,11 @@ const FAKE_DATABASE: IDatabase = {
 let databaseUnderTest: IDatabase = FAKE_DATABASE;
 
 export function restoreTestDatabase() {
-  databaseUnderTest = FAKE_DATABASE;
+  setTestDatabase(FAKE_DATABASE);
 }
 
-Database.getInstance = function() {
-  // don't save to database during tests
-  return databaseUnderTest;
-};
+export function setTestDatabase(db: IDatabase) {
+  databaseUnderTest = db;
+}
 
+Database.getInstance = () => databaseUnderTest;


### PR DESCRIPTION
This required a couple of external changes. For instance, introducing an
Async version of a handler, so tests could wait for results.

Also fixed an irritating issue, looks like I did a poor job of
saving and restoring the fake database test. Ha.