### PR TITLE
Wild tags count for Robotic Workforce.

### DIFF
--- a/src/cards/base/RoboticWorkforce.ts
+++ b/src/cards/base/RoboticWorkforce.ts
@@ -34,7 +34,7 @@ export class RoboticWorkforce extends Card implements IProjectCard {
   }
 
   private isCardApplicable(card: ICard, player: Player): boolean {
-    if (!card.tags.includes(Tags.BUILDING)) {
+    if (!card.tags.includes(Tags.BUILDING) && !card.tags.includes(Tags.WILD)) {
       return false;
     }
     if (card.name === CardName.BIOMASS_COMBUSTORS) {

--- a/tests/cards/base/RoboticWorkforce.spec.ts
+++ b/tests/cards/base/RoboticWorkforce.spec.ts
@@ -16,7 +16,7 @@ import {SelectSpace} from '../../../src/inputs/SelectSpace';
 import {Resources} from '../../../src/common/Resources';
 import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
-import {resetBoard, setCustomGameOptions, runNextAction} from '../../TestingUtils';
+import {resetBoard, setCustomGameOptions, runNextAction, cast} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 import {TileType} from '../../../src/common/TileType';
 import {ICard} from '../../../src/cards/ICard';
@@ -30,6 +30,8 @@ import {VenusGovernor} from '../../../src/cards/venusNext/VenusGovernor';
 import {CardType} from '../../../src/common/cards/CardType';
 import {ICorporationCard} from '../../../src/cards/corporation/ICorporationCard';
 import {IProjectCard} from '../../../src/cards/IProjectCard';
+import {ResearchNetwork} from '../../../src/cards/prelude/ResearchNetwork';
+import {SelectCard} from '../../../src/inputs/SelectCard';
 
 describe('RoboticWorkforce', () => {
   let card : RoboticWorkforce; let player : TestPlayer; let game : Game;
@@ -68,9 +70,8 @@ describe('RoboticWorkforce', () => {
     const noctisFarming = new NoctisFarming();
     player.playedCards.push(noctisFarming);
 
-    const action = card.play(player);
-    expect(action).is.not.undefined;
-    action!.cb([noctisFarming]);
+    const action = cast(card.play(player), SelectCard);
+    action.cb([noctisFarming]);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
   });
 
@@ -83,9 +84,8 @@ describe('RoboticWorkforce', () => {
     expect(action).is.undefined; // Not enough energy production for gyropolis, no other building card to copy
 
     player.addProduction(Resources.ENERGY, 2);
-    const selectCard = card.play(player);
-    expect(selectCard).is.not.undefined;
-    selectCard!.cb([gyropolis]);
+    const selectCard = cast(card.play(player), SelectCard);
+    selectCard.cb([gyropolis]);
     expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
   });
@@ -98,9 +98,8 @@ describe('RoboticWorkforce', () => {
     expect(action).is.undefined; // Not enough energy production
 
     player.addProduction(Resources.ENERGY, 2);
-    const selectCard = card.play(player);
-    expect(selectCard).is.not.undefined;
-    selectCard!.cb([capital]);
+    const selectCard = cast(card.play(player), SelectCard);
+    selectCard.cb([capital]);
     expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(5);
   });
@@ -114,9 +113,8 @@ describe('RoboticWorkforce', () => {
     expect(action).is.undefined; // Not enough energy production
 
     player.addProduction(Resources.ENERGY, 2);
-    const selectCard = card.play(player);
-    expect(selectCard).is.not.undefined;
-    selectCard!.cb([capitalAres]);
+    const selectCard = cast(card.play(player), SelectCard);
+    selectCard.cb([capitalAres]);
     expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(5);
   });
@@ -131,16 +129,14 @@ describe('RoboticWorkforce', () => {
     expect(solarFarmSpace.bonus.every((b) => b === SpaceBonus.PLANT)).is.true;
 
     expect(player.getProduction(Resources.ENERGY)).to.eq(0);
-    const action = solarFarm.play(player);
-    expect(action).is.not.undefined;
-    action!.cb(solarFarmSpace);
+    const action = cast(solarFarm.play(player), SelectSpace);
+    action.cb(solarFarmSpace);
     expect(player.getProduction(Resources.ENERGY)).to.eq(2);
 
     player.playedCards.push(solarFarm);
 
-    const selectCard = card.play(player);
-    expect(selectCard).is.not.undefined;
-    selectCard!.cb([solarFarm]);
+    const selectCard = cast(card.play(player), SelectCard);
+    selectCard.cb([solarFarm]);
     expect(player.getProduction(Resources.ENERGY)).to.eq(4);
   });
 
@@ -148,12 +144,11 @@ describe('RoboticWorkforce', () => {
     const corporationCard = new UtopiaInvest();
     player.corporationCard = corporationCard;
 
-    const action = card.play(player);
-    expect(action).is.not.undefined;
+    const action = cast(card.play(player), SelectCard);
 
     expect(player.getProduction(Resources.STEEL)).to.eq(0);
     expect(player.getProduction(Resources.TITANIUM)).to.eq(0);
-    action!.cb([corporationCard as any]);
+    action.cb([corporationCard as any]);
     expect(player.getProduction(Resources.STEEL)).to.eq(1);
     expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
   });
@@ -170,6 +165,17 @@ describe('RoboticWorkforce', () => {
 
     const action = card.play(player);
     expect(action).is.undefined;
+  });
+
+  it('Should work with Research Network', () => {
+    const researchNetwork = new ResearchNetwork();
+    player.playedCards.push(researchNetwork);
+    const action = cast(card.play(player), SelectCard);
+
+    expect(action.cards[0]).eq(researchNetwork);
+    expect(player.getProduction(Resources.MEGACREDITS)).to.eq(0);
+    action.cb([researchNetwork]);
+    expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
   });
 
   describe('test all cards', () => {


### PR DESCRIPTION
From FAQ:

> This card can be used to copy the Research Network prelude card to
> gain 1 MC production (by treating the Wild tag as a building tag
> for that action).