### PR TITLE
Update description of card "Declaration of Independence"

### DIFF
--- a/src/cards/pathfinders/DeclarationOfIndependence.ts
+++ b/src/cards/pathfinders/DeclarationOfIndependence.ts
@@ -23,7 +23,7 @@ export class DeclarationOfIndependence extends Card implements IProjectCard {
         cardNumber: 'Pf34',
         renderData: CardRenderer.builder((b) => b.delegates(2).asterix),
         // TODO(kberg): remove "in reserve" to work like Cultural Metropolis.
-        description: 'Have at least 6 Mars tags in play. Place 2 delegates from the reserve in 1 party.',
+        description: 'Requires that you have at least 6 Mars tags in play. Place 2 delegates from the reserve in 1 party.',
       },
     });
   }

--- a/src/locales/de/pathfinder_cards.json
+++ b/src/locales/de/pathfinder_cards.json
@@ -58,7 +58,7 @@
   "(Add 5 data to ANY card.)": "(Füge einer beliebigen Karte 5 Daten hinzu.)",
 
   "Declaration of Independence": "Unabhängigkeitserklärung",
-  "(Have at least 6 Mars tags in play. Place 2 delegates from the reserve in 1 party.)": "(Benötigt 6 eigene Marssymbole. Setze 2 Delegierte in eine beliebige Partei.)",
+  "(Requires that you have at least 6 Mars tags in play. Place 2 delegates from the reserve in 1 party.)": "(Benötigt 6 eigene Marssymbole. Setze 2 Delegierte in eine beliebige Partei.)",
 
   "Designed Organisms": "Designte Organismen",
   "(Requires 5 science tags. Increase your plant production 2 steps. Gain 3 plants. Add 3 microbes to ANY card. Add 1 animal to ANY card.)": "(Benötigt 5 eigene Wissenschaftssymbole. Erhöhe deine Pflanzen-Produktion um 2. Erhalte 3 Pflanzen. Füge einer beliebigen Karte 3 Mikroben hinzu. Füge einer beliebigen Karte 1 Tier hinzu.)",


### PR DESCRIPTION
The current text description of the card is a bit misleading.
Align it with other cards that explicitly state the requirement is based only on player's tags (such as Luna Political Institute).