### PR TITLE
Fix broken undo.

### DIFF
--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -200,6 +200,9 @@ export class PostgreSQL implements IDatabase {
     this.statistics.saveCount++;
     if (game.gameOptions.undoOption) logForUndo(game.id, 'start save', game.lastSaveId);
     try {
+      // By pre-computing the next game ID we avoid certain race conditions where
+      // saveGame is called twice in a row.
+      const nextSaveId = game.lastSaveId + 1;
       // xmax = 0 is described at https://stackoverflow.com/questions/39058213/postgresql-upsert-differentiate-inserted-and-updated-rows-using-system-columns-x
       const res = await this.client.query(
         `INSERT INTO games (game_id, save_id, game, players)
@@ -208,7 +211,7 @@ export class PostgreSQL implements IDatabase {
         RETURNING (xmax = 0) AS inserted`,
         [game.id, game.lastSaveId, gameJSON, game.getPlayers().length]);
 
-      game.lastSaveId++;
+      game.lastSaveId = nextSaveId;
 
       let inserted: boolean = true;
       try {

--- a/tests/TestPlayer.ts
+++ b/tests/TestPlayer.ts
@@ -7,8 +7,8 @@ import {InputResponse} from '../src/common/inputs/InputResponse';
 import {PlayerId} from '../src/common/Types';
 
 export class TestPlayer extends Player {
-  constructor(color: Color) {
-    super('player-' + color, color, false, 0, 'p-' + color + '-id' as PlayerId);
+  constructor(color: Color, beginner: boolean = false) {
+    super('player-' + color, color, beginner, 0, 'p-' + color + '-id' as PlayerId);
   }
 
   public setProductionForTest(units: Partial<Units>) {

--- a/tests/TestPlayers.ts
+++ b/tests/TestPlayers.ts
@@ -3,8 +3,8 @@ import {TestPlayer} from './TestPlayer';
 
 class TestPlayerFactory {
   constructor(private color: Color) {}
-  newPlayer(): TestPlayer {
-    return new TestPlayer(this.color);
+  newPlayer(beginner: boolean = false): TestPlayer {
+    return new TestPlayer(this.color, beginner);
   }
 }
 

--- a/tests/database/IDatabaseSuite.ts
+++ b/tests/database/IDatabaseSuite.ts
@@ -9,7 +9,7 @@ import {restoreTestDatabase, setTestDatabase} from '../utils/setup';
 import {IDatabase} from '../../src/database/IDatabase';
 
 export interface ITestDatabase extends IDatabase {
-  saveGamePromise: Promise<void>;
+  lastSaveGamePromise: Promise<void>;
   afterEach?: () => void;
 }
 
@@ -38,7 +38,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
     it('game is saved', async () => {
       const player = TestPlayers.BLACK.newPlayer();
       Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       const allGames = await db.getGames();
       expect(allGames).deep.eq(['game-id-1212']);
     });
@@ -46,7 +46,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
     it('getGames - removes duplicates', async () => {
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       await db.saveGame(game);
 
       const allGames = await db.getGames();
@@ -56,9 +56,9 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
     it('getGames - includes finished games', async () => {
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       Game.newInstance('game-id-2323', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
 
       await db.cleanGame(game.id);
 
@@ -69,7 +69,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
     it('saveIds', async () => {
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       expect(game.lastSaveId).eq(1);
 
       await db.saveGame(game);
@@ -83,7 +83,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
     it('cleanGame', async () => {
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       expect(game.lastSaveId).eq(1);
 
       await db.saveGame(game);
@@ -101,7 +101,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
     it('gets player count', async () => {
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       expect(game.lastSaveId).eq(1);
 
       expect(db.getPlayerCount(game.id)).become(1);
@@ -110,7 +110,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
     it('does not find player count by id', async () => {
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       expect(game.lastSaveId).eq(1);
 
       expect(db.getPlayerCount('g-notfound')).is.rejected;
@@ -120,7 +120,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
       it('purgeUnfinishedGames', async () => {
         const player = TestPlayers.BLACK.newPlayer();
         const game = Game.newInstance('game-id-1212', [player], player);
-        await db.saveGamePromise;
+        await db.lastSaveGamePromise;
         expect(game.lastSaveId).eq(1);
 
         await db.saveGame(game);
@@ -141,7 +141,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
     it('getGameVersion', async () => {
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       expect(game.lastSaveId).eq(1);
 
       player.megaCredits = 200;
@@ -174,7 +174,7 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
 
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-123', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
       const serialized = await db.loadCloneableGame('game-id-123');
 
       expect(game.id).eq(serialized.id);

--- a/tests/database/SQLite.spec.ts
+++ b/tests/database/SQLite.spec.ts
@@ -3,7 +3,7 @@ import {Game} from '../../src/Game';
 import {IN_MEMORY_SQLITE_PATH, SQLite} from '../../src/database/SQLite';
 
 class TestSQLite extends SQLite implements ITestDatabase {
-  public saveGamePromise: Promise<void> = Promise.resolve();
+  public lastSaveGamePromise: Promise<void> = Promise.resolve();
 
   constructor() {
     super(IN_MEMORY_SQLITE_PATH, true);
@@ -14,8 +14,8 @@ class TestSQLite extends SQLite implements ITestDatabase {
   }
 
   public override saveGame(game: Game): Promise<void> {
-    this.saveGamePromise = super.saveGame(game);
-    return this.saveGamePromise;
+    this.lastSaveGamePromise = super.saveGame(game);
+    return this.lastSaveGamePromise;
   }
 }
 

--- a/tests/integration/PostgreSQL.spec.ts
+++ b/tests/integration/PostgreSQL.spec.ts
@@ -4,13 +4,18 @@ import {ITestDatabase, describeDatabaseSuite} from '../database/IDatabaseSuite';
 import {Game} from '../../src/Game';
 import {PostgreSQL} from '../../src/database/PostgreSQL';
 import {TestPlayers} from '../TestPlayers';
+import {SelectOption} from '../../src/inputs/SelectOption';
+import {Phase} from '../../src/common/Phase';
+import {setCustomGameOptions} from '../TestingUtils';
+import {Player} from '../../src/Player';
 
 /*
  * This test can be run with `npm run test:integration` as long as the test is set up
  * correctly.
  */
 class TestPostgreSQL extends PostgreSQL implements ITestDatabase {
-  public saveGamePromise: Promise<void> = Promise.resolve();
+  public lastSaveGamePromise: Promise<void> = Promise.resolve();
+  public readonly promises: Array<Promise<void>> = [];
 
   constructor() {
     super({
@@ -22,12 +27,13 @@ class TestPostgreSQL extends PostgreSQL implements ITestDatabase {
   }
 
   // Tests can wait for saveGamePromise since save() is called inside other methods.
-  public override saveGame(game: Game): Promise<void> {
-    this.saveGamePromise = super.saveGame(game);
-    return this.saveGamePromise;
+  public override async saveGame(game: Game): Promise<void> {
+    this.lastSaveGamePromise = super.saveGame(game);
+    this.promises.push(this.lastSaveGamePromise);
+    return this.lastSaveGamePromise;
   }
 
-  public override async stats() {
+  public override async stats(): Promise<{[key: string]: string | number}> {
     const response = await super.stats();
     response['size-bytes-games'] = 'any';
     response['size-bytes-game-results'] = 'any';
@@ -71,7 +77,7 @@ describeDatabaseSuite({
       const db = dbFunction() as TestPostgreSQL;
       const player = TestPlayers.BLACK.newPlayer();
       const game = Game.newInstance('game-id-1212', [player], player);
-      await db.saveGamePromise;
+      await db.lastSaveGamePromise;
 
       await db.saveGame(game);
       await db.saveGame(game);
@@ -95,6 +101,80 @@ describeDatabaseSuite({
       // Loading v3 shows that it has the revised value of megacredits.
       const newSerializedv3 = await db.getGameVersion(game.id, 3);
       expect(newSerializedv3.players[0].megaCredits).eq(77);
+      expect(game.lastSaveId).eq(4);
+    });
+
+    it('test save id count with undo', async () => {
+      async function awaitAllSaves() {
+        await Promise.all(db.promises);
+        db.promises.length = 0;
+      }
+
+      const db = dbFunction() as TestPostgreSQL;
+      const player = TestPlayers.BLACK.newPlayer(/** beginner */ true);
+      const player2 = TestPlayers.RED.newPlayer(/** beginner */ true);
+      const game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({draftVariant: false, undoOption: true}));
+      await awaitAllSaves();
+
+      async function getStat(field: string): Promise<string | number> {
+        return (await db.stats())[field];
+      }
+      expect(await getStat('save-count')).eq(1);
+      expect(await db.getSaveIds(game.id)).deep.eq([0]);
+
+      game.playerIsFinishedWithResearchPhase(player);
+      game.playerIsFinishedWithResearchPhase(player2);
+      expect(game.phase).eq(Phase.ACTION);
+
+      await awaitAllSaves();
+      expect(await getStat('save-count')).eq(2);
+      expect(await db.getSaveIds(game.id)).deep.eq([0, 1]);
+
+      // Creating a very simple waitingFor that does nothing.
+      const simpleOption = new SelectOption('', '', () => undefined);
+
+      function takeAction(p: Player) {
+        // Player.takeAction sets waitingFor and waitingForCb. This overrides it
+        // with our own simple option, and then mimics the waitingForCb behavior at
+        // the end of Player.takeAction
+        p.setWaitingFor(simpleOption, () => {
+          (p as any).incrementActionsTaken();
+          p.takeAction();
+        });
+      }
+
+      expect(game.activePlayer).eq(player.id);
+      expect(player.actionsTakenThisRound).eq(0);
+
+      // Player's first action
+      takeAction(player);
+      player.process([]);
+      await awaitAllSaves();
+
+      expect(await getStat('save-count')).eq(3);
+      expect(await db.getSaveIds(game.id)).deep.eq([0, 1, 2]);
+      expect(game.activePlayer).eq(player.id);
+      expect(player.actionsTakenThisRound).eq(1);
+
+      // This stat reports whether a game with undo enabled updates instead of inserts.
+      expect(await getStat('save-confict-undo-count')).eq(0);
+
+      // Player's second action
+      takeAction(player);
+      player.process([]);
+      await awaitAllSaves();
+
+      // Notice how save-count went from 3 to 5. It saved twice.
+      expect(await getStat('save-count')).eq(5);
+      // That's because one of them is an update instead of an insert.
+      expect(await getStat('save-confict-undo-count')).eq(1);
+
+      expect(await db.getSaveIds(game.id)).deep.eq([0, 1, 2, 3]);
+      expect(game.activePlayer).eq(player2.id);
+      expect(player.actionsTakenThisRound).eq(0);
+
+      // Of all the steps in this test, this is the one which will verify the broken undo
+      // is repaired correctly. When it was broken, this was 5.
       expect(game.lastSaveId).eq(4);
     });
   },


### PR DESCRIPTION
The broken behavior* is due to the fact that when the server switches between players it saves -- twice. Isn't that strange? It's how it works. While that should be fixed, it's how it works.

If the app saved twice by saving from id 3 to 4, and then 4 to 5, that would be great, but it's not what it was doing. It was saving v3, and then saving as v3 again. Because save() also updates, this isn't a real problem.

The problem is that both times, it increments `game.lastSaveId`, so during the first save it saves v3 and bumps `game.lastSaveId` from 3 to 4, and during the second save it saves v3 and bumps `game.lastSaveId` from 4 to 5.

This repair ensures that no matter what version the server expects to save, it bumps `game.lastSaveId` to the number above it.

This is verified in the test with one of the last lines in the new test. With old behavior, this test fails. I checked it.

What does all of this have to do with undo? Well, without trying to describe it, basically, the database has versions 0,1,2,3, but
`game.lastSaveId` is 5, and then the server tries to load `game.lastSaveId - 1`.

There you go.