### PR TITLE
add linting rule require-await

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'rules': {
+    'require-await': 'error',
+  }
+};

--- a/src/database/GameIds.ts
+++ b/src/database/GameIds.ts
@@ -23,7 +23,7 @@ export class GameIds extends EventEmitter {
     }
   }
 
-  private async getAllInstances(allGameIds: Array<GameId>) : Promise<void[]> {
+  private getAllInstances(allGameIds: Array<GameId>) : Promise<void[]> {
     return Promise.all(allGameIds.map((x) => {
       return this.getInstance(x);
     }));

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -223,7 +223,7 @@ export class SQLite implements IDatabase {
     });
   }
 
-  async purgeUnfinishedGames(maxGameDays: string | undefined = process.env.MAX_GAME_DAYS): Promise<void> {
+  purgeUnfinishedGames(maxGameDays: string | undefined = process.env.MAX_GAME_DAYS): Promise<void> {
     // Purge unfinished games older than MAX_GAME_DAYS days. If this .env variable is not present, unfinished games will not be purged.
     if (maxGameDays) {
       const dateToSeconds = daysAgoToSeconds(maxGameDays, 0);
@@ -233,7 +233,7 @@ export class SQLite implements IDatabase {
     }
   }
 
-  async restoreGame(game_id: GameId, save_id: number): Promise<SerializedGame> {
+  restoreGame(game_id: GameId, save_id: number): Promise<SerializedGame> {
     return new Promise((resolve, reject) => {
       // Retrieve last save from database
       this.db.get('SELECT game game FROM games WHERE game_id = ? AND save_id = ? ORDER BY save_id DESC LIMIT 1', [game_id, save_id], (err: Error | null, row: { game: any; }) => {

--- a/src/routes/PlayerInput.ts
+++ b/src/routes/PlayerInput.ts
@@ -75,7 +75,7 @@ export class PlayerInput extends AsyncHandler {
   ): Promise<void> {
     return new Promise((resolve) => {
       let body = '';
-      req.on('data', async (data) => {
+      req.on('data', (data) => {
         body += data.toString();
       });
       req.once('end', async () => {


### PR DESCRIPTION
Adding the [require-await](https://eslint.org/docs/latest/rules/require-await) lint rule. This rule can help developers new to async and await. Also useful during refactors to catch usages that become unnecessary.