### PR TITLE
set solarPhaseOption on next tick to avoid watch

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -627,7 +627,7 @@ export default (Vue as WithRefs<Refs>).extend({
           component.showCardsBlackList = results['cardsBlackList'].length > 0;
 
           for (const k in results) {
-            if (['customCorporationsList', 'customColoniesList', 'cardsBlackList', 'players'].includes(k)) continue;
+            if (['customCorporationsList', 'customColoniesList', 'cardsBlackList', 'players', 'solarPhaseOption'].includes(k)) continue;
             (component as any)[k] = results[k];
           }
 
@@ -651,6 +651,9 @@ export default (Vue as WithRefs<Refs>).extend({
             if ( ! component.seededGame) {
               component.seed = Math.random();
             }
+
+            // set to alter after any watched properties
+            component.solarPhaseOption = Boolean(results.solarPhaseOption);
           });
         }
       }, false);


### PR DESCRIPTION
This was introduced with [this commit](https://github.com/terraforming-mars/terraforming-mars/commit/3bc27172efffcd48ec6d309aa7f3391d7c553d9a). When the `venusNext` option is changed this toggles `solarPhaseOption` as it is now a watched property. This changes the setting of `solarPhaseOption` to happen on the next tick to avoid the watched property modification. This closes #4511 