### PR TITLE
increase checks if card is playable

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -500,8 +500,8 @@ export class Game {
   }
 
   public marsIsTerraformed(): boolean {
-    const oxygenMaxed = this.oxygenLevel >= constants.MAX_OXYGEN_LEVEL;
-    const temperatureMaxed = this.temperature >= constants.MAX_TEMPERATURE;
+    const oxygenMaxed = !this.canIncreaseOxygenLevel();
+    const temperatureMaxed = !this.canIncreaseTemperature();
     const oceansMaxed = !this.canAddOcean();
     let globalParametersMaxed = oxygenMaxed && temperatureMaxed && oceansMaxed;
     const venusMaxed = this.getVenusScaleLevel() === constants.MAX_VENUS_SCALE;
@@ -1113,8 +1113,12 @@ export class Game {
     player.takeAction();
   }
 
+  public canIncreaseOxygenLevel(): boolean {
+    return this.oxygenLevel < constants.MAX_OXYGEN_LEVEL;
+  }
+
   public increaseOxygenLevel(player: Player, increments: -2 | -1 | 1 | 2): undefined {
-    if (this.oxygenLevel >= constants.MAX_OXYGEN_LEVEL) {
+    if (!this.canIncreaseOxygenLevel()) {
       return undefined;
     }
 
@@ -1198,8 +1202,12 @@ export class Game {
     return this.venusScaleLevel;
   }
 
+  public canIncreaseTemperature(): boolean {
+    return this.temperature < constants.MAX_TEMPERATURE;
+  }
+
   public increaseTemperature(player: Player, increments: -2 | -1 | 1 | 2 | 3): undefined {
-    if (this.temperature >= constants.MAX_TEMPERATURE) {
+    if (!this.canIncreaseTemperature()) {
       return undefined;
     }
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1085,7 +1085,7 @@ export class Player {
     action.title = 'Select action for World Government Terraforming';
     action.buttonLabel = 'Confirm';
     const game = this.game;
-    if (game.getTemperature() < constants.MAX_TEMPERATURE) {
+    if (game.canIncreaseTemperature()) {
       action.options.push(
         new SelectOption('Increase temperature', 'Increase', () => {
           game.increaseTemperature(this, 1);
@@ -1094,7 +1094,7 @@ export class Player {
         }),
       );
     }
-    if (game.getOxygenLevel() < constants.MAX_OXYGEN_LEVEL) {
+    if (game.canIncreaseOxygenLevel()) {
       action.options.push(
         new SelectOption('Increase oxygen', 'Increase', () => {
           game.increaseOxygenLevel(this, 1);

--- a/src/cards/base/AquiferPumping.ts
+++ b/src/cards/base/AquiferPumping.ts
@@ -31,7 +31,8 @@ export class AquiferPumping extends Card implements IActionCard, IProjectCard {
     return undefined;
   }
   public canAct(player: Player): boolean {
-    return player.canAfford(OCEAN_COST, {steel: true, tr: {oceans: 1}});
+    return player.canAfford(OCEAN_COST, {steel: true, tr: {oceans: 1}}) &&
+             player.game.canAddOcean();
   }
   public action(player: Player) {
     player.game.defer(new SelectHowToPayDeferred(player, 8, {canUseSteel: true, title: 'Select how to pay for action', afterPay: () => {

--- a/src/cards/base/GHGProducingBacteria.ts
+++ b/src/cards/base/GHGProducingBacteria.ts
@@ -47,7 +47,7 @@ export class GHGProducingBacteria extends Card implements IActionCard, IProjectC
     return true;
   }
   public action(player: Player) {
-    if (this.resourceCount < 2) {
+    if (this.resourceCount < 2 || !player.game.canIncreaseTemperature()) {
       player.addResourceTo(this, {log: true});
       return undefined;
     }

--- a/src/cards/base/RegolithEaters.ts
+++ b/src/cards/base/RegolithEaters.ts
@@ -44,7 +44,7 @@ export class RegolithEaters extends Card implements IActionCard, IProjectCard, I
     return true;
   }
   public action(player: Player) {
-    if (this.resourceCount < 2) {
+    if (this.resourceCount < 2 || !player.game.canIncreaseOxygenLevel()) {
       player.addResourceTo(this, {log: true});
       return undefined;
     }

--- a/src/cards/base/WaterImportFromEuropa.ts
+++ b/src/cards/base/WaterImportFromEuropa.ts
@@ -36,7 +36,8 @@ export class WaterImportFromEuropa extends Card implements IActionCard, IProject
     return undefined;
   }
   public canAct(player: Player): boolean {
-    return player.canAfford(ACTION_COST, {titanium: true, tr: {oceans: 1}});
+    return player.canAfford(ACTION_COST, {titanium: true, tr: {oceans: 1}}) &&
+           player.game.canAddOcean();
   }
   public action(player: Player) {
     player.game.defer(new SelectHowToPayDeferred(player, ACTION_COST, {canUseTitanium: true, title: 'Select how to pay for action', afterPay: () => {

--- a/src/cards/base/standardActions/ConvertHeat.ts
+++ b/src/cards/base/standardActions/ConvertHeat.ts
@@ -2,7 +2,7 @@ import {StandardActionCard} from '../../StandardActionCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../../render/CardRenderer';
 import {Player} from '../../../Player';
-import {HEAT_FOR_TEMPERATURE, MAX_TEMPERATURE} from '../../../common/constants';
+import {HEAT_FOR_TEMPERATURE} from '../../../common/constants';
 import {Units} from '../../../common/Units';
 
 
@@ -22,7 +22,7 @@ export class ConvertHeat extends StandardActionCard {
   }
 
   public canAct(player: Player): boolean {
-    if (player.game.getTemperature() === MAX_TEMPERATURE) {
+    if (!player.game.canIncreaseTemperature()) {
       return false;
     }
 

--- a/src/cards/base/standardProjects/AsteroidStandardProject.ts
+++ b/src/cards/base/standardProjects/AsteroidStandardProject.ts
@@ -2,7 +2,6 @@ import {Player} from '../../../Player';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../../render/CardRenderer';
 import {StandardProjectCard} from '../../StandardProjectCard';
-import * as constants from '../../../common/constants';
 
 export class AsteroidStandardProject extends StandardProjectCard {
   constructor() {
@@ -22,7 +21,7 @@ export class AsteroidStandardProject extends StandardProjectCard {
   }
 
   public override canAct(player: Player): boolean {
-    if (player.game.getTemperature() === constants.MAX_TEMPERATURE) {
+    if (!player.game.canIncreaseTemperature()) {
       return false;
     }
     return super.canAct(player);

--- a/src/cards/pathfinders/RobinHaulings.ts
+++ b/src/cards/pathfinders/RobinHaulings.ts
@@ -9,7 +9,7 @@ import {CardResource} from '../../common/CardResource';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
 import {played} from '../Options';
 import {IProjectCard} from '../IProjectCard';
-import {MAX_OXYGEN_LEVEL, MAX_VENUS_SCALE} from '../../common/constants';
+import {MAX_VENUS_SCALE} from '../../common/constants';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
 
@@ -57,7 +57,7 @@ export class RobinHaulings extends Card implements ICorporationCard {
   }
 
   private canRaiseOxygen(player: Player) {
-    return player.game.getOxygenLevel() < MAX_OXYGEN_LEVEL && player.canAfford(0, {tr: {oxygen: 1}});
+    return player.game.canIncreaseOxygenLevel() && player.canAfford(0, {tr: {oxygen: 1}});
   }
 
   public canAct(player: Player) {

--- a/src/cards/venusNext/VenusMagnetizer.ts
+++ b/src/cards/venusNext/VenusMagnetizer.ts
@@ -7,6 +7,7 @@ import {CardName} from '../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {Card} from '../Card';
+import {MAX_VENUS_SCALE} from '../../common/constants';
 
 export class VenusMagnetizer extends Card implements IActionCard {
   constructor() {
@@ -33,7 +34,9 @@ export class VenusMagnetizer extends Card implements IActionCard {
     return undefined;
   }
   public canAct(player: Player): boolean {
-    return player.getProduction(Resources.ENERGY) > 0 && player.canAfford(0, {tr: {venus: 1}});
+    return player.getProduction(Resources.ENERGY) > 0 &&
+     player.canAfford(0, {tr: {venus: 1}}) &&
+     player.game.getVenusScaleLevel() < MAX_VENUS_SCALE;
   }
   public action(player: Player) {
     player.addProduction(Resources.ENERGY, -1);


### PR DESCRIPTION
Introduces new game methods in order to check if Oxygen and temperature can be Increased.
- Use this methods where reasonable
- Added Checks for a few action cards if they can be played or if the global condition has already been maxed out.

**Detail:**
- AquiferPumping / WaterImportFromEuropa = Only available if oceans are not maxed
- GHGProducingBacteria & RegolithEaters = Do not display options if scale is maxed.
- VenusMagnetizer = Only available if venus scale is not maxed.