### PR TITLE
remove non-null assertion from GlobalEventDealer

### DIFF
--- a/src/turmoil/globalEvents/GlobalEventDealer.ts
+++ b/src/turmoil/globalEvents/GlobalEventDealer.ts
@@ -214,12 +214,23 @@ export class GlobalEventDealer {
   }
 
   public static deserialize(d: SerializedGlobalEventDealer): GlobalEventDealer {
-    const deck = d.deck.map((element: GlobalEventName) => {
-      return getGlobalEventByName(element)!;
+    const deck: Array<IGlobalEvent> = [];
+    d.deck.forEach((element: GlobalEventName) => {
+      const globalEvent = getGlobalEventByName(element);
+      if (globalEvent !== undefined) {
+        deck.push(globalEvent);
+      } else {
+        console.warn(`unable to find global event ${element} for deck while deserializing`);
+      }
     });
-
-    const discardPile = d.discarded.map((element: GlobalEventName) => {
-      return getGlobalEventByName(element)!;
+    const discardPile: Array<IGlobalEvent> = [];
+    d.discarded.forEach((element: GlobalEventName) => {
+      const globalEvent = getGlobalEventByName(element);
+      if (globalEvent !== undefined) {
+        discardPile.push(globalEvent);
+      } else {
+        console.warn(`unable to find global event ${element} for discarded while deserializing`);
+      }
     });
     return new GlobalEventDealer(deck, discardPile);
   }

--- a/src/turmoil/globalEvents/GlobalEventDealer.ts
+++ b/src/turmoil/globalEvents/GlobalEventDealer.ts
@@ -145,6 +145,7 @@ export function getGlobalEventByName(globalEventName: GlobalEventName): IGlobalE
   const Factory = ALL_EVENTS.get(globalEventName);
 
   if (Factory !== undefined) return new Factory();
+  console.warn(`unable to find global event ${globalEventName}`);
   return undefined;
 }
 
@@ -217,20 +218,12 @@ export class GlobalEventDealer {
     const deck: Array<IGlobalEvent> = [];
     d.deck.forEach((element: GlobalEventName) => {
       const globalEvent = getGlobalEventByName(element);
-      if (globalEvent !== undefined) {
-        deck.push(globalEvent);
-      } else {
-        console.warn(`unable to find global event ${element} for deck while deserializing`);
-      }
+      if (globalEvent !== undefined) deck.push(globalEvent);
     });
     const discardPile: Array<IGlobalEvent> = [];
     d.discarded.forEach((element: GlobalEventName) => {
       const globalEvent = getGlobalEventByName(element);
-      if (globalEvent !== undefined) {
-        discardPile.push(globalEvent);
-      } else {
-        console.warn(`unable to find global event ${element} for discarded while deserializing`);
-      }
+      if (globalEvent !== undefined) discardPile.push(globalEvent);
     });
     return new GlobalEventDealer(deck, discardPile);
   }


### PR DESCRIPTION
Saw non-null assertions being used in #4588 . Was surprised to see them! Then realized we didn't have a linting rule in place preventing them. Hoping to enable [no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion/). There are 20 or so places we are using these in `/src`. This removes them from the `GlobalEventDealer`.