### PR TITLE
Provide Card2, bespokeCanPlay, & bespokePlay.

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1131,6 +1131,8 @@ export class Player {
     return undefined;
   }
 
+  // eslint-disable-next-line valid-jsdoc
+  /** @deprecated use Card2. */
   public simplePlay(card: IProjectCard | ICorporationCard) {
     if (card instanceof MoonCard || (card.migrated === true)) {
       if (card.productionBox !== undefined) {
@@ -1380,7 +1382,9 @@ export class Player {
     return candidateCards.filter((card) => this.canPlay(card));
   }
 
-  private canAffordCard(card: IProjectCard): boolean {
+  // TODO(kberg): After migration, see if this can become private again.
+  // Or perhaps moved into card?
+  public canAffordCard(card: IProjectCard): boolean {
     return this.canAfford(
       this.getCardCost(card),
       {
@@ -1399,8 +1403,12 @@ export class Player {
     return this.simpleCanPlay(card);
   }
 
-  // Verify if requirements for the card can be met, ignoring the project cost.
-  // Only made public for tests.
+  // eslint-disable-next-line valid-jsdoc
+  /**
+   * Verify if requirements for the card can be met, ignoring the project cost.
+   * Only made public for tests.
+   * @deprecated use Card2.
+   */
   public simpleCanPlay(card: IProjectCard): boolean {
     if (card.requirements !== undefined && !card.requirements.satisfies(this)) {
       return false;

--- a/src/server/cards/ares/BiofertilizerFacility.ts
+++ b/src/server/cards/ares/BiofertilizerFacility.ts
@@ -1,4 +1,4 @@
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {SelectSpace} from '../../inputs/SelectSpace';
 import {ISpace} from '../../boards/ISpace';
@@ -14,8 +14,7 @@ import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class BiofertilizerFacility extends Card implements IProjectCard {
-  public migrated = true;
+export class BiofertilizerFacility extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -40,7 +39,7 @@ export class BiofertilizerFacility extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.game.defer(new AddResourcesToCard(player, CardResource.MICROBE, {count: 2}));
 
     return new SelectSpace(

--- a/src/server/cards/ares/OceanCity.ts
+++ b/src/server/cards/ares/OceanCity.ts
@@ -1,4 +1,4 @@
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {SelectSpace} from '../../inputs/SelectSpace';
 import {ISpace} from '../../boards/ISpace';
@@ -10,8 +10,7 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class OceanCity extends Card implements IProjectCard {
-  public migrated = true;
+export class OceanCity extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -35,7 +34,7 @@ export class OceanCity extends Card implements IProjectCard {
   }
 
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select space for Ocean City',
       player.game.board.getOceanSpaces({upgradedOceans: false}),

--- a/src/server/cards/ares/OceanFarm.ts
+++ b/src/server/cards/ares/OceanFarm.ts
@@ -1,4 +1,4 @@
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {SelectSpace} from '../../inputs/SelectSpace';
 import {ISpace} from '../../boards/ISpace';
@@ -11,9 +11,7 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class OceanFarm extends Card implements IProjectCard {
-  public migrated = true;
-
+export class OceanFarm extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -36,7 +34,7 @@ export class OceanFarm extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select space for Ocean Farm',
       player.game.board.getOceanSpaces({upgradedOceans: false}),

--- a/src/server/cards/base/AICentral.ts
+++ b/src/server/cards/base/AICentral.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {IActionCard} from '../ICard';
@@ -8,8 +8,7 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class AICentral extends Card implements IActionCard, IProjectCard {
-  public migrated = true;
+export class AICentral extends Card2 implements IActionCard, IProjectCard {
   constructor() {
     super({
       cardType: CardType.ACTIVE,
@@ -32,9 +31,6 @@ export class AICentral extends Card implements IActionCard, IProjectCard {
         }),
       },
     });
-  }
-  public play() {
-    return undefined;
   }
   public canAct(): boolean {
     return true;

--- a/src/server/cards/base/BuildingIndustries.ts
+++ b/src/server/cards/base/BuildingIndustries.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class BuildingIndustries extends Card implements IProjectCard {
-  public migrated = true;
+export class BuildingIndustries extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -26,8 +25,5 @@ export class BuildingIndustries extends Card implements IProjectCard {
         }),
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/Capital.ts
+++ b/src/server/cards/base/Capital.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {TileType} from '../../../common/TileType';
@@ -15,8 +15,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 
-export class Capital extends Card implements IProjectCard {
-  public migrated = true;
+export class Capital extends Card2 implements IProjectCard {
   constructor(
     name: CardName = CardName.CAPITAL,
     adjacencyBonus: AdjacencyBonus | undefined = undefined,
@@ -49,7 +48,7 @@ export class Capital extends Card implements IProjectCard {
       metadata,
     });
   }
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
   public override getVictoryPoints(player: Player) {
@@ -60,7 +59,7 @@ export class Capital extends Card implements IProjectCard {
     }
     return 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select space for special city tile',
       player.game.board.getAvailableSpacesForCity(player),

--- a/src/server/cards/base/CarbonateProcessing.ts
+++ b/src/server/cards/base/CarbonateProcessing.ts
@@ -1,13 +1,11 @@
-
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class CarbonateProcessing extends Card implements IProjectCard {
-  public migrated = true;
+export class CarbonateProcessing extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -25,8 +23,5 @@ export class CarbonateProcessing extends Card implements IProjectCard {
         })),
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/CommercialDistrict.ts
+++ b/src/server/cards/base/CommercialDistrict.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {TileType} from '../../../common/TileType';
@@ -12,8 +12,7 @@ import {AdjacencyBonus} from '../../ares/AdjacencyBonus';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 
-export class CommercialDistrict extends Card implements IProjectCard {
-  public migrated = true;
+export class CommercialDistrict extends Card2 implements IProjectCard {
   constructor(
     name: CardName = CardName.COMMERCIAL_DISTRICT,
     adjacencyBonus: AdjacencyBonus | undefined = undefined,
@@ -42,7 +41,7 @@ export class CommercialDistrict extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesOnLand(player).length > 0;
   }
   public override getVictoryPoints(player: Player) {
@@ -54,7 +53,7 @@ export class CommercialDistrict extends Card implements IProjectCard {
     }
     return 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select space for special tile',
       player.game.board.getAvailableSpacesOnLand(player),

--- a/src/server/cards/base/CorporateStronghold.ts
+++ b/src/server/cards/base/CorporateStronghold.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Tag} from '../../../common/cards/Tag';
 import {SelectSpace} from '../../inputs/SelectSpace';
@@ -8,8 +8,7 @@ import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class CorporateStronghold extends Card implements IProjectCard {
-  public migrated = true;
+export class CorporateStronghold extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -31,10 +30,10 @@ export class CorporateStronghold extends Card implements IProjectCard {
       },
     });
   }
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select space for city tile',
       player.game.board.getAvailableSpacesForCity(player),

--- a/src/server/cards/base/CupolaCity.ts
+++ b/src/server/cards/base/CupolaCity.ts
@@ -1,7 +1,7 @@
 
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SelectSpace} from '../../inputs/SelectSpace';
@@ -11,8 +11,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {max} from '../Options';
 
-export class CupolaCity extends Card implements IProjectCard {
-  public migrated = true;
+export class CupolaCity extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -34,10 +33,10 @@ export class CupolaCity extends Card implements IProjectCard {
       },
     });
   }
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select a space for city tile',
       player.game.board.getAvailableSpacesForCity(player),

--- a/src/server/cards/base/DeepWellHeating.ts
+++ b/src/server/cards/base/DeepWellHeating.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class DeepWellHeating extends Card implements IProjectCard {
-  public migrated = true;
+export class DeepWellHeating extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -27,7 +26,7 @@ export class DeepWellHeating extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return player.game.increaseTemperature(player, 1);
   }
 }

--- a/src/server/cards/base/DomedCrater.ts
+++ b/src/server/cards/base/DomedCrater.ts
@@ -1,7 +1,7 @@
 
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SelectSpace} from '../../inputs/SelectSpace';
@@ -11,9 +11,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit, max} from '../Options';
 
-export class DomedCrater extends Card implements IProjectCard {
-  public migrated = true;
-
+export class DomedCrater extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -40,10 +38,10 @@ export class DomedCrater extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select space for city tile',
       player.game.board.getAvailableSpacesForCity(player),

--- a/src/server/cards/base/EOSChasmaNationalPark.ts
+++ b/src/server/cards/base/EOSChasmaNationalPark.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SelectCard} from '../../inputs/SelectCard';
@@ -9,8 +9,7 @@ import {CardResource} from '../../../common/CardResource';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class EosChasmaNationalPark extends Card implements IProjectCard {
-  public migrated = true;
+export class EosChasmaNationalPark extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -32,7 +31,7 @@ export class EosChasmaNationalPark extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     const cards = player.getResourceCards(CardResource.ANIMAL);
     player.plants += 3;
 

--- a/src/server/cards/base/ElectroCatapult.ts
+++ b/src/server/cards/base/ElectroCatapult.ts
@@ -1,7 +1,7 @@
 import {IActionCard} from '../ICard';
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {OrOptions} from '../../inputs/OrOptions';
@@ -12,8 +12,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {max} from '../Options';
 
-export class ElectroCatapult extends Card implements IActionCard, IProjectCard {
-  public migrated = true;
+export class ElectroCatapult extends Card2 implements IActionCard, IProjectCard {
   constructor() {
     super({
       cardType: CardType.ACTIVE,
@@ -67,9 +66,6 @@ export class ElectroCatapult extends Card implements IActionCard, IProjectCard {
       this.log(player, Resources.STEEL);
       player.megaCredits += 7;
     }
-    return undefined;
-  }
-  public play() {
     return undefined;
   }
 

--- a/src/server/cards/base/FoodFactory.ts
+++ b/src/server/cards/base/FoodFactory.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class FoodFactory extends Card implements IProjectCard {
-  public migrated = true;
+export class FoodFactory extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -27,8 +26,5 @@ export class FoodFactory extends Card implements IProjectCard {
         description: 'Decrease your Plant production 1 step and increase your M€ production 4 steps',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/FuelFactory.ts
+++ b/src/server/cards/base/FuelFactory.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class FuelFactory extends Card implements IProjectCard {
-  public migrated = true;
+export class FuelFactory extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -26,9 +25,5 @@ export class FuelFactory extends Card implements IProjectCard {
         description: 'Decrease your Energy production 1 step and increase your titanium and your M€ production 1 step each.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/FueledGenerators.ts
+++ b/src/server/cards/base/FueledGenerators.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class FueledGenerators extends Card implements IProjectCard {
-  public migrated = true;
+export class FueledGenerators extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -26,9 +25,5 @@ export class FueledGenerators extends Card implements IProjectCard {
         description: 'Decrease your M€ production 1 step and increase your Energy production 1 steps.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/FusionPower.ts
+++ b/src/server/cards/base/FusionPower.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class FusionPower extends Card implements IProjectCard {
-  public migrated = true;
+export class FusionPower extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -25,10 +24,6 @@ export class FusionPower extends Card implements IProjectCard {
         description: 'Requires 2 Power tags. Increase your Energy production 3 steps.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }
 

--- a/src/server/cards/base/GHGFactories.ts
+++ b/src/server/cards/base/GHGFactories.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
 
-export class GHGFactories extends Card implements IProjectCard {
-  public migrated = true;
+export class GHGFactories extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -27,8 +26,5 @@ export class GHGFactories extends Card implements IProjectCard {
         description: 'Decrease your Energy production 1 step and increase your heat production 4 steps.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/GeothermalPower.ts
+++ b/src/server/cards/base/GeothermalPower.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class GeothermalPower extends Card implements IProjectCard {
-  public migrated = true;
+export class GeothermalPower extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -21,8 +20,5 @@ export class GeothermalPower extends Card implements IProjectCard {
         description: 'Increase your energy production 2 steps.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/GreatDam.ts
+++ b/src/server/cards/base/GreatDam.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class GreatDam extends Card implements IProjectCard {
-  public migrated = true;
+export class GreatDam extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -26,9 +25,6 @@ export class GreatDam extends Card implements IProjectCard {
         description: 'Requires 4 ocean tiles. Increase your Energy production 2 steps.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }
 

--- a/src/server/cards/base/IndustrialMicrobes.ts
+++ b/src/server/cards/base/IndustrialMicrobes.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class IndustrialMicrobes extends Card implements IProjectCard {
-  public migrated = true;
+export class IndustrialMicrobes extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -23,9 +22,6 @@ export class IndustrialMicrobes extends Card implements IProjectCard {
         description: 'Increase your Energy production and your steel production 1 step each.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }
 

--- a/src/server/cards/base/MagneticFieldDome.ts
+++ b/src/server/cards/base/MagneticFieldDome.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {Player} from '../../Player';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class MagneticFieldDome extends Card implements IProjectCard {
-  public migrated = true;
+export class MagneticFieldDome extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -31,7 +30,7 @@ export class MagneticFieldDome extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.increaseTerraformRating();
     return undefined;
   }

--- a/src/server/cards/base/MagneticFieldGenerators.ts
+++ b/src/server/cards/base/MagneticFieldGenerators.ts
@@ -1,14 +1,13 @@
 import {Player} from '../../Player';
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
 
-export class MagneticFieldGenerators extends Card implements IProjectCard {
-  public migrated = true;
+export class MagneticFieldGenerators extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -32,7 +31,7 @@ export class MagneticFieldGenerators extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.increaseTerraformRatingSteps(3);
     return undefined;
   }

--- a/src/server/cards/base/Mine.ts
+++ b/src/server/cards/base/Mine.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Mine extends Card implements IProjectCard {
-  public migrated = true;
+export class Mine extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -21,9 +20,5 @@ export class Mine extends Card implements IProjectCard {
         renderData: CardRenderer.builder((b) => b.production((pb) => pb.steel(1))),
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/MoholeArea.ts
+++ b/src/server/cards/base/MoholeArea.ts
@@ -1,5 +1,5 @@
 import {TileType} from '../../../common/TileType';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {IProjectCard} from '../IProjectCard';
 import {SpaceType} from '../../../common/boards/SpaceType';
@@ -12,8 +12,7 @@ import {AdjacencyBonus} from '../../ares/AdjacencyBonus';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
 
-export class MoholeArea extends Card implements IProjectCard {
-  public migrated = true;
+export class MoholeArea extends Card2 implements IProjectCard {
   constructor(
     name: CardName = CardName.MOHOLE_AREA,
     adjacencyBonus: AdjacencyBonus | undefined = undefined,
@@ -36,7 +35,7 @@ export class MoholeArea extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace('Select an ocean space for special tile', player.game.board.getAvailableSpacesForOcean(player), (space: ISpace) => {
       player.game.addTile(player, SpaceType.OCEAN, space, {tileType: TileType.MOHOLE_AREA});
       space.adjacency = this.adjacencyBonus;

--- a/src/server/cards/base/NaturalPreserve.ts
+++ b/src/server/cards/base/NaturalPreserve.ts
@@ -1,7 +1,7 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
 import {TileType} from '../../../common/TileType';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {ISpace} from '../../boards/ISpace';
@@ -13,8 +13,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {nextToNoOtherTileFn} from '../../boards/Board';
 import {max} from '../Options';
 
-export class NaturalPreserve extends Card implements IProjectCard {
-  public migrated = true;
+export class NaturalPreserve extends Card2 implements IProjectCard {
   constructor(
     name: CardName = CardName.NATURAL_PRESERVE,
     adjacencyBonus: AdjacencyBonus | undefined = undefined,
@@ -41,10 +40,10 @@ export class NaturalPreserve extends Card implements IProjectCard {
     return player.game.board.getAvailableSpacesOnLand(player)
       .filter(nextToNoOtherTileFn(player.game.board));
   }
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return this.getAvailableSpaces(player).length > 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace('Select space for special tile next to no other tile', this.getAvailableSpaces(player), (foundSpace: ISpace) => {
       player.game.addTile(player, foundSpace.spaceType, foundSpace, {tileType: TileType.NATURAL_PRESERVE});
       foundSpace.adjacency = this.adjacencyBonus;

--- a/src/server/cards/base/NoctisCity.ts
+++ b/src/server/cards/base/NoctisCity.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SelectSpace} from '../../inputs/SelectSpace';
@@ -8,8 +8,7 @@ import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class NoctisCity extends Card implements IProjectCard {
-  public migrated = true;
+export class NoctisCity extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -31,14 +30,14 @@ export class NoctisCity extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     if (player.game.board.getNoctisCitySpaceId !== undefined) {
       return true;
     } else {
       return player.game.board.getAvailableSpacesForCity(player).length > 0;
     }
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     const noctisCitySpaceId = player.game.board.getNoctisCitySpaceId();
     if (noctisCitySpaceId !== undefined) {
       player.game.addCityTile(player, noctisCitySpaceId);

--- a/src/server/cards/base/NoctisFarming.ts
+++ b/src/server/cards/base/NoctisFarming.ts
@@ -1,14 +1,13 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class NoctisFarming extends Card implements IProjectCard {
-  public migrated = true;
+export class NoctisFarming extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -31,7 +30,7 @@ export class NoctisFarming extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.plants += 2;
     return undefined;
   }

--- a/src/server/cards/base/NuclearPower.ts
+++ b/src/server/cards/base/NuclearPower.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class NuclearPower extends Card implements IProjectCard {
-  public migrated = true;
+export class NuclearPower extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -26,9 +25,5 @@ export class NuclearPower extends Card implements IProjectCard {
         description: 'Decrease your M€ production 2 steps and increase your Energy production 3 steps.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/OpenCity.ts
+++ b/src/server/cards/base/OpenCity.ts
@@ -1,5 +1,5 @@
 import {IProjectCard} from '../IProjectCard';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Tag} from '../../../common/cards/Tag';
 import {Player} from '../../Player';
@@ -9,8 +9,7 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class OpenCity extends Card implements IProjectCard {
-  public migrated = true;
+export class OpenCity extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -37,10 +36,10 @@ export class OpenCity extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace('Select space for city tile', player.game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
       player.game.addCityTile(player, space.id);
       player.plants += 2;

--- a/src/server/cards/base/PeroxidePower.ts
+++ b/src/server/cards/base/PeroxidePower.ts
@@ -1,12 +1,11 @@
 import {Tag} from '../../../common/cards/Tag';
 import {IProjectCard} from '../IProjectCard';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class PeroxidePower extends Card implements IProjectCard {
-  public migrated = true;
+export class PeroxidePower extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -26,8 +25,5 @@ export class PeroxidePower extends Card implements IProjectCard {
         description: 'Decrease your M€ production 1 step and increase your Energy production 2 steps.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/PowerPlant.ts
+++ b/src/server/cards/base/PowerPlant.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class PowerPlant extends Card implements IProjectCard {
-  public migrated = true;
+export class PowerPlant extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -23,10 +22,6 @@ export class PowerPlant extends Card implements IProjectCard {
         description: 'Increase your Energy production 1 step.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }
 

--- a/src/server/cards/base/ProtectedValley.ts
+++ b/src/server/cards/base/ProtectedValley.ts
@@ -1,5 +1,5 @@
 import {IProjectCard} from '../IProjectCard';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SpaceType} from '../../../common/boards/SpaceType';
@@ -9,8 +9,7 @@ import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class ProtectedValley extends Card implements IProjectCard {
-  public migrated = true;
+export class ProtectedValley extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -31,7 +30,7 @@ export class ProtectedValley extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select space reserved for ocean to place greenery tile',
       player.game.board.getAvailableSpacesForOcean(player),

--- a/src/server/cards/base/RadChemFactory.ts
+++ b/src/server/cards/base/RadChemFactory.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class RadChemFactory extends Card implements IProjectCard {
-  public migrated = true;
+export class RadChemFactory extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -28,7 +27,7 @@ export class RadChemFactory extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.increaseTerraformRatingSteps(2);
     return undefined;
   }

--- a/src/server/cards/base/SoilFactory.ts
+++ b/src/server/cards/base/SoilFactory.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SoilFactory extends Card implements IProjectCard {
-  public migrated = true;
+export class SoilFactory extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -27,8 +26,5 @@ export class SoilFactory extends Card implements IProjectCard {
         description: 'Decrease your Energy production 1 step and increase your Plant production 1 step.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/SolarPower.ts
+++ b/src/server/cards/base/SolarPower.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SolarPower extends Card implements IProjectCard {
-  public migrated = true;
+export class SolarPower extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -24,8 +23,5 @@ export class SolarPower extends Card implements IProjectCard {
         description: 'Increase your energy production 1 step.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/SpaceElevator.ts
+++ b/src/server/cards/base/SpaceElevator.ts
@@ -1,14 +1,13 @@
 import {IActionCard} from '../ICard';
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SpaceElevator extends Card implements IActionCard, IProjectCard {
-  public migrated = true;
+export class SpaceElevator extends Card2 implements IActionCard, IProjectCard {
   constructor() {
     super({
       cardType: CardType.ACTIVE,
@@ -30,9 +29,7 @@ export class SpaceElevator extends Card implements IActionCard, IProjectCard {
       },
     });
   }
-  public play() {
-    return undefined;
-  }
+
   public canAct(player: Player): boolean {
     return player.steel > 0;
   }

--- a/src/server/cards/base/StripMine.ts
+++ b/src/server/cards/base/StripMine.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class StripMine extends Card implements IProjectCard {
-  public migrated = true;
+export class StripMine extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -31,7 +30,7 @@ export class StripMine extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return player.game.increaseOxygenLevel(player, 2);
   }
 }

--- a/src/server/cards/base/TectonicStressPower.ts
+++ b/src/server/cards/base/TectonicStressPower.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class TectonicStressPower extends Card implements IProjectCard {
-  public migrated = true;
+export class TectonicStressPower extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -26,8 +25,5 @@ export class TectonicStressPower extends Card implements IProjectCard {
         description: 'Requires 2 Science tags. Increase your Energy production 3 steps.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/TitaniumMine.ts
+++ b/src/server/cards/base/TitaniumMine.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class TitaniumMine extends Card implements IProjectCard {
-  public migrated = true;
+export class TitaniumMine extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -23,8 +22,5 @@ export class TitaniumMine extends Card implements IProjectCard {
         description: 'Increase your titanium production 1 step.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/TropicalResort.ts
+++ b/src/server/cards/base/TropicalResort.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class TropicalResort extends Card implements IProjectCard {
-  public migrated = true;
+export class TropicalResort extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -27,8 +26,5 @@ export class TropicalResort extends Card implements IProjectCard {
         description: 'Reduce your heat production 2 steps and increase your M€ production 3 steps.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/base/UndergroundCity.ts
+++ b/src/server/cards/base/UndergroundCity.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SelectSpace} from '../../inputs/SelectSpace';
@@ -8,8 +8,7 @@ import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class UndergroundCity extends Card implements IProjectCard {
-  public migrated = true;
+export class UndergroundCity extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -30,10 +29,10 @@ export class UndergroundCity extends Card implements IProjectCard {
       },
     });
   }
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace('Select space for city tile', player.game.board.getAvailableSpacesForCity(player), (foundSpace: ISpace) => {
       player.game.addCityTile(player, foundSpace.id);
       return undefined;

--- a/src/server/cards/base/UrbanizedArea.ts
+++ b/src/server/cards/base/UrbanizedArea.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {ISpace} from '../../boards/ISpace';
@@ -9,8 +9,7 @@ import {CardName} from '../../../common/cards/CardName';
 import {Board} from '../../boards/Board';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class UrbanizedArea extends Card implements IProjectCard {
-  public migrated = true;
+export class UrbanizedArea extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -35,10 +34,10 @@ export class UrbanizedArea extends Card implements IProjectCard {
     return player.game.board.getAvailableSpacesOnLand(player)
       .filter((space) => player.game.board.getAdjacentSpaces(space).filter((adjacentSpace) => Board.isCitySpace(adjacentSpace)).length >= 2);
   }
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return this.getAvailableSpaces(player).length > 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace('Select space next to at least 2 other city tiles', this.getAvailableSpaces(player), (foundSpace: ISpace) => {
       player.game.addCityTile(player, foundSpace.id);
       return undefined;

--- a/src/server/cards/base/Windmills.ts
+++ b/src/server/cards/base/Windmills.ts
@@ -1,14 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
-import {PlayerInput} from '../../PlayerInput';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Windmills extends Card implements IProjectCard {
-  public migrated = true;
+export class Windmills extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -27,9 +25,5 @@ export class Windmills extends Card implements IProjectCard {
         description: 'Requires 7% oxygen. Increase your Energy production 1 step.',
       },
     });
-  }
-
-  public play(): PlayerInput | undefined {
-    return undefined;
   }
 }

--- a/src/server/cards/colonies/SpacePort.ts
+++ b/src/server/cards/colonies/SpacePort.ts
@@ -7,10 +7,9 @@ import {SelectSpace} from '../../inputs/SelectSpace';
 import {ISpace} from '../../boards/ISpace';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRequirements} from '../CardRequirements';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 
-export class SpacePort extends Card implements IProjectCard {
-  public migrated = true;
+export class SpacePort extends Card2 implements IProjectCard {
   constructor() {
     super({
       cost: 22,
@@ -34,7 +33,7 @@ export class SpacePort extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     if (player.game.board.getAvailableSpacesForCity(player).length === 0) return false;
     let coloniesCount: number = 0;
     player.game.colonies.forEach((colony) => {
@@ -43,7 +42,7 @@ export class SpacePort extends Card implements IProjectCard {
     return coloniesCount > 0;
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.colonies.increaseFleetSize();
 
     return new SelectSpace('Select space for city tile', player.game.board.getAvailableSpacesForCity(player), (space: ISpace) => {

--- a/src/server/cards/colonies/SpinoffDepartment.ts
+++ b/src/server/cards/colonies/SpinoffDepartment.ts
@@ -4,10 +4,9 @@ import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 
-export class SpinoffDepartment extends Card implements IProjectCard {
-  public migrated = true;
+export class SpinoffDepartment extends Card2 implements IProjectCard {
   constructor() {
     super({
       cost: 10,
@@ -33,9 +32,5 @@ export class SpinoffDepartment extends Card implements IProjectCard {
     if (card.cost >= 20) {
       player.drawCard();
     }
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/community/CuriosityII.ts
+++ b/src/server/cards/community/CuriosityII.ts
@@ -1,4 +1,4 @@
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {ICorporationCard} from '../corporation/ICorporationCard';
 import {Tag} from '../../../common/cards/Tag';
 import {Player} from '../../Player';
@@ -16,8 +16,7 @@ import {SpaceType} from '../../../common/boards/SpaceType';
 import {SpaceBonus} from '../../../common/boards/SpaceBonus';
 import {Phase} from '../../../common/Phase';
 
-export class CuriosityII extends Card implements ICorporationCard {
-  public migrated = true;
+export class CuriosityII extends Card2 implements ICorporationCard {
   constructor() {
     super({
       cardType: CardType.CORPORATION,
@@ -56,10 +55,6 @@ export class CuriosityII extends Card implements ICorporationCard {
     if (space.bonus.some((bonus) => eligibleBonuses.includes(bonus)) || space.tile?.covers !== undefined) {
       cardOwner.game.defer(new SimpleDeferredAction(cardOwner, () => this.corpAction(cardOwner)));
     }
-  }
-
-  public play() {
-    return undefined;
   }
 
   private corpAction(player: Player) {

--- a/src/server/cards/corporation/MiningGuild.ts
+++ b/src/server/cards/corporation/MiningGuild.ts
@@ -1,4 +1,4 @@
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {Tag} from '../../../common/cards/Tag';
 import {Player} from '../../Player';
 import {ICorporationCard} from './ICorporationCard';
@@ -13,8 +13,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {BoardType} from '../../boards/BoardType';
 import {digit} from '../Options';
 
-export class MiningGuild extends Card implements ICorporationCard {
-  public migrated = true;
+export class MiningGuild extends Card2 implements ICorporationCard {
   constructor() {
     super({
       cardType: CardType.CORPORATION,
@@ -57,7 +56,7 @@ export class MiningGuild extends Card implements ICorporationCard {
     }
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.steel = 5;
     return undefined;
   }

--- a/src/server/cards/pathfinders/CommunicationCenter.ts
+++ b/src/server/cards/pathfinders/CommunicationCenter.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
@@ -11,8 +11,7 @@ import {SimpleDeferredAction} from '../../deferredActions/DeferredAction';
 import {Size} from '../../../common/cards/render/Size';
 import {ICard} from '../ICard';
 
-export class CommunicationCenter extends Card implements IProjectCard {
-  public migrated = true;
+export class CommunicationCenter extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.ACTIVE,
@@ -40,7 +39,7 @@ export class CommunicationCenter extends Card implements IProjectCard {
   // Card behavior is in PathfindersExpansion.onCardPlayed. Card.onCardPlayed
   // does not apply to _any card played_
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.game.defer(new SimpleDeferredAction(player, () => {
       // Play this after the card's been put in hand. Otherwise it will generate an error.
       player.addResourceTo(this, 2);
@@ -60,4 +59,3 @@ export class CommunicationCenter extends Card implements IProjectCard {
     }
   }
 }
-

--- a/src/server/cards/pathfinders/DesignedOrganisms.ts
+++ b/src/server/cards/pathfinders/DesignedOrganisms.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
@@ -10,8 +10,7 @@ import {CardRequirements} from '../CardRequirements';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
 import {CardResource} from '../../../common/CardResource';
 
-export class DesignedOrganisms extends Card implements IProjectCard {
-  public migrated = true;
+export class DesignedOrganisms extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -33,11 +32,10 @@ export class DesignedOrganisms extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.addResource(Resources.PLANTS, 3);
     player.game.defer(new AddResourcesToCard(player, CardResource.MICROBE, {count: 3}));
     player.game.defer(new AddResourcesToCard(player, CardResource.ANIMAL, {count: 1}));
     return undefined;
   }
 }
-

--- a/src/server/cards/pathfinders/EarlyExpedition.ts
+++ b/src/server/cards/pathfinders/EarlyExpedition.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
@@ -13,8 +13,7 @@ import {ISpace} from '../../boards/ISpace';
 import {SelectSpace} from '../../inputs/SelectSpace';
 import {max} from '../Options';
 
-export class EarlyExpedition extends Card implements IProjectCard {
-  public migrated = true;
+export class EarlyExpedition extends Card2 implements IProjectCard {
   // This card repeats the NEXT TO NO OTHER TILE behavior from Research Outpost, and Philares
   // has some similar code. Time for code reduction.
 
@@ -44,11 +43,11 @@ export class EarlyExpedition extends Card implements IProjectCard {
       .filter(nextToNoOtherTileFn(player.game.board));
   }
 
-  public override canPlay(player: Player) {
+  public override bespokeCanPlay(player: Player) {
     return this.getAvailableSpaces(player).length > 0;
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.game.defer(new AddResourcesToCard(player, CardResource.DATA));
 
     return new SelectSpace('Select place next to no other tile for city', this.getAvailableSpaces(player), (foundSpace: ISpace) => {
@@ -57,4 +56,3 @@ export class EarlyExpedition extends Card implements IProjectCard {
     });
   }
 }
-

--- a/src/server/cards/pathfinders/LobbyHalls.ts
+++ b/src/server/cards/pathfinders/LobbyHalls.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
@@ -10,8 +10,7 @@ import {DeclareCloneTag} from '../../pathfinders/DeclareCloneTag';
 import {ICloneTagCard} from './ICloneTagCard';
 import {Turmoil} from '../../turmoil/Turmoil';
 
-export class LobbyHalls extends Card implements IProjectCard, ICloneTagCard {
-  public migrated = true;
+export class LobbyHalls extends Card2 implements IProjectCard, ICloneTagCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -36,7 +35,7 @@ export class LobbyHalls extends Card implements IProjectCard, ICloneTagCard {
     return [this.cloneTag, Tag.BUILDING];
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.game.defer(new DeclareCloneTag(player, this));
     const turmoil = Turmoil.getTurmoil(player.game);
     if (turmoil.getAvailableDelegateCount(player.id, 'reserve') > 0) {

--- a/src/server/cards/pathfinders/MartianDustProcessingPlant.ts
+++ b/src/server/cards/pathfinders/MartianDustProcessingPlant.ts
@@ -1,13 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Tag} from '../../../common/cards/Tag';
 
-export class MartianDustProcessingPlant extends Card implements IProjectCard {
-  public migrated = true;
+export class MartianDustProcessingPlant extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -29,9 +28,8 @@ export class MartianDustProcessingPlant extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.increaseTerraformRating();
     return undefined;
   }
 }
-

--- a/src/server/cards/pathfinders/MartianRepository.ts
+++ b/src/server/cards/pathfinders/MartianRepository.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {VictoryPoints} from '../ICard';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
@@ -10,8 +10,7 @@ import {CardResource} from '../../../common/CardResource';
 import {ICard} from '../ICard';
 import {played} from '../Options';
 
-export class MartianRepository extends Card implements IProjectCard {
-  public migrated = true;
+export class MartianRepository extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.ACTIVE,
@@ -40,9 +39,5 @@ export class MartianRepository extends Card implements IProjectCard {
   public onCardPlayed(player: Player, card: ICard) {
     const qty = player.tags.cardTagCount(card, Tag.SCIENCE) + player.tags.cardTagCount(card, Tag. MARS);
     if (qty > 0) player.addResourceTo(this, {qty, log: true});
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/pathfinders/MuseumofEarlyColonisation.ts
+++ b/src/server/cards/pathfinders/MuseumofEarlyColonisation.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
@@ -8,8 +8,7 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardRequirements} from '../CardRequirements';
 import {all} from '../Options';
 
-export class MuseumofEarlyColonisation extends Card implements IProjectCard {
-  public migrated = true;
+export class MuseumofEarlyColonisation extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -33,9 +32,8 @@ export class MuseumofEarlyColonisation extends Card implements IProjectCard {
     });
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.increaseTerraformRating();
     return undefined;
   }
 }
-

--- a/src/server/cards/pathfinders/NewVenice.ts
+++ b/src/server/cards/pathfinders/NewVenice.ts
@@ -1,4 +1,4 @@
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {SelectSpace} from '../../inputs/SelectSpace';
 import {ISpace} from '../../boards/ISpace';
@@ -10,8 +10,7 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class NewVenice extends Card implements IProjectCard {
-  public migrated = true;
+export class NewVenice extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -35,11 +34,12 @@ export class NewVenice extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  // TODO(kberg): use reserveUnits for plants.
+  public override bespokeCanPlay(player: Player): boolean {
     return player.plants >= 2;
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.plants -= 2;
 
     return new SelectSpace(

--- a/src/server/cards/pathfinders/PowerPlant.ts
+++ b/src/server/cards/pathfinders/PowerPlant.ts
@@ -1,12 +1,11 @@
 import {IProjectCard} from '../IProjectCard';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Tag} from '../../../common/cards/Tag';
 
-export class PowerPlant extends Card implements IProjectCard {
-  public migrated = true;
+export class PowerPlant extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -23,10 +22,6 @@ export class PowerPlant extends Card implements IProjectCard {
         description: 'Increase your heat production 2 steps and your energy production 1 step.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }
 

--- a/src/server/cards/pathfinders/RedCity.ts
+++ b/src/server/cards/pathfinders/RedCity.ts
@@ -1,7 +1,7 @@
 import {Tag} from '../../../common/cards/Tag';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRequirements} from '../CardRequirements';
@@ -13,8 +13,7 @@ import {AresHandler} from '../../ares/AresHandler';
 import {Board} from '../../boards/Board';
 import {IProjectCard} from '../IProjectCard';
 
-export class RedCity extends Card implements IProjectCard {
-  public migrated = true;
+export class RedCity extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -44,11 +43,11 @@ export class RedCity extends Card implements IProjectCard {
     const citySpaces = board.getAvailableSpacesForCity(player);
     return citySpaces.filter((space) => !board.getAdjacentSpaces(space).some(Board.isGreenerySpace));
   }
-  public override canPlay(player: Player) {
+  public override bespokeCanPlay(player: Player) {
     return this.availableRedCitySpaces(player).length > 0;
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace('Select space for Red City', this.availableRedCitySpaces(player), (space) => {
       player.game.addTile(player, space.spaceType, space, {tileType: TileType.RED_CITY, card: this.name});
       return undefined;

--- a/src/server/cards/prelude/CheungShingMARS.ts
+++ b/src/server/cards/prelude/CheungShingMARS.ts
@@ -1,13 +1,12 @@
 import {Tag} from '../../../common/cards/Tag';
 import {ICorporationCard} from '../corporation/ICorporationCard';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {played} from '../Options';
 
-export class CheungShingMARS extends Card implements ICorporationCard {
-  public migrated = true;
+export class CheungShingMARS extends Card2 implements ICorporationCard {
   constructor() {
     super({
       cardType: CardType.CORPORATION,
@@ -31,9 +30,5 @@ export class CheungShingMARS extends Card implements ICorporationCard {
         }),
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/prelude/HousePrinting.ts
+++ b/src/server/cards/prelude/HousePrinting.ts
@@ -1,12 +1,11 @@
 import {Tag} from '../../../common/cards/Tag';
 import {CardType} from '../../../common/cards/CardType';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {IProjectCard} from '../IProjectCard';
 
-export class HousePrinting extends Card implements IProjectCard {
-  public migrated = true;
+export class HousePrinting extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -24,8 +23,5 @@ export class HousePrinting extends Card implements IProjectCard {
         description: 'Increase your steel production 1 step.',
       },
     });
-  }
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/prelude/LavaTubeSettlement.ts
+++ b/src/server/cards/prelude/LavaTubeSettlement.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {LavaFlows} from '../base/LavaFlows';
@@ -9,8 +9,7 @@ import {BoardName} from '../../../common/boards/BoardName';
 import {PlaceCityTile} from '../../deferredActions/PlaceCityTile';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class LavaTubeSettlement extends Card implements IProjectCard {
-  public migrated = true;
+export class LavaTubeSettlement extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -42,11 +41,11 @@ export class LavaTubeSettlement extends Card implements IProjectCard {
     return LavaFlows.getVolcanicSpaces(player);
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return this.getSpacesForCity(player).length > 0 && player.production.energy >= 1;
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.game.defer(new PlaceCityTile(
       player,
       'Select either Tharsis Tholus, Ascraeus Mons, Pavonis Mons or Arsia Mons',

--- a/src/server/cards/promo/AsteroidDeflectionSystem.ts
+++ b/src/server/cards/promo/AsteroidDeflectionSystem.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {IActionCard} from '../ICard';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {VictoryPoints} from '../ICard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
@@ -11,8 +11,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {played} from '../Options';
 
-export class AsteroidDeflectionSystem extends Card implements IActionCard, IProjectCard {
-  public migrated = true;
+export class AsteroidDeflectionSystem extends Card2 implements IActionCard, IProjectCard {
   constructor() {
     super({
       cardType: CardType.ACTIVE,
@@ -40,10 +39,6 @@ export class AsteroidDeflectionSystem extends Card implements IActionCard, IProj
     });
   }
   public override resourceCount = 0;
-
-  public play() {
-    return undefined;
-  }
 
   public canAct(): boolean {
     return true;

--- a/src/server/cards/promo/Factorum.ts
+++ b/src/server/cards/promo/Factorum.ts
@@ -1,4 +1,4 @@
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {ICorporationCard} from '../corporation/ICorporationCard';
 import {Player} from '../../Player';
 import {Tag} from '../../../common/cards/Tag';
@@ -11,8 +11,7 @@ import {CardType} from '../../../common/cards/CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-export class Factorum extends Card implements IActionCard, ICorporationCard {
-  public migrated = true;
+export class Factorum extends Card2 implements IActionCard, ICorporationCard {
   constructor() {
     super({
       cardType: CardType.CORPORATION,
@@ -36,10 +35,6 @@ export class Factorum extends Card implements IActionCard, ICorporationCard {
         }),
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 
   public canAct(player: Player): boolean {

--- a/src/server/cards/promo/FieldCappedCity.ts
+++ b/src/server/cards/promo/FieldCappedCity.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SelectSpace} from '../../inputs/SelectSpace';
@@ -8,8 +8,7 @@ import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class FieldCappedCity extends Card implements IProjectCard {
-  public migrated = true;
+export class FieldCappedCity extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -31,11 +30,11 @@ export class FieldCappedCity extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     return new SelectSpace(
       'Select space for city tile',
       player.game.board.getAvailableSpacesForCity(player),

--- a/src/server/cards/promo/GreatDamPromo.ts
+++ b/src/server/cards/promo/GreatDamPromo.ts
@@ -9,10 +9,9 @@ import {ISpace} from '../../boards/ISpace';
 import {Board} from '../../boards/Board';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 
-export class GreatDamPromo extends Card implements IProjectCard {
-  public migrated = true;
+export class GreatDamPromo extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -33,11 +32,11 @@ export class GreatDamPromo extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return this.getAvailableSpaces(player).length > 0;
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     const availableSpaces = this.getAvailableSpaces(player);
     if (availableSpaces.length < 1) return undefined;
 

--- a/src/server/cards/promo/MagneticFieldGeneratorsPromo.ts
+++ b/src/server/cards/promo/MagneticFieldGeneratorsPromo.ts
@@ -1,7 +1,7 @@
 import {Player} from '../../Player';
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {SelectSpace} from '../../inputs/SelectSpace';
@@ -10,8 +10,7 @@ import {ISpace} from '../../boards/ISpace';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
 
-export class MagneticFieldGeneratorsPromo extends Card implements IProjectCard {
-  public migrated = true;
+export class MagneticFieldGeneratorsPromo extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -34,10 +33,10 @@ export class MagneticFieldGeneratorsPromo extends Card implements IProjectCard {
       },
     });
   }
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     return player.game.board.getAvailableSpacesOnLand(player).length > 0;
   }
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.increaseTerraformRatingSteps(3);
 
     const availableSpaces = player.game.board.getAvailableSpacesOnLand(player);

--- a/src/server/cards/promo/Recyclon.ts
+++ b/src/server/cards/promo/Recyclon.ts
@@ -6,14 +6,13 @@ import {CardResource} from '../../../common/CardResource';
 import {IProjectCard} from '../IProjectCard';
 import {SelectOption} from '../../inputs/SelectOption';
 import {OrOptions} from '../../inputs/OrOptions';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit, played} from '../Options';
 
-export class Recyclon extends Card implements ICorporationCard {
-  public migrated = true;
+export class Recyclon extends Card2 implements ICorporationCard {
   constructor() {
     super({
       cardType: CardType.CORPORATION,
@@ -41,7 +40,7 @@ export class Recyclon extends Card implements ICorporationCard {
   }
   public override resourceCount = 0;
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.addResourceTo(this);
     return undefined;
   }

--- a/src/server/cards/turmoil/CulturalMetropolis.ts
+++ b/src/server/cards/turmoil/CulturalMetropolis.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
@@ -11,8 +11,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {Turmoil} from '../../turmoil/Turmoil';
 
-export class CulturalMetropolis extends Card implements IProjectCard {
-  public migrated = true;
+export class CulturalMetropolis extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.AUTOMATED,
@@ -35,14 +34,14 @@ export class CulturalMetropolis extends Card implements IProjectCard {
     });
   }
 
-  public override canPlay(player: Player): boolean {
+  public override bespokeCanPlay(player: Player): boolean {
     // This card requires player has 2 delegates available
     const turmoil = Turmoil.getTurmoil(player.game);
     const hasEnoughDelegates = turmoil.getAvailableDelegateCount(player.id, 'both') >= 2;
     return hasEnoughDelegates;
   }
 
-  public play(player: Player) {
+  public override bespokePlay(player: Player) {
     player.game.defer(new PlaceCityTile(player));
     const title = 'Select where to send two delegates';
 

--- a/src/server/cards/turmoil/MartianMediaCenter.ts
+++ b/src/server/cards/turmoil/MartianMediaCenter.ts
@@ -1,6 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
@@ -11,8 +11,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {Turmoil} from '../../turmoil/Turmoil';
 
-export class MartianMediaCenter extends Card implements IProjectCard {
-  public migrated = true;
+export class MartianMediaCenter extends Card2 implements IProjectCard {
   constructor() {
     super({
       cardType: CardType.ACTIVE,
@@ -35,10 +34,6 @@ export class MartianMediaCenter extends Card implements IProjectCard {
         description: 'Requires that Mars First is ruling or that you have 2 delegates there. Increase your M€ production 2 steps.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 
   public canAct(player: Player): boolean {

--- a/src/server/cards/turmoil/SponsoredMohole.ts
+++ b/src/server/cards/turmoil/SponsoredMohole.ts
@@ -5,10 +5,9 @@ import {CardType} from '../../../common/cards/CardType';
 import {PartyName} from '../../../common/turmoil/PartyName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 
-export class SponsoredMohole extends Card implements IProjectCard {
-  public migrated = true;
+export class SponsoredMohole extends Card2 implements IProjectCard {
   constructor() {
     super({
       cost: 5,
@@ -26,9 +25,5 @@ export class SponsoredMohole extends Card implements IProjectCard {
         description: 'Requires that Kelvinists are ruling or that you have 2 delegates there. Increase your heat production 2 steps.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/src/server/cards/turmoil/UtopiaInvest.ts
+++ b/src/server/cards/turmoil/UtopiaInvest.ts
@@ -5,14 +5,13 @@ import {ICorporationCard} from '../corporation/ICorporationCard';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
 import {Resources} from '../../../common/Resources';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
 
-export class UtopiaInvest extends Card implements IActionCard, ICorporationCard {
-  public migrated = true;
+export class UtopiaInvest extends Card2 implements IActionCard, ICorporationCard {
   constructor() {
     super({
       name: CardName.UTOPIA_INVEST,
@@ -35,10 +34,6 @@ export class UtopiaInvest extends Card implements IActionCard, ICorporationCard 
         }),
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
   public canAct(player: Player): boolean {
     return player.production.megacredits +

--- a/src/server/cards/venusNext/Manutech.ts
+++ b/src/server/cards/venusNext/Manutech.ts
@@ -2,13 +2,12 @@ import {ICorporationCard} from '../corporation/ICorporationCard';
 import {Player} from '../../Player';
 import {Tag} from '../../../common/cards/Tag';
 import {Resources} from '../../../common/Resources';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Manutech extends Card implements ICorporationCard {
-  public migrated = true;
+export class Manutech extends Card2 implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MANUTECH,
@@ -31,10 +30,6 @@ export class Manutech extends Card implements ICorporationCard {
         }),
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 
   public static onProductionGain(player: Player, resource: Resources, amount: number) {

--- a/src/server/cards/venusNext/MiningQuota.ts
+++ b/src/server/cards/venusNext/MiningQuota.ts
@@ -3,11 +3,10 @@ import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
-import {Card} from '../Card';
+import {Card2} from '../Card';
 import {IProjectCard} from '../IProjectCard';
 
-export class MiningQuota extends Card implements IProjectCard {
-  public migrated = true;
+export class MiningQuota extends Card2 implements IProjectCard {
   constructor() {
     super({
       name: CardName.MINING_QUOTA,
@@ -25,9 +24,5 @@ export class MiningQuota extends Card implements IProjectCard {
         description: 'Requires Venus, Earth and Jovian tags. Increase your steel production 2 steps.',
       },
     });
-  }
-
-  public play() {
-    return undefined;
   }
 }

--- a/tests/cards/ares/BiofertilizerFacility.spec.ts
+++ b/tests/cards/ares/BiofertilizerFacility.spec.ts
@@ -29,7 +29,7 @@ describe('BiofertilizerFacility', function() {
   });
 
   it('Cannot play without a science tag', function() {
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Play', function() {
@@ -43,8 +43,8 @@ describe('BiofertilizerFacility', function() {
     expect(microbeHost.resourceCount || 0).is.eq(0);
     expect(game.deferredActions).has.lengthOf(0);
 
-    expect(player.canPlayIgnoringCost(card)).is.true;
-    const action = cast(player.simplePlay(card), SelectSpace);
+    expect(card.canPlay(player)).is.true;
+    const action = cast(card.play(player), SelectSpace);
     expect(player.production.plants).is.eq(1);
 
     const citySpace = game.board.getAvailableSpacesForCity(player)[0];

--- a/tests/cards/ares/CommercialDistrictAres.spec.ts
+++ b/tests/cards/ares/CommercialDistrictAres.spec.ts
@@ -7,6 +7,7 @@ import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
 import {CommercialDistrictAres} from '../../../src/server/cards/ares/CommercialDistrictAres';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('CommercialDistrictAres', function() {
   let card: CommercialDistrictAres;
@@ -20,11 +21,11 @@ describe('CommercialDistrictAres', function() {
   });
 
   it('Should play', function() {
+    expect(card.canPlay(player)).is.false;
     player.production.add(Resources.ENERGY, 1);
     expect(card.canPlay(player)).is.true;
 
-    const action = card.play(player);
-    expect(action instanceof SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(action.availableSpaces[0]);
 
     expect(action.availableSpaces[0].adjacency).to.deep.eq({bonus: [SpaceBonus.MEGACREDITS, SpaceBonus.MEGACREDITS]});

--- a/tests/cards/ares/EcologicalSurvey.spec.ts
+++ b/tests/cards/ares/EcologicalSurvey.spec.ts
@@ -11,9 +11,10 @@ import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
 import {ArcticAlgae} from '../../../src/server/cards/base/ArcticAlgae';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {Phase} from '../../../src/common/Phase';
-import {addGreenery, runAllActions} from '../../TestingUtils';
+import {addGreenery, cast, runAllActions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {OceanCity} from '../../../src/server/cards/ares/OceanCity';
+import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 
 describe('EcologicalSurvey', () => {
   let card: EcologicalSurvey;
@@ -133,7 +134,7 @@ describe('EcologicalSurvey', () => {
     game.simpleAddTile(redPlayer, space, {tileType: TileType.OCEAN});
 
     player.plants = 0;
-    const selectSpace = new OceanCity().play(player);
+    const selectSpace = cast(new OceanCity().play(player), SelectSpace);
     selectSpace.cb(space);
     expect(player.plants).eq(0);
   });

--- a/tests/cards/ares/GeologicalSurvey.spec.ts
+++ b/tests/cards/ares/GeologicalSurvey.spec.ts
@@ -11,9 +11,10 @@ import {TileType} from '../../../src/common/TileType';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
 import {EmptyBoard} from '../../ares/EmptyBoard';
 import {MarsFirst} from '../../../src/server/turmoil/parties/MarsFirst';
-import {addGreenery, resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, runAllActions} from '../../TestingUtils';
+import {addGreenery, resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, runAllActions, cast} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {OceanCity} from '../../../src/server/cards/ares/OceanCity';
+import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 
 describe('GeologicalSurvey', () => {
   let card: GeologicalSurvey;
@@ -166,7 +167,7 @@ describe('GeologicalSurvey', () => {
     game.simpleAddTile(redPlayer, space, {tileType: TileType.OCEAN});
 
     player.heat = 0;
-    const selectSpace = new OceanCity().play(player);
+    const selectSpace = cast(new OceanCity().play(player), SelectSpace);
     selectSpace.cb(space);
     runAllActions(game);
     expect(player.heat).eq(0);

--- a/tests/cards/ares/OceanCity.spec.ts
+++ b/tests/cards/ares/OceanCity.spec.ts
@@ -26,25 +26,25 @@ describe('OceanCity', function() {
 
   it('Can play', function() {
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.production.add(Resources.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {
@@ -71,7 +71,7 @@ describe('OceanCity', function() {
     const oceanSpace = addOcean(player);
     player.production.add(Resources.ENERGY, 1);
 
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(oceanSpace);
 
@@ -94,19 +94,18 @@ describe('OceanCity', function() {
       .filter((space) => space.spaceType === SpaceType.LAND)[0];
     game.addCityTile(player, citySpace.id);
 
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(oceanSpace);
     expect(oceanSpace.player).to.eq(player);
     expect(oceanSpace.tile!.tileType).to.eq(TileType.OCEAN_CITY);
   });
 
-  // Add a test where cards that get points for adjacent oceans get credit
-  it('', function() {});
+  // TODO(kberg): Add a test where cards that get points for adjacent oceans get credit
 
   it('Ocean City counts as ocean for adjacency', function() {
     const oceanSpace = addOcean(player);
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(oceanSpace);
     const greenery = game.board
       .getAdjacentSpaces(oceanSpace)
@@ -121,7 +120,7 @@ describe('OceanCity', function() {
 
   it('Ocean City counts for city-related VP', function() {
     const oceanSpace = addOcean(player);
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(oceanSpace);
     const greenery = game.board
       .getAdjacentSpaces(oceanSpace)
@@ -138,7 +137,7 @@ describe('OceanCity', function() {
     const oceanSpace = game.board.getAvailableSpacesForOcean(player)[0];
 
     const capital = new Capital();
-    const capitalAction = capital.play(player);
+    const capitalAction = cast(capital.play(player), SelectSpace);
     player.playedCards = [capital];
 
     const capitalSpace = game.board
@@ -152,7 +151,7 @@ describe('OceanCity', function() {
 
     // And now adds the tile.
     game.addOceanTile(player, oceanSpace.id);
-    const oceanCityAction = card.play(player);
+    const oceanCityAction = cast(card.play(player), SelectSpace);
 
     oceanCityAction.cb(oceanSpace);
     expect(oceanSpace.tile!.tileType).to.eq(TileType.OCEAN_CITY);
@@ -169,7 +168,7 @@ describe('OceanCity', function() {
     game.addOceanTile(player, oceanSpace.id);
     expect(player.plants).eq(1);
 
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectSpace);
 
     expect(player.plants).eq(1);
 

--- a/tests/cards/ares/OceanFarm.spec.ts
+++ b/tests/cards/ares/OceanFarm.spec.ts
@@ -25,16 +25,16 @@ describe('OceanFarm', () => {
 
   it('Can play', () => {
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Play', () => {
@@ -42,7 +42,7 @@ describe('OceanFarm', () => {
     expect(player.production.plants).eq(0);
 
     const oceanSpace = addOcean(player);
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     expect(player.production.heat).eq(1);
     expect(player.production.plants).eq(1);

--- a/tests/cards/base/AICentral.spec.ts
+++ b/tests/cards/base/AICentral.spec.ts
@@ -16,19 +16,19 @@ describe('AICentral', function() {
   });
 
   it('Can not play if not enough science tags to play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if no energy production', function() {
     player.playedCards.push(card, card, card);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(card, card, card);
     player.production.add(Resources.ENERGY, 1);
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(card.getVictoryPoints()).to.eq(1);
   });

--- a/tests/cards/base/BuildingIndustries.spec.ts
+++ b/tests/cards/base/BuildingIndustries.spec.ts
@@ -13,14 +13,14 @@ describe('BuildingIndustries', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.production.steel).to.eq(2);
   });

--- a/tests/cards/base/Capital.spec.ts
+++ b/tests/cards/base/Capital.spec.ts
@@ -24,19 +24,19 @@ describe('Capital', () => {
   it('Cannot play without 2 energy production', () => {
     maxOutOceans(player, 4);
     player.production.add(Resources.ENERGY, 1);
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Cannot play if oceans requirement not met', () => {
     maxOutOceans(player, 3);
     player.production.add(Resources.ENERGY, 2);
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     maxOutOceans(player, 4);
     player.production.add(Resources.ENERGY, 2);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
@@ -45,9 +45,9 @@ describe('Capital', () => {
       oceanSpaces[i].tile = {tileType: TileType.OCEAN};
     }
     player.production.add(Resources.ENERGY, 2);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     expect(player.production.energy).to.eq(0);
     expect(player.production.megacredits).to.eq(5);
 

--- a/tests/cards/base/CommercialDistrict.spec.ts
+++ b/tests/cards/base/CommercialDistrict.spec.ts
@@ -20,14 +20,14 @@ describe('CommercialDistrict', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(action.availableSpaces[0]);
 
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/CorporateStronghold.spec.ts
+++ b/tests/cards/base/CorporateStronghold.spec.ts
@@ -19,14 +19,14 @@ describe('CorporateStronghold', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(action.availableSpaces[0]);
 
     expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.CITY);

--- a/tests/cards/base/CupolaCity.spec.ts
+++ b/tests/cards/base/CupolaCity.spec.ts
@@ -21,20 +21,20 @@ describe('CupolaCity', function() {
   });
 
   it('Can not play without energy production', function() {
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if oxygen level too high', function() {
     player.production.add(Resources.ENERGY, 1);
     (game as any).oxygenLevel = 10;
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(action.availableSpaces[0]);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/DomedCrater.spec.ts
+++ b/tests/cards/base/DomedCrater.spec.ts
@@ -31,9 +31,9 @@ describe('DomedCrater', function() {
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(action.availableSpaces[0]);
     expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.CITY);

--- a/tests/cards/base/EOSChasmaNationalPark.spec.ts
+++ b/tests/cards/base/EOSChasmaNationalPark.spec.ts
@@ -21,9 +21,9 @@ describe('EosChasmaNationalPark', () => {
 
   it('Can play', () => {
     (game as any).temperature = -14;
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     (game as any).temperature = -12;
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
@@ -32,8 +32,8 @@ describe('EosChasmaNationalPark', () => {
     const fish = new Fish();
     player.playedCards.push(birds, fish);
 
-    expect(player.canPlayIgnoringCost(card)).is.true;
-    const action = cast(player.simplePlay(card), SelectCard);
+    expect(card.canPlay(player)).is.true;
+    const action = cast(card.play(player), SelectCard);
     expect(player.getVictoryPoints().victoryPoints).to.eq(0);
     player.playedCards.push(card);
     expect(player.getVictoryPoints().victoryPoints).to.eq(1);
@@ -54,7 +54,7 @@ describe('EosChasmaNationalPark', () => {
 
     expect(player.getVictoryPoints().victoryPoints).to.eq(0);
 
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     player.playCard(card);
 
     expect(birds.resourceCount).to.eq(1);

--- a/tests/cards/base/ElectroCatapult.spec.ts
+++ b/tests/cards/base/ElectroCatapult.spec.ts
@@ -18,19 +18,19 @@ describe('ElectroCatapult', () => {
   });
 
   it('Cannot play without energy production', () => {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Cannot play if oxygen level too high', () => {
     player.production.add(Resources.ENERGY, 1);
     (game as any).oxygenLevel = 9;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     player.production.override({energy: 1});
     (game as any).oxygenLevel = 8;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {

--- a/tests/cards/base/FoodFactory.spec.ts
+++ b/tests/cards/base/FoodFactory.spec.ts
@@ -20,7 +20,7 @@ describe('FoodFactory', function() {
     player.production.add(Resources.PLANTS, 1);
     expect(player.simpleCanPlay(card)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.plants).to.eq(0);
     expect(player.production.megacredits).to.eq(4);
 

--- a/tests/cards/base/FuelFactory.spec.ts
+++ b/tests/cards/base/FuelFactory.spec.ts
@@ -19,7 +19,7 @@ describe('FuelFactory', function() {
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
     expect(player.simpleCanPlay(card)).is.true;
-    player.simplePlay(card);
+    card.play(player);
 
     expect(player.production.energy).to.eq(0);
     expect(player.production.megacredits).to.eq(1);

--- a/tests/cards/base/FueledGenerators.spec.ts
+++ b/tests/cards/base/FueledGenerators.spec.ts
@@ -9,7 +9,7 @@ describe('FueledGenerators', function() {
     const player = TestPlayer.BLUE.newPlayer();
 
     player.production.add(Resources.PLANTS, 1);
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.megacredits).to.eq(-1);
     expect(player.production.energy).to.eq(1);
   });

--- a/tests/cards/base/FusionPower.spec.ts
+++ b/tests/cards/base/FusionPower.spec.ts
@@ -20,7 +20,7 @@ describe('FusionPower', function() {
     player.playedCards.push(card, card);
     expect(player.simpleCanPlay(card)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(3);
   });
 });

--- a/tests/cards/base/GHGFactories.spec.ts
+++ b/tests/cards/base/GHGFactories.spec.ts
@@ -14,13 +14,13 @@ describe('GHGFactories', function() {
   });
 
   it('Can not play', function() {
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.canPlayIgnoringCost(card)).is.true;
-    player.simplePlay(card);
+    expect(card.canPlay(player)).is.true;
+    card.play(player);
 
     expect(player.production.energy).to.eq(0);
     expect(player.production.heat).to.eq(4);

--- a/tests/cards/base/GeothermalPower.spec.ts
+++ b/tests/cards/base/GeothermalPower.spec.ts
@@ -6,7 +6,7 @@ describe('GeothermalPower', function() {
   it('Should play', function() {
     const card = new GeothermalPower();
     const player = TestPlayer.BLUE.newPlayer();
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.energy).to.eq(2);
   });

--- a/tests/cards/base/GreatDam.spec.ts
+++ b/tests/cards/base/GreatDam.spec.ts
@@ -17,15 +17,15 @@ describe('GreatDam', () => {
 
   it('Can play', () => {
     maxOutOceans(player, 3);
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     maxOutOceans(player, 4);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
     maxOutOceans(player, 4);
-    expect(player.canPlayIgnoringCost(card)).is.true;
-    player.simplePlay(card);
+    expect(card.canPlay(player)).is.true;
+    card.play(player);
 
     expect(player.production.energy).to.eq(2);
     expect(card.getVictoryPoints()).to.eq(1);

--- a/tests/cards/base/IndustrialMicrobes.spec.ts
+++ b/tests/cards/base/IndustrialMicrobes.spec.ts
@@ -9,7 +9,7 @@ describe('IndustrialMicrobes', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, redPlayer], player);
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.energy).to.eq(1);
     expect(player.production.steel).to.eq(1);

--- a/tests/cards/base/MagneticFieldDome.spec.ts
+++ b/tests/cards/base/MagneticFieldDome.spec.ts
@@ -24,7 +24,7 @@ describe('MagneticFieldDome', function() {
     player.production.add(Resources.ENERGY, 2);
     expect(player.simpleCanPlay(card)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(1);
     expect(player.getTerraformRating()).to.eq(21);

--- a/tests/cards/base/MagneticFieldGenerators.spec.ts
+++ b/tests/cards/base/MagneticFieldGenerators.spec.ts
@@ -24,7 +24,7 @@ describe('MagneticFieldGenerators', function() {
     player.production.add(Resources.ENERGY, 4);
     expect(player.simpleCanPlay(card)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(2);
     expect(player.getTerraformRating()).to.eq(23);

--- a/tests/cards/base/Mine.spec.ts
+++ b/tests/cards/base/Mine.spec.ts
@@ -6,7 +6,7 @@ describe('Mine', function() {
   it('Should play', function() {
     const card = new Mine();
     const player = TestPlayer.BLUE.newPlayer();
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.steel).to.eq(1);
   });

--- a/tests/cards/base/MoholeArea.spec.ts
+++ b/tests/cards/base/MoholeArea.spec.ts
@@ -12,7 +12,7 @@ describe('MoholeArea', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, redPlayer], player);
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     const space = action.availableSpaces[0];
     action.cb(space);
 

--- a/tests/cards/base/NaturalPreserve.spec.ts
+++ b/tests/cards/base/NaturalPreserve.spec.ts
@@ -24,22 +24,22 @@ describe('NaturalPreserve', () => {
       game.addTile(player, land.spaceType, land, {tileType: TileType.NATURAL_PRESERVE});
     }
 
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Cannot play if oxygen level too high', () => {
     (game as any).oxygenLevel = 5;
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     (game as any).oxygenLevel = 4;
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
-    expect(player.canPlayIgnoringCost(card)).is.true;
-    const action = cast(player.simplePlay(card), SelectSpace);
+    expect(card.canPlay(player)).is.true;
+    const action = cast(card.play(player), SelectSpace);
     const space = action.availableSpaces[0];
     action.cb(space);
     expect(player.production.megacredits).to.eq(1);

--- a/tests/cards/base/NoctisCity.spec.ts
+++ b/tests/cards/base/NoctisCity.spec.ts
@@ -32,7 +32,7 @@ describe('NoctisCity', function() {
     const game = newTestGame(2, {boardName: BoardName.HELLAS});
     const player = game.getPlayersInGenerationOrder()[0];
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     expect(action!.availableSpaces).deep.eq(game.board.getAvailableSpacesForCity(player));
   });
 
@@ -40,7 +40,7 @@ describe('NoctisCity', function() {
     player.production.add(Resources.ENERGY, 1);
     expect(player.simpleCanPlay(card)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.production.megacredits).to.eq(3);
 

--- a/tests/cards/base/NoctisFarming.spec.ts
+++ b/tests/cards/base/NoctisFarming.spec.ts
@@ -16,14 +16,14 @@ describe('NoctisFarming', function() {
   });
 
   it('Can not play', function() {
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     (game as any).temperature = -20;
     expect(player.simpleCanPlay(card)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.megacredits).to.eq(1);
     expect(player.plants).to.eq(2);
 

--- a/tests/cards/base/NuclearPower.spec.ts
+++ b/tests/cards/base/NuclearPower.spec.ts
@@ -23,7 +23,7 @@ describe('NuclearPower', function() {
 
   it('Should play', function() {
     expect(player.simpleCanPlay(card)).is.true;
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.megacredits).to.eq(-2);
     expect(player.production.energy).to.eq(3);
   });

--- a/tests/cards/base/OpenCity.spec.ts
+++ b/tests/cards/base/OpenCity.spec.ts
@@ -19,21 +19,21 @@ describe('OpenCity', function() {
   });
 
   it('Can not play without energy production', function() {
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if oxygen level too low', function() {
     player.production.add(Resources.ENERGY, 1);
     (game as any).oxygenLevel = 11;
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
     (game as any).oxygenLevel = 12;
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(action.availableSpaces[0]);
     expect(game.getCitiesOnMarsCount()).to.eq(1);
 

--- a/tests/cards/base/PeroxidePower.spec.ts
+++ b/tests/cards/base/PeroxidePower.spec.ts
@@ -6,7 +6,7 @@ describe('PeroxidePower', function() {
   it('Should play', function() {
     const card = new PeroxidePower();
     const player = TestPlayer.BLUE.newPlayer();
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.megacredits).to.eq(-1);
     expect(player.production.energy).to.eq(2);

--- a/tests/cards/base/PowerPlant.spec.ts
+++ b/tests/cards/base/PowerPlant.spec.ts
@@ -6,7 +6,7 @@ describe('PowerPlant', function() {
   it('Should play', function() {
     const card = new PowerPlant();
     const player = TestPlayer.BLUE.newPlayer();
-    expect(player.simplePlay(card)).is.undefined;
+    expect(card.play(player)).is.undefined;
     expect(player.production.energy).to.eq(1);
   });
 });

--- a/tests/cards/base/ProtectedValley.spec.ts
+++ b/tests/cards/base/ProtectedValley.spec.ts
@@ -12,7 +12,7 @@ describe('ProtectedValley', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
     const game = Game.newInstance('gameid', [player, redPlayer], player);
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(action.availableSpaces[0]);
     expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.GREENERY);
     expect(player.production.megacredits).to.eq(2);

--- a/tests/cards/base/RadChemFactory.spec.ts
+++ b/tests/cards/base/RadChemFactory.spec.ts
@@ -17,14 +17,14 @@ describe('RadChemFactory', function() {
   });
 
   it('Can not play', function() {
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.getTerraformRating()).to.eq(22);
   });

--- a/tests/cards/base/SoilFactory.spec.ts
+++ b/tests/cards/base/SoilFactory.spec.ts
@@ -13,14 +13,14 @@ describe('SoilFactory', function() {
   });
 
   it('Can not play', function() {
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(1);
 

--- a/tests/cards/base/SolarPower.spec.ts
+++ b/tests/cards/base/SolarPower.spec.ts
@@ -7,7 +7,7 @@ describe('SolarPower', function() {
   it('Should play', function() {
     const card = new SolarPower();
     const player = TestPlayer.BLUE.newPlayer();
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.energy).to.eq(1);
     expect(card.getVictoryPoints()).to.eq(1);

--- a/tests/cards/base/SpaceElevator.spec.ts
+++ b/tests/cards/base/SpaceElevator.spec.ts
@@ -19,7 +19,7 @@ describe('SpaceElevator', function() {
   });
 
   it('Should play', function() {
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.titanium).to.eq(1);
     expect(card.getVictoryPoints()).to.eq(2);
   });

--- a/tests/cards/base/StripMine.spec.ts
+++ b/tests/cards/base/StripMine.spec.ts
@@ -35,7 +35,7 @@ describe('StripMine', function() {
     player.production.add(Resources.ENERGY, 2);
     expect(player.simpleCanPlay(card)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.production.steel).to.eq(2);
     expect(player.production.titanium).to.eq(1);

--- a/tests/cards/base/TectonicStressPower.spec.ts
+++ b/tests/cards/base/TectonicStressPower.spec.ts
@@ -13,13 +13,13 @@ describe('TectonicStressPower', function() {
   });
 
   it('Can not play', function() {
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new SearchForLife(), new SearchForLife());
-    expect(player.canPlayIgnoringCost(card)).is.true;
-    player.simplePlay(card);
+    expect(card.canPlay(player)).is.true;
+    card.play(player);
 
     expect(player.production.energy).to.eq(3);
     expect(card.getVictoryPoints()).to.eq(1);

--- a/tests/cards/base/TitaniumMine.spec.ts
+++ b/tests/cards/base/TitaniumMine.spec.ts
@@ -9,7 +9,7 @@ describe('TitaniumMine', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, redPlayer], player);
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.titanium).to.eq(1);
   });

--- a/tests/cards/base/TropicalResort.spec.ts
+++ b/tests/cards/base/TropicalResort.spec.ts
@@ -9,7 +9,7 @@ describe('TropicalResort', function() {
     const card = new TropicalResort();
     const player = TestPlayer.BLUE.newPlayer();
     player.production.add(Resources.HEAT, 2);
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.heat).to.eq(0);
     expect(player.production.megacredits).to.eq(3);

--- a/tests/cards/base/UndergroundCity.spec.ts
+++ b/tests/cards/base/UndergroundCity.spec.ts
@@ -27,7 +27,7 @@ describe('UndergroundCity', function() {
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 2);
     expect(player.simpleCanPlay(card)).is.true;
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(action.availableSpaces[0]);
     expect(game.getCitiesCount()).to.eq(1);

--- a/tests/cards/base/UrbanizedArea.spec.ts
+++ b/tests/cards/base/UrbanizedArea.spec.ts
@@ -43,7 +43,7 @@ describe('UrbanizedArea', function() {
     player.production.add(Resources.ENERGY, 1);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     expect(action.availableSpaces).has.lengthOf(1);
 
     action.cb(action.availableSpaces[0]);

--- a/tests/cards/base/Windmills.spec.ts
+++ b/tests/cards/base/Windmills.spec.ts
@@ -17,13 +17,13 @@ describe('Windmills', function() {
 
   it('Can not play', function() {
     (game as any).oxygenLevel = 6;
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
   it('Should play', function() {
     (game as any).oxygenLevel = 7;
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(1);
     expect(card.getVictoryPoints()).to.eq(1);
   });

--- a/tests/cards/colonies/SpacePort.spec.ts
+++ b/tests/cards/colonies/SpacePort.spec.ts
@@ -38,7 +38,7 @@ describe('SpacePort', function() {
     player.game.colonies[0].colonies.push(player.id);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(action.availableSpaces[0]);
     expect(player.production.energy).to.eq(0);
     expect(player.production.megacredits).to.eq(4);

--- a/tests/cards/colonies/SpinoffDepartment.spec.ts
+++ b/tests/cards/colonies/SpinoffDepartment.spec.ts
@@ -11,7 +11,7 @@ describe('SpinoffDepartment', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, player2], player);
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.megacredits).to.eq(2);
     card.onCardPlayed(player, card2);

--- a/tests/cards/corporation/MiningGuild.spec.ts
+++ b/tests/cards/corporation/MiningGuild.spec.ts
@@ -4,11 +4,12 @@ import {Game} from '../../../src/server/Game';
 import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {Phase} from '../../../src/common/Phase';
-import {maxOutOceans, setCustomGameOptions, runAllActions} from '../../TestingUtils';
+import {maxOutOceans, setCustomGameOptions, runAllActions, cast} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {BoardType} from '../../../src/server/boards/BoardType';
 import {TileType} from '../../../src/common/TileType';
 import {OceanCity} from '../../../src/server/cards/ares/OceanCity';
+import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 
 describe('MiningGuild', () => {
   let card: MiningGuild;
@@ -29,7 +30,7 @@ describe('MiningGuild', () => {
   });
 
   it('Should play', () => {
-    player.simplePlay(card);
+    card.play(player);
     expect(player.steel).to.eq(5);
     expect(player.production.steel).to.eq(1);
   });
@@ -89,7 +90,7 @@ describe('MiningGuild', () => {
     expect(player.production.steel).to.eq(1);
 
     const oceanCity = new OceanCity();
-    const selectSpace = oceanCity.play(player);
+    const selectSpace = cast(oceanCity.play(player), SelectSpace);
     selectSpace.cb(space);
 
     expect(space.tile?.tileType).equal(TileType.OCEAN_CITY);

--- a/tests/cards/pathfinders/CommunicationCenter.spec.ts
+++ b/tests/cards/pathfinders/CommunicationCenter.spec.ts
@@ -22,18 +22,18 @@ describe('CommunicationCenter', function() {
   });
 
   it('canPlay', () => {
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.production.add(Resources.ENERGY, 1);
 
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', () => {
     card.resourceCount = 0;
     player.production.add(Resources.ENERGY, 2);
 
-    expect(player.simplePlay(card));
+    expect(card.play(player));
 
     runAllActions(game);
 

--- a/tests/cards/pathfinders/DesignedOrganisms.spec.ts
+++ b/tests/cards/pathfinders/DesignedOrganisms.spec.ts
@@ -21,10 +21,10 @@ describe('DesignedOrganisms', function() {
 
   it('canPlay', function() {
     player.tagsForTest = {science: 4};
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.tagsForTest = {science: 5};
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {
@@ -32,7 +32,7 @@ describe('DesignedOrganisms', function() {
     const penguins = new Penguins();
     player.playedCards = [tardigrades, penguins];
 
-    player.simplePlay(card);
+    card.play(player);
     runAllActions(game);
 
     expect(player.plants).eq(3);

--- a/tests/cards/pathfinders/EarlyExpedition.spec.ts
+++ b/tests/cards/pathfinders/EarlyExpedition.spec.ts
@@ -22,15 +22,15 @@ describe('EarlyExpedition', function() {
   it('canPlay', function() {
     (game as any).temperature = -16;
     player.production.override({energy: 1});
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     (game as any).temperature = -18;
     player.production.override({energy: 0});
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     (game as any).temperature = -18;
     player.production.override({energy: 1});
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {
@@ -38,7 +38,7 @@ describe('EarlyExpedition', function() {
     const lunarObservationPost = new LunarObservationPost(); // Holds data.
     player.playedCards = [lunarObservationPost];
 
-    const selectSpace = cast(player.simplePlay(card), SelectSpace);
+    const selectSpace = cast(card.play(player), SelectSpace);
     runAllActions(game);
 
     expect(player.production.asUnits()).eql(Units.of({megacredits: 3}));

--- a/tests/cards/pathfinders/LobbyHalls.spec.ts
+++ b/tests/cards/pathfinders/LobbyHalls.spec.ts
@@ -27,7 +27,7 @@ describe('LobbyHalls', function() {
   });
 
   it('play', function() {
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.asUnits()).deep.eq(Units.of({megacredits: 2}));
   });
 
@@ -35,7 +35,7 @@ describe('LobbyHalls', function() {
     turmoil.delegateReserve = [];
     expect(card.tags).deep.eq([Tag.CLONE, Tag.BUILDING]);
 
-    player.simplePlay(card);
+    card.play(player);
 
     // Only one available action
     expect(game.deferredActions.length).eq(1);
@@ -48,7 +48,7 @@ describe('LobbyHalls', function() {
     expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(6);
     expect(card.tags).deep.eq([Tag.CLONE, Tag.BUILDING]);
 
-    player.simplePlay(card);
+    card.play(player);
 
     expect(game.deferredActions.length).eq(2);
 

--- a/tests/cards/pathfinders/MartianDustProcessingPlant.spec.ts
+++ b/tests/cards/pathfinders/MartianDustProcessingPlant.spec.ts
@@ -18,16 +18,16 @@ describe('MartianDustProcessingPlant', function() {
 
   it('canPlay', function() {
     player.production.override({energy: 0});
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
     player.production.override({energy: 1});
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {
     player.production.override({energy: 1});
     expect(player.getTerraformRating()).eq(14);
 
-    player.simplePlay(card);
+    card.play(player);
 
     expect(player.production.asUnits()).deep.eq(Units.of({steel: 2}));
     expect(player.getTerraformRating()).eq(15);

--- a/tests/cards/pathfinders/MartianRepository.spec.ts
+++ b/tests/cards/pathfinders/MartianRepository.spec.ts
@@ -17,14 +17,14 @@ describe('MartianRepository', function() {
   });
 
   it('can play', function() {
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
     player.production.override({energy: 1});
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {
     player.production.override({energy: 1});
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.asUnits()).deep.eq(Units.EMPTY);
   });
 

--- a/tests/cards/pathfinders/MuseumofEarlyColonisation.spec.ts
+++ b/tests/cards/pathfinders/MuseumofEarlyColonisation.spec.ts
@@ -23,32 +23,32 @@ describe('MuseumofEarlyColonisation', function() {
     const greenery = addGreenery(player2);
     const city = addCity(player2);
     player.production.override({energy: 1});
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.production.override({energy: 0});
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.production.override({energy: 1});
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     ocean.tile!.tileType = TileType.BIOFERTILIZER_FACILITY;
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     ocean.tile!.tileType = TileType.OCEAN;
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     greenery.tile!.tileType = TileType.BIOFERTILIZER_FACILITY;
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     greenery.tile!.tileType = TileType.GREENERY;
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     city.tile!.tileType = TileType.BIOFERTILIZER_FACILITY;
-    expect(player.canPlayIgnoringCost(card)).is.false;
+    expect(card.canPlay(player)).is.false;
   });
 
   it('play', function() {
     player.production.override({energy: 1});
     expect(player.getTerraformRating()).eq(20);
 
-    player.simplePlay(card);
+    card.play(player);
 
     expect(player.production.asUnits()).deep.eq(Units.of({steel: 1, titanium: 1, plants: 1}));
     expect(player.getTerraformRating()).eq(21);

--- a/tests/cards/pathfinders/NewVenice.spec.ts
+++ b/tests/cards/pathfinders/NewVenice.spec.ts
@@ -45,7 +45,7 @@ describe('NewVenice', function() {
     player.plants = 2;
     player.production.override({energy: 0, megacredits: 0});
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     expect(player.plants).eq(0);
     expect(player.production.megacredits).eq(2);
@@ -65,7 +65,7 @@ describe('NewVenice', function() {
   it('Cannot place a city next to New Venice', function() {
     const oceanSpace = addOcean(player);
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(oceanSpace);
 
@@ -88,7 +88,7 @@ describe('NewVenice', function() {
       .filter((space) => space.spaceType === SpaceType.LAND)[0];
     game.addCityTile(player, citySpace.id);
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(oceanSpace);
     expect(oceanSpace.player).to.eq(player);
@@ -97,7 +97,7 @@ describe('NewVenice', function() {
 
   it('New Venice counts as ocean for adjacency', function() {
     const oceanSpace = addOcean(player);
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(oceanSpace);
     const greenery = game.board
       .getAdjacentSpaces(oceanSpace)
@@ -112,7 +112,7 @@ describe('NewVenice', function() {
 
   it('New Venice counts for city-related VP', function() {
     const oceanSpace = addOcean(player);
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(oceanSpace);
     const greenery = game.board
       .getAdjacentSpaces(oceanSpace)
@@ -129,7 +129,7 @@ describe('NewVenice', function() {
     const oceanSpace = game.board.getAvailableSpacesForOcean(player)[0];
 
     const capital = new Capital();
-    const capitalAction = capital.play(player);
+    const capitalAction = cast(capital.play(player), SelectSpace);
     player.playedCards = [capital];
 
     const capitalSpace = game.board
@@ -143,7 +143,7 @@ describe('NewVenice', function() {
 
     // And now adds the tile.
     game.addOceanTile(player, oceanSpace.id);
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(oceanSpace);
     expect(oceanSpace.tile!.tileType).to.eq(TileType.OCEAN_CITY);
@@ -160,7 +160,7 @@ describe('NewVenice', function() {
     game.addOceanTile(player, oceanSpace.id);
     expect(player.plants).eq(4);
 
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(oceanSpace);
 

--- a/tests/cards/pathfinders/PowerPlant.spec.ts
+++ b/tests/cards/pathfinders/PowerPlant.spec.ts
@@ -16,7 +16,7 @@ describe('PowerPlant', function() {
   });
 
   it('play', function() {
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.asUnits()).deep.eq(Units.of({heat: 2, energy: 1}));
   });

--- a/tests/cards/pathfinders/RedCity.spec.ts
+++ b/tests/cards/pathfinders/RedCity.spec.ts
@@ -88,7 +88,7 @@ describe('RedCity', function() {
   it('play', function() {
     const redCitySpace = board.getSpace('53');
     player.production.override({energy: 1});
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     expect(player.production.asUnits()).deep.eq(Units.of({energy: 0, megacredits: 2}));
     expect(action.availableSpaces).includes(redCitySpace);
 
@@ -101,7 +101,7 @@ describe('RedCity', function() {
   it('vps', function() {
     const redCitySpace = board.getSpace('53');
     player.production.override({energy: 1});
-    cast(player.simplePlay(card), SelectSpace).cb(redCitySpace);
+    cast(card.play(player), SelectSpace).cb(redCitySpace);
 
     expect(card.getVictoryPoints(player)).eq(4);
 
@@ -121,7 +121,7 @@ describe('RedCity', function() {
   it('cannot place greenery next to red city', function() {
     const redCitySpace = board.getSpace('53');
     player.production.override({energy: 1});
-    cast(player.simplePlay(card), SelectSpace).cb(redCitySpace);
+    cast(card.play(player), SelectSpace).cb(redCitySpace);
     const adjacentSpaces = board.getAdjacentSpaces(redCitySpace);
 
     // Nobody may place a greenery next to Red City.

--- a/tests/cards/prelude/CheungShingMARS.spec.ts
+++ b/tests/cards/prelude/CheungShingMARS.spec.ts
@@ -24,7 +24,7 @@ describe('CheungShingMARS', function() {
   });
 
   it('Should play', function() {
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.megacredits).to.eq(3);
   });
 });

--- a/tests/cards/prelude/HousePrinting.spec.ts
+++ b/tests/cards/prelude/HousePrinting.spec.ts
@@ -6,7 +6,7 @@ describe('HousePrinting', function() {
   it('Should play', function() {
     const card = new HousePrinting();
     const player = TestPlayer.BLUE.newPlayer();
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(card.getVictoryPoints()).to.eq(1);
     expect(player.production.steel).to.eq(1);

--- a/tests/cards/prelude/LavaTubeSettlement.spec.ts
+++ b/tests/cards/prelude/LavaTubeSettlement.spec.ts
@@ -42,7 +42,7 @@ describe('LavaTubeSettlement', function() {
     player.production.add(Resources.ENERGY, 1);
     expect(player.simpleCanPlay(card)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     const selectSpace = game.deferredActions.peek()!.execute() as SelectSpace;
     selectSpace.cb(selectSpace.availableSpaces[0]);
 

--- a/tests/cards/promo/AsteroidDeflectionSystem.spec.ts
+++ b/tests/cards/promo/AsteroidDeflectionSystem.spec.ts
@@ -18,14 +18,14 @@ describe('AsteroidDeflectionSystem', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.energy).to.eq(0);
   });
 

--- a/tests/cards/promo/Factorum.spec.ts
+++ b/tests/cards/promo/Factorum.spec.ts
@@ -24,7 +24,7 @@ describe('Factorum', function() {
   });
 
   it('Should play', function() {
-    const play = player.simplePlay(card);
+    const play = card.play(player);
     expect(play).is.undefined;
     expect(player.production.steel).to.eq(1);
     player.megaCredits = 10;
@@ -44,7 +44,7 @@ describe('Factorum', function() {
   });
 
   it('Only offer building card if player has energy', function() {
-    const play = player.simplePlay(card);
+    const play = card.play(player);
     expect(play).is.undefined;
     player.megaCredits = 10;
     player.energy = 1;

--- a/tests/cards/promo/FieldCappedCity.spec.ts
+++ b/tests/cards/promo/FieldCappedCity.spec.ts
@@ -12,7 +12,7 @@ describe('FieldCappedCity', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, redPlayer], player);
-    const action = cast(player.simplePlay(card), SelectSpace);
+    const action = cast(card.play(player), SelectSpace);
     action.cb(action.availableSpaces[0]);
     expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.CITY);
     expect(player.plants).to.eq(3);

--- a/tests/cards/promo/GreatDamPromo.spec.ts
+++ b/tests/cards/promo/GreatDamPromo.spec.ts
@@ -25,7 +25,7 @@ describe('GreatDamPromo', function() {
   it('Should play', function() {
     maxOutOceans(player, 4);
 
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).instanceOf(SelectSpace);
     expect(player.production.energy).to.eq(2);
     expect(card.getVictoryPoints()).to.eq(1);
@@ -34,7 +34,7 @@ describe('GreatDamPromo', function() {
   it('Works with Ares', function() {
     maxOutOceans(player, 4).forEach((space) => space.tile = {tileType: TileType.OCEAN_CITY});
 
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).instanceOf(SelectSpace);
     expect(player.production.energy).to.eq(2);
     expect(card.getVictoryPoints()).to.eq(1);

--- a/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
+++ b/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
@@ -26,7 +26,7 @@ describe('MagneticFieldGeneratorsPromo', function() {
     player.production.add(Resources.ENERGY, 4);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).instanceOf(SelectSpace);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(2);

--- a/tests/cards/promo/Recyclon.spec.ts
+++ b/tests/cards/promo/Recyclon.spec.ts
@@ -6,7 +6,7 @@ describe('Recyclon', function() {
   it('Should play', function() {
     const card = new Recyclon();
     const player = TestPlayer.BLUE.newPlayer();
-    const play = player.simplePlay(card);
+    const play = card.play(player);
     expect(play).is.undefined;
     expect(player.production.steel).to.eq(1);
     expect(card.resourceCount).to.eq(1);

--- a/tests/cards/turmoil/CulturalMetropolis.spec.ts
+++ b/tests/cards/turmoil/CulturalMetropolis.spec.ts
@@ -30,13 +30,13 @@ describe('Cultural Metropolis', function() {
   it('Can not play without energy production', function() {
     turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'lobby');
     turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'reserve');
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
 
   it('Can not play without two delegate in unity or unity ruling', function() {
     player.production.add(Resources.ENERGY, 1);
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play without 2 delegates available', function() {
@@ -47,9 +47,9 @@ describe('Cultural Metropolis', function() {
       turmoil.sendDelegateToParty(player.id, PartyName.REDS, game, 'reserve');
     }
     expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).to.equal(2);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     turmoil.sendDelegateToParty(player.id, PartyName.REDS, game, 'reserve');
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
@@ -62,9 +62,9 @@ describe('Cultural Metropolis', function() {
 
     expect(unity.delegates).has.lengthOf(startingUnityDelegateCount + 2);
     expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).to.equal(5);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(game.deferredActions).has.lengthOf(2);
     player.game.deferredActions.pop(); // Pop out the city placement deferred action
     const action = player.game.deferredActions.pop() as SendDelegateToArea;

--- a/tests/cards/turmoil/MartianMediaCenter.spec.ts
+++ b/tests/cards/turmoil/MartianMediaCenter.spec.ts
@@ -12,13 +12,13 @@ describe('MartianMediaCenter', function() {
 
     const gameOptions = setCustomGameOptions();
     const game = Game.newInstance('gameid', [player], player, gameOptions);
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     const mars = game.turmoil!.getPartyByName(PartyName.MARS)!;
     mars.delegates.push(player.id, player.id);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.megacredits).to.eq(2);
   });
 });

--- a/tests/cards/turmoil/SponsoredMohole.spec.ts
+++ b/tests/cards/turmoil/SponsoredMohole.spec.ts
@@ -12,13 +12,13 @@ describe('SponsoredMohole', function() {
     const redPlayer = TestPlayer.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
     const game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     const kelvinists = game.turmoil!.getPartyByName(PartyName.KELVINISTS)!;
     kelvinists.delegates.push(player.id, player.id);
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.heat).to.eq(2);
   });
 });

--- a/tests/cards/turmoil/UtopiaInvest.spec.ts
+++ b/tests/cards/turmoil/UtopiaInvest.spec.ts
@@ -11,7 +11,7 @@ describe('UtopiaInvest', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, redPlayer], player, setCustomGameOptions());
-    const play = player.simplePlay(card);
+    const play = card.play(player);
     expect(play).is.undefined;
     expect(player.production.titanium).to.eq(1);
     expect(player.production.steel).to.eq(1);

--- a/tests/cards/venusNext/Manutech.spec.ts
+++ b/tests/cards/venusNext/Manutech.spec.ts
@@ -19,7 +19,7 @@ describe('Manutech', function() {
   });
 
   it('Should play', function() {
-    player.simplePlay(card);
+    card.play(player);
     expect(player.production.steel).to.eq(1);
     expect(player.steel).to.eq(1);
   });

--- a/tests/cards/venusNext/MiningQuota.spec.ts
+++ b/tests/cards/venusNext/MiningQuota.spec.ts
@@ -8,30 +8,30 @@ describe('MiningQuota', function() {
     const card = new MiningQuota();
     const player = TestPlayer.BLUE.newPlayer();
     player.playedCards.push(new SisterPlanetSupport);
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1};
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {earth: 1};
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {jovian: 1};
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, earth: 1};
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {jovian: 1, earth: 1};
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, jovian: 1};
-    expect(player.canPlayIgnoringCost(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, jovian: 1, earth: 1};
-    expect(player.canPlayIgnoringCost(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    const action = player.simplePlay(card);
+    const action = card.play(player);
     expect(action).is.undefined;
     expect(player.production.steel).to.eq(2);
   });


### PR DESCRIPTION
This is going to be cleaner and easier to manage than the current
approach. This removes most uses of `migrated`. The rest will come
shortly.