### PR TITLE
Fix GameIDs tests.

### DIFF
--- a/tests/utils/setup.ts
+++ b/tests/utils/setup.ts
@@ -22,7 +22,7 @@ const FAKE_DATABASE: IDatabase = {
   stats: () => Promise.resolve({}),
 
   storeParticipants: () => Promise.resolve(),
-  getParticipants: () => Promise.reject(new Error('Not used')),
+  getParticipants: () => Promise.resolve([]),
 };
 
 let databaseUnderTest: IDatabase = FAKE_DATABASE;


### PR DESCRIPTION
Actually most tests. This is generating silent errors, which aren't really meaningful, but this is more appropriate.