### PR TITLE
Restore loading order when getting game IDs.

### DIFF
--- a/src/database/IDatabase.ts
+++ b/src/database/IDatabase.ts
@@ -67,6 +67,10 @@ export interface IDatabase {
 
     /**
      * Return a list of all `game_id`s.
+     *
+     * When the server starts games will be loaded from first to last. The postgres implmentation
+     * speeds up loading by sorting game ids so games most recently updated are loaded first, thereby
+     * being available sooner than other games.
      */
     getGames(): Promise<Array<GameId>>;
 

--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -59,7 +59,15 @@ export class PostgreSQL implements IDatabase {
   }
 
   public async getGames(): Promise<Array<GameId>> {
-    const sql: string = 'SELECT distinct game_id FROM games';
+    const sql: string =
+    `SELECT games.game_id
+    FROM games, (
+      SELECT max(save_id) save_id, game_id
+      FROM games
+      GROUP BY game_id) a
+    WHERE games.game_id = a.game_id
+    AND games.save_id = a.save_id
+    ORDER BY created_time DESC`;
     const res = await this.client.query(sql);
     return res.rows.map((row) => row.game_id);
   }

--- a/tests/database/IDatabaseSuite.ts
+++ b/tests/database/IDatabaseSuite.ts
@@ -10,7 +10,7 @@ import {IDatabase} from '../../src/database/IDatabase';
 
 export interface ITestDatabase extends IDatabase {
   lastSaveGamePromise: Promise<void>;
-  afterEach?: () => void;
+  afterEach?: () => Promise<void>;
 }
 
 export type DatabaseTestDescriptor = {
@@ -30,9 +30,9 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
       return db.initialize();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       restoreTestDatabase();
-      return db.afterEach?.();
+      await db.afterEach?.();
     });
 
     it('game is saved', async () => {
@@ -62,8 +62,8 @@ export function describeDatabaseSuite(dtor: DatabaseTestDescriptor) {
 
       await db.cleanGame(game.id);
 
-      const allGames = await db.getGames();
-      expect(allGames).deep.eq(['game-id-1212', 'game-id-2323']);
+      const allGameIds = await db.getGames();
+      expect(allGameIds).has.members(['game-id-1212', 'game-id-2323']);
     });
 
     it('saveIds', async () => {


### PR DESCRIPTION
This behavior causes startup to be very very slow for games
played during a restart.