### PR TITLE
Don't include community's ValuableGases when playing with Prelude.

### DIFF
--- a/src/server/cards/pathfinders/PathfindersCardManifest.ts
+++ b/src/server/cards/pathfinders/PathfindersCardManifest.ts
@@ -233,6 +233,7 @@ export const PATHFINDERS_CARD_MANIFEST = new CardManifest({
   cardsToRemove: [
     CardName.VENUS_FIRST,
     CardName.RESEARCH_GRANT,
+    CardName.VALUABLE_GASES,
   ],
 });
 


### PR DESCRIPTION
Fixes #4221.