### PR TITLE
Fix market manipulation log

### DIFF
--- a/src/cards/colonies/MarketManipulation.ts
+++ b/src/cards/colonies/MarketManipulation.ts
@@ -81,9 +81,9 @@ export class MarketManipulation extends Card implements IProjectCard {
           'Select which colony tile track to decrease',
           'Decrease',
           decreasableColonies.filter((decreaseableColony) => decreaseableColony.name !== increasedColony.name),
-          (colony: IColony) => {
-            LogHelper.logColonyTrackDecrease(player, increasedColony);
-            colony.decreaseTrack();
+          (decreasedColony: IColony) => {
+            decreasedColony.decreaseTrack();
+            LogHelper.logColonyTrackDecrease(player, decreasedColony);
             return undefined;
           },
         );


### PR DESCRIPTION
Noticed while playing the log said the same colony was increased and decreased. This was just an issue with the log. Changed variable name from `colony` to `decreasedColony` to make it more clear.