### PR TITLE
Lost of syntactic test improvements that improve typing.

### DIFF
--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -28,7 +28,7 @@ import {RandomMAOptionType} from '../src/common/ma/RandomMAOptionType';
 import {SpaceBonus} from '../src/common/boards/SpaceBonus';
 import {TileType} from '../src/common/TileType';
 import {IColony} from '../src/server/colonies/IColony';
-import {IAward} from '@/server/awards/IAward';
+import {IAward} from '../src/server/awards/IAward';
 
 describe('Game', () => {
   it('should initialize with right defaults', () => {
@@ -226,8 +226,8 @@ describe('Game', () => {
     // Must remove waitingFor or playerIsFinishedTakingActions
     // will pre-emptively exit -- you can't end the game
     // if the game is waiting for a player to do something!
-    (player as any).waitingFor = undefined;
-    (player2 as any).waitingFor = undefined;
+    player.popWaitingFor();
+    player2.popWaitingFor();
     game.playerIsFinishedTakingActions();
     // Now game should be in end state
     expect(game.phase).to.eq(Phase.END);
@@ -300,8 +300,8 @@ describe('Game', () => {
     // Must remove waitingFor or playerIsFinishedTakingActions
     // will pre-emptively exit -- you can't end the game
     // if the game is waiting for a player to do something!
-    (player as any).waitingFor = undefined;
-    (otherPlayer as any).waitingFor = undefined;
+    player.popWaitingFor();
+    otherPlayer.popWaitingFor();
 
     // Trigger end game
     player.setTerraformRating(20);
@@ -331,14 +331,14 @@ describe('Game', () => {
   });
 
   it('Final greenery placement in order of the current generation', () => {
-    const player1 = new Player('p1', Color.BLUE, false, 0, 'p1-id');
-    const player2 = new Player('p2', Color.GREEN, false, 0, 'p2-id');
-    const player3 = new Player('p3', Color.YELLOW, false, 0, 'p3-id');
-    const player4 = new Player('p4', Color.RED, false, 0, 'p4-id');
+    const player1 = new TestPlayer(Color.BLUE);
+    const player2 = new TestPlayer(Color.GREEN);
+    const player3 = new TestPlayer(Color.YELLOW);
+    const player4 = new TestPlayer(Color.RED);
     const game = Game.newInstance('gto', [player1, player2, player3, player4], player3);
 
-    game.getPlayersInGenerationOrder().forEach((p) => {
-      (p as any).waitingFor = undefined;
+    [player1, player2, player3, player4].forEach((p) => {
+      p.popWaitingFor();
       p.plants = 8;
     });
 
@@ -383,15 +383,15 @@ describe('Game', () => {
   });
 
   it('Final greenery placement skips players without enough plants', () => {
-    const player1 = new Player('p1', Color.BLUE, false, 0, 'p1-id');
-    const player2 = new Player('p2', Color.GREEN, false, 0, 'p2-id');
-    const player3 = new Player('p3', Color.YELLOW, false, 0, 'p3-id');
-    const player4 = new Player('p4', Color.RED, false, 0, 'p4-id');
+    const player1 = new TestPlayer(Color.BLUE);
+    const player2 = new TestPlayer(Color.GREEN);
+    const player3 = new TestPlayer(Color.YELLOW);
+    const player4 = new TestPlayer(Color.RED);
     const game = Game.newInstance('gto', [player1, player2, player3, player4], player2);
     game.incrementFirstPlayer();
 
-    game.getPlayersInGenerationOrder().forEach((p) => {
-      (p as any).waitingFor = undefined;
+    [player1, player2, player3, player4].forEach((p) => {
+      p.popWaitingFor();
     });
 
     player1.plants = 8;

--- a/tests/cards/ares/IndustrialCenterAres.spec.ts
+++ b/tests/cards/ares/IndustrialCenterAres.spec.ts
@@ -6,6 +6,8 @@ import {IndustrialCenterAres} from '../../../src/server/cards/ares/IndustrialCen
 import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
 import {TestPlayer} from '../../TestPlayer';
+import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
+import {cast} from '../../TestingUtils';
 
 describe('IndustrialCenterAres', function() {
   let card: IndustrialCenterAres;
@@ -23,11 +25,10 @@ describe('IndustrialCenterAres', function() {
     game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
     expect(game.getCitiesOnMarsCount()).to.eq(1);
 
-    const action = card.play(player);
-    const space = action!.availableSpaces[0];
-        action!.cb(space);
-        expect(space.tile).is.not.undefined;
-        expect(space.tile && space.tile.tileType).to.eq(TileType.INDUSTRIAL_CENTER);
-        expect(space.adjacency).to.deep.eq({bonus: [SpaceBonus.STEEL]});
+    const action = cast(card.play(player), SelectSpace);
+    const space = action.availableSpaces[0];
+    action.cb(space);
+    expect(space.tile?.tileType).to.eq(TileType.INDUSTRIAL_CENTER);
+    expect(space.adjacency).to.deep.eq({bonus: [SpaceBonus.STEEL]});
   });
 });

--- a/tests/cards/base/AerobrakedAmmoniaAsteroid.spec.ts
+++ b/tests/cards/base/AerobrakedAmmoniaAsteroid.spec.ts
@@ -1,4 +1,6 @@
+import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {AerobrakedAmmoniaAsteroid} from '../../../src/server/cards/base/AerobrakedAmmoniaAsteroid';
 import {Ants} from '../../../src/server/cards/base/Ants';
 import {Decomposers} from '../../../src/server/cards/base/Decomposers';
@@ -46,13 +48,12 @@ describe('AerobrakedAmmoniaAsteroid', function() {
     const otherMicrobeCard = new Decomposers();
     player.playedCards.push(selectedCard, otherMicrobeCard);
 
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectCard);
     expect(player.production.heat).to.eq(3);
     expect(player.production.plants).to.eq(1);
 
-    expect(action).is.not.undefined;
-        action!.cb([selectedCard]);
+    action.cb([selectedCard]);
 
-        expect(selectedCard.resourceCount).to.eq(2);
+    expect(selectedCard.resourceCount).to.eq(2);
   });
 });

--- a/tests/cards/base/ArtificialLake.spec.ts
+++ b/tests/cards/base/ArtificialLake.spec.ts
@@ -27,15 +27,15 @@ describe('ArtificialLake', function() {
   it('Should play', function() {
     const action = cast(card.play(player), SelectSpace);
 
-        action!.availableSpaces.forEach((space) => {
-          expect(space.spaceType).to.eq(SpaceType.LAND);
-        });
+    action.availableSpaces.forEach((space) => {
+      expect(space.spaceType).to.eq(SpaceType.LAND);
+    });
 
-        action!.cb(action!.availableSpaces[0]);
-        const placedTile = action!.availableSpaces[0].tile;
-        expect(placedTile!.tileType).to.eq(TileType.OCEAN);
+    action.cb(action!.availableSpaces[0]);
+    const placedTile = action.availableSpaces[0].tile;
+    expect(placedTile!.tileType).to.eq(TileType.OCEAN);
 
-        expect(card.getVictoryPoints()).to.eq(1);
+    expect(card.getVictoryPoints()).to.eq(1);
   });
 
   it('Cannot place ocean if all oceans are already placed', function() {

--- a/tests/cards/base/Birds.spec.ts
+++ b/tests/cards/base/Birds.spec.ts
@@ -5,6 +5,7 @@ import {Game} from '../../../src/server/Game';
 import {Resources} from '../../../src/common/Resources';
 import {SelectPlayer} from '../../../src/server/inputs/SelectPlayer';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('Birds', function() {
   let card: Birds;
@@ -33,7 +34,7 @@ describe('Birds', function() {
 
     card.play(player);
     expect(game.deferredActions).has.lengthOf(1);
-    const selectPlayer = game.deferredActions.peek()!.execute() as SelectPlayer;
+    const selectPlayer = cast(game.deferredActions.peek()!.execute(), SelectPlayer);
     selectPlayer.cb(player2);
 
     expect(player2.production.plants).to.eq(0);

--- a/tests/cards/base/BlackPolarDust.spec.ts
+++ b/tests/cards/base/BlackPolarDust.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {BlackPolarDust} from '../../../src/server/cards/base/BlackPolarDust';
 import {Game} from '../../../src/server/Game';
-import {maxOutOceans} from '../../TestingUtils';
+import {cast, maxOutOceans} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/common/Resources';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
@@ -29,7 +29,7 @@ describe('BlackPolarDust', function() {
     expect(player.production.heat).to.eq(3);
 
     expect(game.deferredActions).has.lengthOf(1);
-    const selectSpace = game.deferredActions.peek()!.execute() as SelectSpace;
+    const selectSpace = cast(game.deferredActions.peek()!.execute(), SelectSpace);
     selectSpace.cb(selectSpace.availableSpaces[0]);
     expect(player.getTerraformRating()).to.eq(21);
   });

--- a/tests/cards/base/BusinessContacts.spec.ts
+++ b/tests/cards/base/BusinessContacts.spec.ts
@@ -1,7 +1,9 @@
 
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {BusinessContacts} from '../../../src/server/cards/base/BusinessContacts';
 import {Game} from '../../../src/server/Game';
+import {IProjectCard} from '../../../src/server/cards/IProjectCard';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {TestPlayer} from '../../TestPlayer';
 
@@ -11,9 +13,7 @@ describe('BusinessContacts', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
     const game = Game.newInstance('gameid', [player, redPlayer], player);
-    const action = card.play(player)!;
-    expect(action).is.not.undefined;
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard<IProjectCard>);
     const card1 = action.cards[0];
     const card2 = action.cards[1];
     const card3 = action.cards[2];

--- a/tests/cards/base/BusinessNetwork.spec.ts
+++ b/tests/cards/base/BusinessNetwork.spec.ts
@@ -4,8 +4,8 @@ import {Player} from '../../../src/server/Player';
 import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Resources} from '../../../src/common/Resources';
-import {IProjectCard} from '../../../src/server/cards/IProjectCard';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('BusinessNetwork', function() {
   let card: BusinessNetwork;
@@ -36,11 +36,10 @@ describe('BusinessNetwork', function() {
 
   it('Cannot buy card if cannot pay', function() {
     player.megaCredits = 2;
-    const action = card.action(player);
-    expect(action).instanceOf(SelectCard);
-    expect(action!.config.max).to.eq(0);
+    const action = cast(card.action(player), SelectCard);
+    expect(action.config.max).to.eq(0);
 
-    (action! as SelectCard<IProjectCard>).cb([]);
+    action.cb([]);
     expect(game.dealer.discarded).has.lengthOf(1);
     expect(player.cardsInHand).has.lengthOf(0);
     expect(player.megaCredits).to.eq(2);
@@ -48,15 +47,14 @@ describe('BusinessNetwork', function() {
 
   it('Should action as not helion', function() {
     player.megaCredits = 3;
-    const action = card.action(player);
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.action(player), SelectCard);
 
-    (action! as SelectCard<IProjectCard>).cb([]);
+    action.cb([]);
     expect(game.dealer.discarded).has.lengthOf(1);
     expect(player.megaCredits).to.eq(3);
 
     player.megaCredits = 3;
-    (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
+    action.cb([action.cards[0]]);
     expect(game.deferredActions).has.lengthOf(1);
     game.deferredActions.runNext();
     expect(player.megaCredits).to.eq(0);

--- a/tests/cards/base/CloudSeeding.spec.ts
+++ b/tests/cards/base/CloudSeeding.spec.ts
@@ -3,7 +3,7 @@ import {CloudSeeding} from '../../../src/server/cards/base/CloudSeeding';
 import {Game} from '../../../src/server/Game';
 import {SelectPlayer} from '../../../src/server/inputs/SelectPlayer';
 import {Resources} from '../../../src/common/Resources';
-import {maxOutOceans} from '../../TestingUtils';
+import {cast, maxOutOceans} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('CloudSeeding', () => {
@@ -67,7 +67,7 @@ describe('CloudSeeding', () => {
     expect(player.production.plants).to.eq(2);
 
     expect(game.deferredActions).has.lengthOf(1);
-    const selectPlayer = game.deferredActions.peek()!.execute() as SelectPlayer;
+    const selectPlayer = cast(game.deferredActions.peek()!.execute(), SelectPlayer);
     selectPlayer.cb(player2);
     expect(player2.production.heat).to.eq(0);
   });

--- a/tests/cards/base/EOSChasmaNationalPark.spec.ts
+++ b/tests/cards/base/EOSChasmaNationalPark.spec.ts
@@ -37,7 +37,7 @@ describe('EosChasmaNationalPark', () => {
     expect(player.getVictoryPoints().victoryPoints).to.eq(0);
     player.playedCards.push(card);
     expect(player.getVictoryPoints().victoryPoints).to.eq(1);
-    action!.cb([birds]);
+    action.cb([birds]);
 
     expect(birds.resourceCount).to.eq(1);
     expect(player.plants).to.eq(3);

--- a/tests/cards/base/ElectroCatapult.spec.ts
+++ b/tests/cards/base/ElectroCatapult.spec.ts
@@ -4,6 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {Resources} from '../../../src/common/Resources';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('ElectroCatapult', () => {
   let card: ElectroCatapult;
@@ -44,16 +45,15 @@ describe('ElectroCatapult', () => {
     player.plants = 1;
     player.steel = 1;
 
-    const action = card.action(player);
-    expect(action).instanceOf(OrOptions);
-    expect(action!.options).has.lengthOf(2);
+    const action = cast(card.action(player), OrOptions);
+    expect(action.options).has.lengthOf(2);
 
-        action!.options[0].cb();
-        expect(player.plants).to.eq(0);
-        expect(player.megaCredits).to.eq(7);
+    action.options[0].cb();
+    expect(player.plants).to.eq(0);
+    expect(player.megaCredits).to.eq(7);
 
-        action!.options[1].cb();
-        expect(player.steel).to.eq(0);
-        expect(player.megaCredits).to.eq(14);
+    action.options[1].cb();
+    expect(player.steel).to.eq(0);
+    expect(player.megaCredits).to.eq(14);
   });
 });

--- a/tests/cards/base/ExtremeColdFungus.spec.ts
+++ b/tests/cards/base/ExtremeColdFungus.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Ants} from '../../../src/server/cards/base/Ants';
 import {ExtremeColdFungus} from '../../../src/server/cards/base/ExtremeColdFungus';
 import {Tardigrades} from '../../../src/server/cards/base/Tardigrades';
@@ -39,15 +40,14 @@ describe('ExtremeColdFungus', () => {
     const tardigrades = new Tardigrades();
     player.playedCards.push(tardigrades);
 
-    const action = card.action(player);
-    expect(action).instanceOf(OrOptions);
-    expect(action!.options).has.lengthOf(2);
+    const action = cast(card.action(player), OrOptions);
+    expect(action.options).has.lengthOf(2);
 
-        action!.options[0].cb();
-        expect(tardigrades.resourceCount).to.eq(2);
+    action.options[0].cb();
+    expect(tardigrades.resourceCount).to.eq(2);
 
-        action!.options[1].cb();
-        expect(player.plants).to.eq(1);
+    action.options[1].cb();
+    expect(player.plants).to.eq(1);
   });
 
   it('Should act - multiple targets', () => {
@@ -55,14 +55,13 @@ describe('ExtremeColdFungus', () => {
     const ants = new Ants();
     player.playedCards.push(tardigrades, ants);
 
-    const action = card.action(player);
-    expect(action).instanceOf(OrOptions);
-    expect(action!.options).has.lengthOf(2);
+    const action = cast(card.action(player), OrOptions);
+    expect(action.options).has.lengthOf(2);
 
-        action!.options[0].cb([tardigrades]);
-        expect(tardigrades.resourceCount).to.eq(2);
+    action.options[0].cb([tardigrades]);
+    expect(tardigrades.resourceCount).to.eq(2);
 
-        action!.options[0].cb([ants]);
-        expect(ants.resourceCount).to.eq(2);
+    action.options[0].cb([ants]);
+    expect(ants.resourceCount).to.eq(2);
   });
 });

--- a/tests/cards/base/Fish.spec.ts
+++ b/tests/cards/base/Fish.spec.ts
@@ -4,6 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectPlayer} from '../../../src/server/inputs/SelectPlayer';
 import {Resources} from '../../../src/common/Resources';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('Fish', function() {
   let card: Fish;
@@ -48,7 +49,7 @@ describe('Fish', function() {
     card.play(player);
 
     expect(game.deferredActions).has.lengthOf(1);
-    const selectPlayer = game.deferredActions.peek()!.execute() as SelectPlayer;
+    const selectPlayer = cast(game.deferredActions.peek()!.execute(), SelectPlayer);
     selectPlayer.cb(player2);
     expect(player2.production.plants).to.eq(0);
   });

--- a/tests/cards/base/Flooding.spec.ts
+++ b/tests/cards/base/Flooding.spec.ts
@@ -36,9 +36,9 @@ describe('Flooding', function() {
       }
     }
 
-    const subAction = cast(action!.cb(oceans[0]), OrOptions);
-    expect(subAction!.options).has.lengthOf(2);
-    expect(subAction!.options[1].cb()).is.undefined;
+    const subAction = cast(action.cb(oceans[0]), OrOptions);
+    expect(subAction.options).has.lengthOf(2);
+    expect(subAction.options[1].cb()).is.undefined;
     const subActionSelectPlayer = cast(subAction.options[0], SelectPlayer);
     expect(subActionSelectPlayer.players).has.lengthOf(1);
     expect(subActionSelectPlayer.players[0]).to.eq(player2);
@@ -75,7 +75,7 @@ describe('Flooding', function() {
     expect(adjacentSpace.tile).is.undefined;
 
     const oceanSpaces = game.board.getAvailableSpacesForOcean(player);
-    const action = card.play(player) as SelectSpace;
+    const action = cast(card.play(player), SelectSpace);
     expect(action.cb(oceanSpaces[0])).is.undefined;
   });
 

--- a/tests/cards/base/GiantIceAsteroid.spec.ts
+++ b/tests/cards/base/GiantIceAsteroid.spec.ts
@@ -28,9 +28,9 @@ describe('GiantIceAsteroid', function() {
     card.play(player);
     expect(game.deferredActions).has.lengthOf(3);
 
-    const firstOcean = game.deferredActions.pop()!.execute() as SelectSpace;
+    const firstOcean = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     firstOcean.cb(firstOcean.availableSpaces[0]);
-    const secondOcean = game.deferredActions.pop()!.execute() as SelectSpace;
+    const secondOcean = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     secondOcean.cb(secondOcean.availableSpaces[1]);
 
     const orOptions = cast(game.deferredActions.pop()!.execute(), OrOptions);
@@ -46,4 +46,3 @@ describe('GiantIceAsteroid', function() {
     expect(player.getTerraformRating()).to.eq(24);
   });
 });
-

--- a/tests/cards/base/HeatTrappers.spec.ts
+++ b/tests/cards/base/HeatTrappers.spec.ts
@@ -4,6 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectPlayer} from '../../../src/server/inputs/SelectPlayer';
 import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/common/Resources';
+import {cast} from '../../TestingUtils';
 
 describe('HeatTrappers', function() {
   let card: HeatTrappers;
@@ -49,7 +50,7 @@ describe('HeatTrappers', function() {
     expect(player.production.energy).to.eq(1);
 
     expect(game.deferredActions).has.lengthOf(1);
-    const selectPlayer = game.deferredActions.peek()!.execute() as SelectPlayer;
+    const selectPlayer = cast(game.deferredActions.peek()!.execute(), SelectPlayer);
     selectPlayer.cb(player2);
     expect(player2.production.heat).to.eq(5);
   });

--- a/tests/cards/base/Herbivores.spec.ts
+++ b/tests/cards/base/Herbivores.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectPlayer} from '../../../src/server/inputs/SelectPlayer';
 import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
-import {runAllActions, runNextAction} from '../../TestingUtils';
+import {cast, runAllActions, runNextAction} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('Herbivores', () => {
@@ -52,7 +52,7 @@ describe('Herbivores', () => {
     expect(card.resourceCount).to.eq(1);
 
     expect(game.deferredActions).has.lengthOf(1);
-    const selectPlayer = runNextAction(game) as SelectPlayer;
+    const selectPlayer = cast(runNextAction(game), SelectPlayer);
     selectPlayer.cb(player2);
     expect(player2.production.plants).to.eq(0);
   });

--- a/tests/cards/base/ImportedHydrogen.spec.ts
+++ b/tests/cards/base/ImportedHydrogen.spec.ts
@@ -34,8 +34,8 @@ describe('ImportedHydrogen', function() {
     action.options[0].cb();
     expect(player.plants).to.eq(3);
 
-    const selectAnimal = action.options[2] as SelectOption;
-    const selectMicrobe = action.options[1] as SelectCard<any>;
+    const selectAnimal = cast(action.options[2], SelectOption);
+    const selectMicrobe = cast(action.options[1], SelectCard);
 
     expect(selectMicrobe.cards).has.lengthOf(2);
     expect(selectMicrobe.cards[0]).to.eq(tardigrades);

--- a/tests/cards/base/ImportedNitrogen.spec.ts
+++ b/tests/cards/base/ImportedNitrogen.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Ants} from '../../../src/server/cards/base/Ants';
 import {Birds} from '../../../src/server/cards/base/Birds';
 import {ImportedNitrogen} from '../../../src/server/cards/base/ImportedNitrogen';
@@ -34,10 +35,9 @@ describe('ImportedNitrogen', function() {
     player.playedCards.push(pets, birds);
     card.play(player);
 
-    const addMicrobes = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
-    expect(addMicrobes).is.undefined;
+    expect(game.deferredActions.pop()!.execute()).is.undefined;
 
-    const addAnimals = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
+    const addAnimals = cast(game.deferredActions.pop()!.execute(), SelectCard<ICard>);
     addAnimals.cb([pets]);
     expect(pets.resourceCount).to.eq(2);
 
@@ -51,12 +51,11 @@ describe('ImportedNitrogen', function() {
     player.playedCards.push(tardigrades, ants);
     card.play(player);
 
-    const addMicrobes = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
+    const addMicrobes = cast(game.deferredActions.pop()!.execute(), SelectCard<ICard>);
     addMicrobes.cb([tardigrades]);
     expect(tardigrades.resourceCount).to.eq(3);
 
-    const addAnimals = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
-    expect(addAnimals).is.undefined;
+    expect(game.deferredActions.pop()!.execute()).is.undefined;
 
     expect(player.getTerraformRating()).to.eq(21);
     expect(player.plants).to.eq(4);
@@ -70,11 +69,11 @@ describe('ImportedNitrogen', function() {
     player.playedCards.push(pets, tardigrades, birds, ants);
     card.play(player);
 
-    const addMicrobes = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
+    const addMicrobes = cast(game.deferredActions.pop()!.execute(), SelectCard<ICard>);
     addMicrobes.cb([tardigrades]);
     expect(tardigrades.resourceCount).to.eq(3);
 
-    const addAnimals = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
+    const addAnimals = cast(game.deferredActions.pop()!.execute(), SelectCard<ICard>);
     addAnimals.cb([pets]);
     expect(pets.resourceCount).to.eq(2);
 

--- a/tests/cards/base/IndustrialCenter.spec.ts
+++ b/tests/cards/base/IndustrialCenter.spec.ts
@@ -4,6 +4,8 @@ import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
 import {TileType} from '../../../src/common/TileType';
 import {TestPlayer} from '../../TestPlayer';
+import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
+import {cast} from '../../TestingUtils';
 
 describe('IndustrialCenter', function() {
   let card: IndustrialCenter;
@@ -34,11 +36,10 @@ describe('IndustrialCenter', function() {
     game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
     expect(game.getCitiesOnMarsCount()).to.eq(1);
 
-    const action = card.play(player);
-    const space = action!.availableSpaces[0];
-        action!.cb(space);
-        expect(space.tile).is.not.undefined;
-        expect(space.tile && space.tile.tileType).to.eq(TileType.INDUSTRIAL_CENTER);
-        expect(space.adjacency?.bonus).eq(undefined);
+    const action = cast(card.play(player), SelectSpace);
+    const space = action.availableSpaces[0];
+    action.cb(space);
+    expect(space.tile?.tileType).to.eq(TileType.INDUSTRIAL_CENTER);
+    expect(space.adjacency?.bonus).eq(undefined);
   });
 });

--- a/tests/cards/base/InventorsGuild.spec.ts
+++ b/tests/cards/base/InventorsGuild.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {InventorsGuild} from '../../../src/server/cards/base/InventorsGuild';
 import {IProjectCard} from '../../../src/server/cards/IProjectCard';
 import {Game} from '../../../src/server/Game';
@@ -25,15 +26,14 @@ describe('InventorsGuild', function() {
 
   it('Should act', function() {
     player.megaCredits = 3;
-    const action = card.action(player);
-    expect(action).instanceOf(SelectCard);
-    (action! as SelectCard<IProjectCard>).cb([]);
+    const action = cast(card.action(player), SelectCard);
+    action.cb([]);
 
     expect(game.dealer.discarded).has.lengthOf(1);
     expect(player.megaCredits).to.eq(3);
     player.megaCredits = 3;
 
-    (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
+    action.cb([action.cards[0]]);
     game.deferredActions.runNext();
     expect(player.megaCredits).to.eq(0);
     expect(player.cardsInHand).has.lengthOf(1);
@@ -41,7 +41,7 @@ describe('InventorsGuild', function() {
 
   it('Cannot buy card if cannot pay', function() {
     player.megaCredits = 2;
-    const selectCard = card.action(player) as SelectCard<IProjectCard>;
+    const selectCard = cast(card.action(player), SelectCard<IProjectCard>);
     expect(selectCard.config.max).to.eq(0);
     selectCard.cb([]);
     expect(game.deferredActions).has.lengthOf(0);

--- a/tests/cards/base/LakeMarineris.spec.ts
+++ b/tests/cards/base/LakeMarineris.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {LakeMarineris} from '../../../src/server/cards/base/LakeMarineris';
 import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
@@ -26,9 +27,9 @@ describe('LakeMarineris', function() {
     card.play(player);
 
     expect(game.deferredActions).has.lengthOf(2);
-    const firstOcean = game.deferredActions.pop()!.execute() as SelectSpace;
+    const firstOcean = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     firstOcean.cb(firstOcean.availableSpaces[0]);
-    const secondOcean = game.deferredActions.pop()!.execute() as SelectSpace;
+    const secondOcean = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     secondOcean.cb(secondOcean.availableSpaces[1]);
     expect(player.getTerraformRating()).to.eq(22);
 

--- a/tests/cards/base/LandClaim.spec.ts
+++ b/tests/cards/base/LandClaim.spec.ts
@@ -5,7 +5,7 @@ import * as constants from '../../../src/common/constants';
 import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {SpaceName} from '../../../src/server/SpaceName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('LandClaim', function() {
@@ -28,8 +28,7 @@ describe('LandClaim', function() {
     Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({
       boardName: BoardName.HELLAS,
     }));
-    const action = card.play(player) as SelectSpace;
-    expect(action).is.not.undefined;
+    const action = cast(card.play(player), SelectSpace);
     expect(player.canAfford(constants.HELLAS_BONUS_OCEAN_COST)).to.be.false;
     expect(action.availableSpaces.some((space) => space.id === SpaceName.HELLAS_OCEAN_TILE)).to.be.true;
   });

--- a/tests/cards/base/NoctisCity.spec.ts
+++ b/tests/cards/base/NoctisCity.spec.ts
@@ -33,7 +33,7 @@ describe('NoctisCity', function() {
     const player = game.getPlayersInGenerationOrder()[0];
 
     const action = cast(card.play(player), SelectSpace);
-    expect(action!.availableSpaces).deep.eq(game.board.getAvailableSpacesForCity(player));
+    expect(action.availableSpaces).deep.eq(game.board.getAvailableSpacesForCity(player));
   });
 
   it('Should play', function() {
@@ -45,6 +45,6 @@ describe('NoctisCity', function() {
     expect(player.production.megacredits).to.eq(3);
 
     const noctis = game.board.getSpace(SpaceName.NOCTIS_CITY);
-    expect(noctis.tile && noctis.tile.tileType).to.eq(TileType.CITY);
+    expect(noctis.tile?.tileType).to.eq(TileType.CITY);
   });
 });

--- a/tests/cards/base/Predators.spec.ts
+++ b/tests/cards/base/Predators.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {BioengineeringEnclosure} from '../../../src/server/cards/ares/BioengineeringEnclosure';
 import {Fish} from '../../../src/server/cards/base/Fish';
 import {Pets} from '../../../src/server/cards/base/Pets';
@@ -46,13 +47,13 @@ describe('Predators', function() {
     player.addResourceTo(smallAnimals);
 
     card.action(player);
-    const selectCard = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.pop()!.execute(), SelectCard<ICard>);
     expect(selectCard.cards).has.lengthOf(2);
     selectCard.cb([selectCard.cards[0]]);
-        game.deferredActions.pop()!.execute(); // Add animal to predators
+    game.deferredActions.pop()!.execute(); // Add animal to predators
 
-        expect(card.resourceCount).to.eq(1);
-        expect(fish.resourceCount).to.eq(0);
+    expect(card.resourceCount).to.eq(1);
+    expect(fish.resourceCount).to.eq(0);
   });
 
   it('Respects pets', function() {
@@ -67,13 +68,12 @@ describe('Predators', function() {
     expect(card.canAct(player)).is.true;
 
     card.action(player);
-    const selectCard = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
-    expect(selectCard).is.undefined; // Only one option: Fish
-        game.deferredActions.pop()!.execute(); // Add animal to predators
+    expect(game.deferredActions.pop()!.execute()).is.undefined; // Only one option: Fish
+    game.deferredActions.pop()!.execute(); // Add animal to predators
 
-        expect(card.resourceCount).to.eq(1);
-        expect(fish.resourceCount).to.eq(0);
-        expect(pets.resourceCount).to.eq(1);
+    expect(card.resourceCount).to.eq(1);
+    expect(fish.resourceCount).to.eq(0);
+    expect(pets.resourceCount).to.eq(1);
   });
 
   it('Respects Bioengineering Enclosure', function() {
@@ -88,13 +88,12 @@ describe('Predators', function() {
     expect(card.canAct(player)).is.true;
 
     card.action(player);
-    const selectCard = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
-    expect(selectCard).is.undefined; // Only one option: Fish
-        game.deferredActions.pop()!.execute(); // Add animal to predators
+    expect(game.deferredActions.pop()!.execute()).is.undefined; // Only one option: Fish
+    game.deferredActions.pop()!.execute(); // Add animal to predators
 
-        expect(card.resourceCount).to.eq(1);
-        expect(fish.resourceCount).to.eq(0);
-        expect(bioengineeringEnclosure.resourceCount).to.eq(1);
+    expect(card.resourceCount).to.eq(1);
+    expect(fish.resourceCount).to.eq(0);
+    expect(bioengineeringEnclosure.resourceCount).to.eq(1);
   });
 
   it('Respects protected habitats', function() {

--- a/tests/cards/base/ResearchOutpost.spec.ts
+++ b/tests/cards/base/ResearchOutpost.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {ResearchOutpost} from '../../../src/server/cards/base/ResearchOutpost';
 import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
@@ -18,8 +19,7 @@ describe('ResearchOutpost', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player) as SelectSpace;
-    expect(action).is.not.undefined;
+    const action = cast(card.play(player), SelectSpace);
 
     action.cb(action.availableSpaces[0]);
     expect(game.getCitiesCount()).to.eq(1);

--- a/tests/cards/base/SymbioticFungus.spec.ts
+++ b/tests/cards/base/SymbioticFungus.spec.ts
@@ -1,4 +1,6 @@
+import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Ants} from '../../../src/server/cards/base/Ants';
 import {Decomposers} from '../../../src/server/cards/base/Decomposers';
 import {SymbioticFungus} from '../../../src/server/cards/base/SymbioticFungus';
@@ -39,10 +41,9 @@ describe('SymbioticFungus', function() {
 
   it('Should act - multiple targets', function() {
     player.playedCards.push(new Ants(), new Decomposers());
-    const action = card.action(player);
-    expect(action).is.not.undefined;
+    const action = cast(card.action(player), SelectCard);
 
-        action!.cb([player.playedCards[0]]);
-        expect(player.playedCards[0].resourceCount).to.eq(1);
+    action.cb([player.playedCards[0]]);
+    expect(player.playedCards[0].resourceCount).to.eq(1);
   });
 });

--- a/tests/cards/base/WaterImportFromEuropa.spec.ts
+++ b/tests/cards/base/WaterImportFromEuropa.spec.ts
@@ -3,7 +3,7 @@ import {WaterImportFromEuropa} from '../../../src/server/cards/base/WaterImportF
 import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {Player} from '../../../src/server/Player';
-import {maxOutOceans} from '../../TestingUtils';
+import {cast, maxOutOceans} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('WaterImportFromEuropa', function() {
@@ -38,7 +38,7 @@ describe('WaterImportFromEuropa', function() {
     expect(player.megaCredits).to.eq(1);
 
     expect(game.deferredActions).has.lengthOf(1);
-    const selectOcean = game.deferredActions.peek()!.execute() as SelectSpace;
+    const selectOcean = cast(game.deferredActions.peek()!.execute(), SelectSpace);
     selectOcean.cb(selectOcean.availableSpaces[0]);
     expect(player.getTerraformRating()).to.eq(21);
   });

--- a/tests/cards/base/standardProjects/AquiferStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/AquiferStandardProject.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../../TestingUtils';
 import {AquiferStandardProject} from '../../../../src/server/cards/base/standardProjects/AquiferStandardProject';
 import {maxOutOceans, setCustomGameOptions, runAllActions} from '../../../TestingUtils';
 import {TestPlayer} from '../../../TestPlayer';
@@ -36,7 +37,7 @@ describe('AquiferStandardProject', function() {
     card.action(player);
     runAllActions(game);
 
-    const selectSpace = player.getWaitingFor() as SelectSpace;
+    const selectSpace = cast(player.getWaitingFor(), SelectSpace);
     const availableSpace = selectSpace.availableSpaces[0];
 
     expect(availableSpace.spaceType).eq(SpaceType.OCEAN);

--- a/tests/cards/base/standardProjects/GreeneryStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/GreeneryStandardProject.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../../TestingUtils';
 import {GreeneryStandardProject} from '../../../../src/server/cards/base/standardProjects/GreeneryStandardProject';
 import {setCustomGameOptions, runAllActions} from '../../../TestingUtils';
 import {TestPlayer} from '../../../TestPlayer';
@@ -37,7 +38,7 @@ describe('GreeneryStandardProject', function() {
     card.action(player);
     runAllActions(game);
 
-    const selectSpace = player.getWaitingFor() as SelectSpace;
+    const selectSpace = cast(player.getWaitingFor(), SelectSpace);
     const availableSpace = selectSpace.availableSpaces[0];
 
     expect(availableSpace.spaceType).eq(SpaceType.LAND);

--- a/tests/cards/colonies/AirRaid.spec.ts
+++ b/tests/cards/colonies/AirRaid.spec.ts
@@ -42,7 +42,7 @@ describe('AirRaid', function() {
 
     card.play(player);
     const option1 = cast(player.game.deferredActions.pop()!.execute(), OrOptions);
-    const option2 = player.game.deferredActions.pop()!.execute() as SelectCard<ICard>;
+    const option2 = cast(player.game.deferredActions.pop()!.execute(), SelectCard<ICard>);
 
     option1.options[0].cb();
     expect(player2.megaCredits).to.eq(0);

--- a/tests/cards/colonies/EcologyResearch.spec.ts
+++ b/tests/cards/colonies/EcologyResearch.spec.ts
@@ -8,7 +8,7 @@ import {Luna} from '../../../src/server/colonies/Luna';
 import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('EcologyResearch', function() {
@@ -64,7 +64,7 @@ describe('EcologyResearch', function() {
     expect(game.deferredActions).has.lengthOf(1);
 
     // add two microbes to Ants
-    const selectCard = game.deferredActions.peek()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.peek()!.execute(), SelectCard<ICard>);
     selectCard.cb([ants]);
 
     expect(ants.resourceCount).to.eq(2);

--- a/tests/cards/colonies/FloaterTechnology.spec.ts
+++ b/tests/cards/colonies/FloaterTechnology.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {FloaterTechnology} from '../../../src/server/cards/colonies/FloaterTechnology';
 import {ICard} from '../../../src/server/cards/ICard';
 import {Dirigibles} from '../../../src/server/cards/venusNext/Dirigibles';
@@ -49,7 +50,7 @@ describe('FloaterTechnology', function() {
     card.action(player);
     expect(game.deferredActions).has.lengthOf(1);
 
-    const selectCard = game.deferredActions.peek()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.peek()!.execute(), SelectCard<ICard>);
     selectCard.cb([floatingHabs]);
     expect(floatingHabs.resourceCount).to.eq(1);
     expect(dirigibles.resourceCount).to.eq(0);

--- a/tests/cards/colonies/MarketManipulation.spec.ts
+++ b/tests/cards/colonies/MarketManipulation.spec.ts
@@ -12,6 +12,7 @@ import {Callisto} from '../../../src/server/colonies/Callisto';
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
 import {ColonyName} from '../../../src/common/colonies/ColonyName';
+import {cast} from '../../TestingUtils';
 
 describe('MarketManipulation', function() {
   let card: MarketManipulation;
@@ -34,13 +35,13 @@ describe('MarketManipulation', function() {
 
   it('Should play', function() {
     card.play(player);
-    const increaseColonyAction = game.deferredActions.pop()!.execute() as SelectColony;
+    const increaseColonyAction = cast(game.deferredActions.pop()!.execute(), SelectColony);
     increaseColonyAction.cb(increaseColonyAction.colonies[0]);
     expect(game.colonies[0].trackPosition).to.eq(2);
     expect(game.colonies[1].trackPosition).to.eq(1);
     expect(game.colonies[2].trackPosition).to.eq(1);
 
-    const decreaseColonyAction = game.deferredActions.pop()!.execute() as SelectColony;
+    const decreaseColonyAction = cast(game.deferredActions.pop()!.execute(), SelectColony);
     decreaseColonyAction.cb(increaseColonyAction.colonies[1]);
     expect(game.colonies[0].trackPosition).to.eq(2);
     expect(game.colonies[1].trackPosition).to.eq(0);
@@ -58,7 +59,7 @@ describe('MarketManipulation', function() {
     player.game.colonies = [pluto, callisto, europa];
     player.game.gameOptions.coloniesExtension = true;
     card.play(player);
-    const increaseColonyAction = game.deferredActions.pop()!.execute() as SelectColony;
+    const increaseColonyAction = cast(game.deferredActions.pop()!.execute(), SelectColony);
     expect(increaseColonyAction.colonies.length).to.eq(2);
 
     increaseColonyAction.cb(increaseColonyAction.colonies[0]);
@@ -66,7 +67,7 @@ describe('MarketManipulation', function() {
     expect(game.colonies[1].trackPosition).to.eq(0);
     expect(game.colonies[2].trackPosition).to.eq(1);
 
-    const decreaseColonyAction = game.deferredActions.pop()!.execute() as SelectColony;
+    const decreaseColonyAction = cast(game.deferredActions.pop()!.execute(), SelectColony);
     expect(decreaseColonyAction.colonies.length).to.eq(1);
     decreaseColonyAction.cb(decreaseColonyAction.colonies[0]);
     expect(game.colonies[0].trackPosition).to.eq(1);

--- a/tests/cards/colonies/NitrogenFromTitan.spec.ts
+++ b/tests/cards/colonies/NitrogenFromTitan.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {JovianLanterns} from '../../../src/server/cards/colonies/JovianLanterns';
 import {NitrogenFromTitan} from '../../../src/server/cards/colonies/NitrogenFromTitan';
 import {TitanFloatingLaunchPad} from '../../../src/server/cards/colonies/TitanFloatingLaunchPad';
@@ -44,7 +45,7 @@ describe('NitrogenFromTitan', function() {
     card.play(player);
     expect(game.deferredActions).has.lengthOf(1);
 
-    const selectCard = game.deferredActions.peek()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.peek()!.execute(), SelectCard<ICard>);
     selectCard.cb([jovianLanterns]);
     expect(jovianLanterns.resourceCount).to.eq(2);
   });

--- a/tests/cards/colonies/Polyphemos.spec.ts
+++ b/tests/cards/colonies/Polyphemos.spec.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {BusinessNetwork} from '../../../src/server/cards/base/BusinessNetwork';
 import {PowerPlant} from '../../../src/server/cards/base/PowerPlant';
 import {Polyphemos} from '../../../src/server/cards/colonies/Polyphemos';
-import {IProjectCard} from '../../../src/server/cards/IProjectCard';
 import {Game} from '../../../src/server/Game';
-import {AndOptions} from '../../../src/server/inputs/AndOptions';
+import {SelectInitialCards} from '../../../src/server/inputs/SelectInitialCards';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {TestPlayer} from '../../TestPlayer';
 
@@ -15,7 +15,7 @@ describe('Polyphemos', function() {
     const card3 = new BusinessNetwork();
     const player = TestPlayer.BLUE.newPlayer();
     Game.newInstance('gameid', [player], player);
-    const pi = player.getWaitingFor() as AndOptions;
+    const pi = cast(player.getWaitingFor(), SelectInitialCards);
     pi.options[0].cb([card]);
     pi.options[1].cb([card2, card2]);
     pi.cb();
@@ -25,10 +25,8 @@ describe('Polyphemos', function() {
     expect(player.production.megacredits).to.eq(5);
 
     player.playedCards.push(card3);
-    const action = card3.action(player);
-    expect(action).is.not.undefined;
-    expect(action).instanceOf(SelectCard);
-    (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
+    const action = cast(card3.action(player), SelectCard);
+    action.cb([action.cards[0]]);
     player.game.deferredActions.runNext();
     expect(player.megaCredits).to.eq(35);
     expect(player.cardsInHand).has.lengthOf(3);

--- a/tests/cards/colonies/StormCraftIncorporated.spec.ts
+++ b/tests/cards/colonies/StormCraftIncorporated.spec.ts
@@ -4,6 +4,7 @@ import * as constants from '../../../src/common/constants';
 import {Game} from '../../../src/server/Game';
 import {SelectAmount} from '../../../src/server/inputs/SelectAmount';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('StormCraftIncorporated', function() {
   let card: StormCraftIncorporated;
@@ -32,9 +33,9 @@ describe('StormCraftIncorporated', function() {
     card.resourceCount = 10;
     const options = card.spendHeat(player, constants.HEAT_FOR_TEMPERATURE);
     expect(options.options.length).to.eq(2);
-    const heatOption = options.options[0] as SelectAmount;
+    const heatOption = cast(options.options[0], SelectAmount);
     expect(heatOption.max).to.eq(constants.HEAT_FOR_TEMPERATURE);
-    const floaterOption = options.options[1] as SelectAmount;
+    const floaterOption = cast(options.options[1], SelectAmount);
     expect(floaterOption.max).to.eq(constants.HEAT_FOR_TEMPERATURE / 2);
   });
 
@@ -42,8 +43,8 @@ describe('StormCraftIncorporated', function() {
     player.heat = 10;
     card.resourceCount = 10;
     const options = card.spendHeat(player, constants.HEAT_FOR_TEMPERATURE);
-    const heatOption = options.options[0] as SelectAmount;
-    const floaterOption = options.options[1] as SelectAmount;
+    const heatOption = cast(options.options[0], SelectAmount);
+    const floaterOption = cast(options.options[1], SelectAmount);
     heatOption.cb(4);
     floaterOption.cb(0);
     expect(function() {
@@ -55,8 +56,8 @@ describe('StormCraftIncorporated', function() {
     player.heat = 10;
     card.resourceCount = 10;
     const options = card.spendHeat(player, constants.HEAT_FOR_TEMPERATURE);
-    const heatOption = options.options[0] as SelectAmount;
-    const floaterOption = options.options[1] as SelectAmount;
+    const heatOption = cast(options.options[0], SelectAmount);
+    const floaterOption = cast(options.options[1], SelectAmount);
     heatOption.cb(2);
     floaterOption.cb(3);
     options.cb();

--- a/tests/cards/colonies/TitanFloatingLaunchPad.spec.ts
+++ b/tests/cards/colonies/TitanFloatingLaunchPad.spec.ts
@@ -62,7 +62,7 @@ describe('TitanFloatingLaunchPad', function() {
 
     card.action(player);
     expect(game.deferredActions).has.lengthOf(1);
-    const selectCard = game.deferredActions.peek()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.peek()!.execute(), SelectCard<ICard>);
     selectCard.cb([card]);
     expect(card.resourceCount).to.eq(1);
   });
@@ -79,14 +79,14 @@ describe('TitanFloatingLaunchPad', function() {
 
     orOptions.options[1].cb(); // Add resource
     expect(game.deferredActions).has.lengthOf(1);
-    const selectCard = game.deferredActions.peek()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.peek()!.execute(), SelectCard<ICard>);
     game.deferredActions.pop();
     selectCard.cb([card]);
     expect(card.resourceCount).to.eq(8);
 
     orOptions.options[0].cb(); // Trade for free
     expect(game.deferredActions).has.lengthOf(1);
-    const selectColony = game.deferredActions.peek()!.execute() as SelectColony;
+    const selectColony = cast(game.deferredActions.peek()!.execute(), SelectColony);
     selectColony.cb(selectColony.colonies[0]);
     expect(card.resourceCount).to.eq(7);
     expect(player.megaCredits).to.eq(2);
@@ -116,7 +116,7 @@ describe('TitanFloatingLaunchPad', function() {
     expect(floaterOption.title).to.match(/Pay 1 Floater/);
 
     floaterOption.cb();
-    (tradeAction as AndOptions).options[1].cb(luna);
+    tradeAction.options[1].cb(luna);
 
     expect(card.resourceCount).eq(0);
     expect(player.megaCredits).eq(2);

--- a/tests/cards/colonies/TitanShuttles.spec.ts
+++ b/tests/cards/colonies/TitanShuttles.spec.ts
@@ -51,7 +51,7 @@ describe('TitanShuttles', function() {
     card.action(player);
     expect(game.deferredActions).has.lengthOf(1);
 
-    const selectCard = game.deferredActions.peek()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.peek()!.execute(), SelectCard<ICard>);
     selectCard.cb([card]);
     expect(card.resourceCount).to.eq(2);
   });
@@ -73,7 +73,7 @@ describe('TitanShuttles', function() {
     orOptions.options[0].cb();
     expect(game.deferredActions).has.lengthOf(1);
 
-    const selectCard = game.deferredActions.peek()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.peek()!.execute(), SelectCard<ICard>);
     selectCard.cb([card2]);
     expect(card2.resourceCount).to.eq(2);
   });

--- a/tests/cards/colonies/TradingColony.spec.ts
+++ b/tests/cards/colonies/TradingColony.spec.ts
@@ -6,7 +6,7 @@ import {Miranda} from '../../../src/server/colonies/Miranda';
 import {Game} from '../../../src/server/Game';
 import {SelectColony} from '../../../src/server/inputs/SelectColony';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('TradingColony', function() {
@@ -29,7 +29,7 @@ describe('TradingColony', function() {
     card.play(player);
     expect(game.deferredActions).has.length(1);
 
-    const selectColony = game.deferredActions.pop()!.execute() as SelectColony;
+    const selectColony = cast(game.deferredActions.pop()!.execute(), SelectColony);
     selectColony.cb(selectColony.colonies[0]);
     expect(player.production.energy).to.eq(1);
     expect(player.colonies.tradeOffset).to.eq(1);

--- a/tests/cards/colonies/UrbanDecomposers.spec.ts
+++ b/tests/cards/colonies/UrbanDecomposers.spec.ts
@@ -9,6 +9,7 @@ import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
 import {TileType} from '../../../src/common/TileType';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('UrbanDecomposers', function() {
   let card: UrbanDecomposers;
@@ -72,7 +73,7 @@ describe('UrbanDecomposers', function() {
     expect(game.deferredActions).has.lengthOf(1);
 
     // add two microbes to Ants
-    const selectCard = game.deferredActions.peek()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.peek()!.execute(), SelectCard<ICard>);
     selectCard.cb([ants]);
     expect(ants.resourceCount).to.eq(2);
     expect(player.production.plants).to.eq(1);

--- a/tests/cards/community/AerospaceMission.spec.ts
+++ b/tests/cards/community/AerospaceMission.spec.ts
@@ -8,7 +8,7 @@ import {Luna} from '../../../src/server/colonies/Luna';
 import {Game} from '../../../src/server/Game';
 import {SelectColony} from '../../../src/server/inputs/SelectColony';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('AerospaceMission', function() {
@@ -36,13 +36,13 @@ describe('AerospaceMission', function() {
     expect(game.colonies[1].name).to.eq(ColonyName.CERES);
 
     // Build the first free on Callisto
-    const selectColony = game.deferredActions.peek()!.execute() as SelectColony;
+    const selectColony = cast(game.deferredActions.peek()!.execute(), SelectColony);
     game.deferredActions.pop();
     selectColony.cb(selectColony.colonies[0]);
     expect(player.production.energy).to.eq(1);
 
     // Build the second free on Ceres
-    const selectColony2 = game.deferredActions.peek()!.execute() as SelectColony;
+    const selectColony2 = cast(game.deferredActions.peek()!.execute(), SelectColony);
     game.deferredActions.pop();
     selectColony2.cb(selectColony2.colonies[0]);
     expect(player.production.steel).to.eq(1);

--- a/tests/cards/community/ExecutiveOrder.spec.ts
+++ b/tests/cards/community/ExecutiveOrder.spec.ts
@@ -33,7 +33,7 @@ describe('ExecutiveOrder', function() {
     selectGlobalEvent.options[0].cb();
     expect(turmoil.currentGlobalEvent).is.not.undefined;
 
-    const selectParty = game.deferredActions.pop()!.execute() as SelectPartyToSendDelegate;
+    const selectParty = cast(game.deferredActions.pop()!.execute(), SelectPartyToSendDelegate);
     selectParty.cb(PartyName.MARS);
     const marsFirst = turmoil.getPartyByName(PartyName.MARS)!;
     expect(marsFirst.delegates.filter((d) => d === player.id)).has.lengthOf(2);

--- a/tests/cards/community/Incite.spec.ts
+++ b/tests/cards/community/Incite.spec.ts
@@ -4,7 +4,7 @@ import {EventAnalysts} from '../../../src/server/cards/turmoil/EventAnalysts';
 import {Game} from '../../../src/server/Game';
 import {SelectPartyToSendDelegate} from '../../../src/server/inputs/SelectPartyToSendDelegate';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('Incite', function() {
@@ -37,7 +37,7 @@ describe('Incite', function() {
     card.initialAction(player);
     expect(game.deferredActions).has.lengthOf(1);
 
-    const sendDelegate = game.deferredActions.peek()!.execute() as SelectPartyToSendDelegate;
+    const sendDelegate = cast(game.deferredActions.peek()!.execute(), SelectPartyToSendDelegate);
     sendDelegate.cb(PartyName.MARS);
 
     const marsFirst = game.turmoil!.getPartyByName(PartyName.MARS);

--- a/tests/cards/community/Playwrights.spec.ts
+++ b/tests/cards/community/Playwrights.spec.ts
@@ -11,7 +11,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {SelectPlayer} from '../../../src/server/inputs/SelectPlayer';
 import {TestPlayer} from '../../TestPlayer';
-import {runAllActions} from '../../TestingUtils';
+import {cast, runAllActions} from '../../TestingUtils';
 
 describe('Playwrights', () => {
   let card: Playwrights;
@@ -46,7 +46,7 @@ describe('Playwrights', () => {
     player.megaCredits = event.cost;
     expect(card.canAct(player)).is.true;
 
-    const selectCard = card.action(player) as SelectCard<IProjectCard>;
+    const selectCard = cast(card.action(player), SelectCard<IProjectCard>);
     selectCard.cb([event]);
 
     game.deferredActions.pop()!.execute(); // SelectPayment
@@ -66,7 +66,7 @@ describe('Playwrights', () => {
 
     player.megaCredits = event.cost;
     expect(card.canAct(player)).is.true;
-    const selectCard = card.action(player) as SelectCard<IProjectCard>;
+    const selectCard = cast(card.action(player), SelectCard<IProjectCard>);
     selectCard.cb([event]);
 
     game.deferredActions.pop()!.execute(); // SelectPayment
@@ -91,7 +91,7 @@ describe('Playwrights', () => {
     const indenturedWorkers = new IndenturedWorkers();
     player.playedCards.push(indenturedWorkers);
 
-    const selectCard = card.action(player) as SelectCard<IProjectCard>;
+    const selectCard = cast(card.action(player), SelectCard<IProjectCard>);
     selectCard.cb([indenturedWorkers]);
     // SelectPayment
     game.deferredActions.pop()!.execute();
@@ -111,11 +111,11 @@ describe('Playwrights', () => {
     player.removingPlayers = [player2.id];
     expect(card.canAct(player)).is.true;
 
-    const selectCard = card.action(player) as SelectCard<IProjectCard>;
+    const selectCard = cast(card.action(player), SelectCard<IProjectCard>);
     selectCard.cb([event]);
 
     game.deferredActions.pop()!.execute(); // SelectPayment
-    const selectPlayer = game.deferredActions.pop()!.execute() as SelectPlayer;
+    const selectPlayer = cast(game.deferredActions.pop()!.execute(), SelectPlayer);
     selectPlayer.cb(player2);
 
     runAllActions(player.game);

--- a/tests/cards/community/PoliticalUprising.spec.ts
+++ b/tests/cards/community/PoliticalUprising.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectPartyToSendDelegate} from '../../../src/server/inputs/SelectPartyToSendDelegate';
 import {Player} from '../../../src/server/Player';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('PoliticalUprising', function() {
@@ -25,7 +25,7 @@ describe('PoliticalUprising', function() {
     expect(game.deferredActions).has.lengthOf(4);
 
     while (game.deferredActions.length) {
-      const selectParty = game.deferredActions.peek()!.execute() as SelectPartyToSendDelegate;
+      const selectParty = cast(game.deferredActions.peek()!.execute(), SelectPartyToSendDelegate);
       selectParty.cb(PartyName.MARS);
       game.deferredActions.pop();
     }

--- a/tests/cards/community/ProjectWorkshop.spec.ts
+++ b/tests/cards/community/ProjectWorkshop.spec.ts
@@ -89,8 +89,7 @@ describe('ProjectWorkshop', function() {
     player.playedCards.push(smallAnimals, extremophiles);
 
     const selectOption = cast(card.action(player), SelectOption);
-
-    const selectCard = selectOption.cb() as SelectCard<ICard>;
+    const selectCard = cast(selectOption.cb(), SelectCard<ICard>);
 
     selectCard.cb([smallAnimals]);
     expect(player.getTerraformRating()).to.eq(originalTR + 2);

--- a/tests/cards/moon/AristarchusRoadNetwork.spec.ts
+++ b/tests/cards/moon/AristarchusRoadNetwork.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {AristarchusRoadNetwork} from '../../../src/server/cards/moon/AristarchusRoadNetwork';
 import {expect} from 'chai';
@@ -44,14 +44,14 @@ describe('AristarchusRoadNetwork', () => {
     expect(player.steel).eq(0);
     expect(player.production.megacredits).eq(2);
 
-    const deferredAction = game.deferredActions.peek() as PlaceMoonRoadTile;
+    const deferredAction = cast(game.deferredActions.peek(), PlaceMoonRoadTile);
     const selectSpace = deferredAction.execute()!;
     const roadSpace = selectSpace.availableSpaces[0];
     expect(roadSpace.tile).is.undefined;
     expect(roadSpace.player).is.undefined;
     expect(moonData.logisticRate).eq(0);
 
-    deferredAction!.execute()!.cb(roadSpace);
+    deferredAction.execute()!.cb(roadSpace);
     expect(roadSpace.tile!.tileType).eq(TileType.MOON_ROAD);
     expect(roadSpace.player).eq(player);
 

--- a/tests/cards/moon/BasicInfrastructure.spec.ts
+++ b/tests/cards/moon/BasicInfrastructure.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {BasicInfrastructure} from '../../../src/server/cards/moon/BasicInfrastructure';
 import {expect} from 'chai';
@@ -30,8 +30,8 @@ describe('BasicInfrastructure', () => {
     expect(player.colonies.getFleetSize()).eq(1);
 
     card.play(player);
-    const placeTileAction = game.deferredActions.peek() as PlaceMoonRoadTile;
-    placeTileAction!.execute()!.cb(moonData.moon.spaces[2]);
+    const placeTileAction = cast(game.deferredActions.peek(), PlaceMoonRoadTile);
+    placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.logisticRate).eq(1);
     expect(player.getTerraformRating()).eq(15);

--- a/tests/cards/moon/CoreMine.spec.ts
+++ b/tests/cards/moon/CoreMine.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {CoreMine} from '../../../src/server/cards/moon/CoreMine';
 import {expect} from 'chai';
@@ -30,8 +30,8 @@ describe('CoreMine', () => {
 
     card.play(player);
     expect(player.production.titanium).eq(1);
-    const placeTileAction = game.deferredActions.peek() as PlaceMoonMineTile;
-    placeTileAction!.execute()!.cb(moonData.moon.spaces[2]);
+    const placeTileAction = cast(game.deferredActions.peek(), PlaceMoonMineTile);
+    placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.miningRate).eq(1);
     expect(player.getTerraformRating()).eq(15);

--- a/tests/cards/moon/FirstLunarSettlement.spec.ts
+++ b/tests/cards/moon/FirstLunarSettlement.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {FirstLunarSettlement} from '../../../src/server/cards/moon/FirstLunarSettlement';
 import {expect} from 'chai';
@@ -29,8 +29,8 @@ describe('FirstLunarSettlement', () => {
     expect(moonData.colonyRate).eq(0);
 
     card.play(player);
-    const placeTileAction = game.deferredActions.peek() as PlaceMoonColonyTile;
-    placeTileAction!.execute()!.cb(moonData.moon.spaces[2]);
+    const placeTileAction = cast(game.deferredActions.peek(), PlaceMoonColonyTile);
+    placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.colonyRate).eq(1);
     expect(player.getTerraformRating()).eq(15);

--- a/tests/cards/moon/LunaEcumenopolis.spec.ts
+++ b/tests/cards/moon/LunaEcumenopolis.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {cast, runAllActions, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaEcumenopolis} from '../../../src/server/cards/moon/LunaEcumenopolis';
 import {expect} from 'chai';
@@ -77,13 +77,13 @@ describe('LunaEcumenopolis', () => {
     moon.getSpace('m19').tile = {tileType: TileType.MOON_COLONY};
     card.play(player);
 
-    const input1 = game.deferredActions.pop()!.execute() as SelectSpace;
+    const input1 = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     expect(input1.availableSpaces.map((space) => space.id)).deep.eq(['m13', 'm18']);
     input1.cb(moon.getSpace('m18'));
     expect(moonData.colonyRate).eq(3);
     expect(player.getTerraformRating()).eq(15);
 
-    const input2 = game.deferredActions.pop()!.execute() as SelectSpace;
+    const input2 = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     expect(input2.availableSpaces.map((space) => space.id)).deep.eq(['m13', 'm17']);
     input1.cb(moon.getSpace('m13'));
     expect(moonData.colonyRate).eq(4);
@@ -115,13 +115,13 @@ describe('LunaEcumenopolis', () => {
     moon.getSpace('m19').tile = {tileType: TileType.MOON_COLONY};
     card.play(player);
 
-    const input1 = game.deferredActions.pop()!.execute() as SelectSpace;
+    const input1 = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     expect(input1.availableSpaces.map((space) => space.id)).deep.eq(['m13', 'm18']);
     input1.cb(moon.getSpace('m18'));
     expect(moonData.colonyRate).eq(3);
     expect(player.getTerraformRating()).eq(15);
 
-    const input2 = game.deferredActions.pop()!.execute() as SelectSpace;
+    const input2 = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     expect(input2.availableSpaces.map((space) => space.id)).deep.eq(['m13', 'm17']);
     input1.cb(moon.getSpace('m13'));
     expect(moonData.colonyRate).eq(4);

--- a/tests/cards/moon/LunaMiningHub.spec.ts
+++ b/tests/cards/moon/LunaMiningHub.spec.ts
@@ -66,7 +66,7 @@ describe('LunaMiningHub', () => {
 
     const placeTileAction = game.deferredActions.pop() as PlaceSpecialMoonTile;
     const space = moonData.moon.spaces[10];
-    placeTileAction!.execute()!.cb(space);
+    placeTileAction.execute()!.cb(space);
 
     expect(moonData.miningRate).eq(1);
     expect(player.getTerraformRating()).eq(15);

--- a/tests/cards/moon/LunaPoliticalInstitute.spec.ts
+++ b/tests/cards/moon/LunaPoliticalInstitute.spec.ts
@@ -1,6 +1,6 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {fakeCard, setCustomGameOptions} from '../../TestingUtils';
+import {cast, fakeCard, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaPoliticalInstitute} from '../../../src/server/cards/moon/LunaPoliticalInstitute';
 import {expect} from 'chai';
@@ -53,7 +53,7 @@ describe('LunaPoliticalInstitute', () => {
 
     expect(marsFirst.delegates.filter((d) => d === player.id)).has.lengthOf(0);
 
-    const selectParty = game.deferredActions.peek()!.execute() as SelectPartyToSendDelegate;
+    const selectParty = cast(game.deferredActions.peek()!.execute(), SelectPartyToSendDelegate);
     selectParty.cb(PartyName.MARS);
 
     expect(marsFirst.delegates.filter((d) => d === player.id)).has.lengthOf(1);

--- a/tests/cards/moon/LunaProjectOffice.spec.ts
+++ b/tests/cards/moon/LunaProjectOffice.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {finishGeneration, setCustomGameOptions} from '../../TestingUtils';
+import {cast, finishGeneration, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaProjectOffice} from '../../../src/server/cards/moon/LunaProjectOffice';
 import {expect} from 'chai';
@@ -180,7 +180,5 @@ describe('LunaProjectOffice', () => {
 });
 
 function getWaitingFor(player: Player): SelectCard<IProjectCard> {
-  const action = player.getWaitingFor();
-  expect(action).instanceof(SelectCard);
-  return action as SelectCard<IProjectCard>;
+  return cast(player.getWaitingFor(), SelectCard<IProjectCard>);
 }

--- a/tests/cards/moon/LunaTrainStation.spec.ts
+++ b/tests/cards/moon/LunaTrainStation.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaTrainStation} from '../../../src/server/cards/moon/LunaTrainStation';
 import {expect} from 'chai';
@@ -55,8 +55,8 @@ describe('LunaTrainStation', () => {
     expect(moonData.logisticRate).eq(1);
 
     const space = moonData.moon.spaces[2];
-    const placeTileAction = game.deferredActions.peek() as PlaceSpecialMoonTile;
-    placeTileAction!.execute()!.cb(space);
+    const placeTileAction = cast(game.deferredActions.peek(), PlaceSpecialMoonTile);
+    placeTileAction.execute()!.cb(space);
 
     expect(space.player).eq(player);
     expect(space.tile!.tileType).eq(TileType.LUNA_TRAIN_STATION);

--- a/tests/cards/moon/LunarObservationPost.spec.ts
+++ b/tests/cards/moon/LunarObservationPost.spec.ts
@@ -43,6 +43,7 @@ describe('LunarObservationPost', () => {
     expect(card.resourceCount).eq(0);
 
     card.action(player);
+    // TODO(kberg): figure out what type action should be.
     const action = game.deferredActions.pop();
     action!.execute();
 

--- a/tests/cards/moon/MareSerenitatisMine.spec.ts
+++ b/tests/cards/moon/MareSerenitatisMine.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MareSerenitatisMine} from '../../../src/server/cards/moon/MareSerenitatisMine';
 import {expect} from 'chai';
@@ -50,13 +50,13 @@ describe('MareSerenitatisMine', () => {
     expect(mareSerenitatis.player).eq(player);
     expect(mareSerenitatis.tile!.tileType).eq(TileType.MOON_MINE);
 
-    const deferredAction = game.deferredActions.peek() as PlaceMoonRoadTile;
+    const deferredAction = cast(game.deferredActions.peek(), PlaceMoonRoadTile);
     const roadSpace = deferredAction.spaces![0];
     expect(roadSpace.tile).is.undefined;
     expect(roadSpace.player).is.undefined;
     expect(moonData.logisticRate).eq(0);
 
-    deferredAction!.execute()!.cb(roadSpace);
+    deferredAction.execute()!.cb(roadSpace);
     expect(roadSpace.tile!.tileType).eq(TileType.MOON_ROAD);
     expect(roadSpace.player).eq(player);
     expect(moonData.logisticRate).eq(1);

--- a/tests/cards/moon/MiningComplex.spec.ts
+++ b/tests/cards/moon/MiningComplex.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MiningComplex} from '../../../src/server/cards/moon/MiningComplex';
 import {expect} from 'chai';
@@ -35,14 +35,14 @@ describe('MiningComplex', () => {
 
     expect(player.megaCredits).eq(0);
 
-    const placeMineTile = game.deferredActions.pop() as PlaceMoonMineTile;
+    const placeMineTile = cast(game.deferredActions.pop(), PlaceMoonMineTile);
     placeMineTile.execute()!.cb(moonData.moon.getSpace('m06'));
 
     expect(moonData.miningRate).eq(1);
     expect(player.getTerraformRating()).eq(15);
 
-    const placeRoadTile = game.deferredActions.pop() as PlaceMoonRoadTile;
-    const selectSpace = placeRoadTile.execute() as SelectSpace;
+    const placeRoadTile = cast(game.deferredActions.pop(), PlaceMoonRoadTile);
+    const selectSpace = cast(placeRoadTile.execute(), SelectSpace);
     const spaces = selectSpace.availableSpaces;
     expect(spaces.map((s) => s.id)).to.have.members(['m02', 'm12']);
     selectSpace.cb(spaces[0]);
@@ -51,4 +51,3 @@ describe('MiningComplex', () => {
     expect(player.getTerraformRating()).eq(16);
   });
 });
-

--- a/tests/cards/moon/MoonColonyStandardProject.spec.ts
+++ b/tests/cards/moon/MoonColonyStandardProject.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
+import {cast, setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MoonColonyStandardProject} from '../../../src/server/cards/moon/MoonColonyStandardProject';
 import {expect} from 'chai';
@@ -44,12 +44,12 @@ describe('MoonColonyStandardProject', () => {
 
   it('has discount', () => {
     card.action(player);
-    let payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    let payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     expect(payAction.amount).eq(22);
 
     player.playedCards.push(new MooncrateBlockFactory());
     card.action(player);
-    payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     expect(payAction.amount).eq(18);
   });
 
@@ -59,7 +59,7 @@ describe('MoonColonyStandardProject', () => {
     expect(player.production.megacredits).eq(0);
 
     card.action(player);
-    const payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    const payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     payAction.options.afterPay!();
 
     expect(player.titanium).eq(2);
@@ -67,8 +67,8 @@ describe('MoonColonyStandardProject', () => {
 
     expect(moonData.colonyRate).eq(0);
 
-    const placeTileAction = game.deferredActions.peek() as PlaceMoonColonyTile;
-    placeTileAction!.execute()!.cb(moonData.moon.spaces[2]);
+    const placeTileAction = cast(game.deferredActions.peek(), PlaceMoonColonyTile);
+    placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.colonyRate).eq(1);
     expect(player.getTerraformRating()).eq(15);

--- a/tests/cards/moon/MoonMineStandardProject.spec.ts
+++ b/tests/cards/moon/MoonMineStandardProject.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
+import {cast, setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MoonMineStandardProject} from '../../../src/server/cards/moon/MoonMineStandardProject';
 import {expect} from 'chai';
@@ -44,12 +44,12 @@ describe('MoonMineStandardProject', () => {
 
   it('has discount', () => {
     card.action(player);
-    let payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    let payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     expect(payAction.amount).eq(20);
 
     player.playedCards.push(new MooncrateBlockFactory());
     card.action(player);
-    payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     expect(payAction.amount).eq(16);
   });
 
@@ -59,15 +59,15 @@ describe('MoonMineStandardProject', () => {
     expect(player.production.steel).eq(0);
 
     card.action(player);
-    const payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    const payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     payAction.options.afterPay!();
 
     expect(player.titanium).eq(2);
     expect(player.production.steel).eq(1);
     expect(moonData.miningRate).eq(0);
 
-    const placeTileAction = game.deferredActions.peek() as PlaceMoonMineTile;
-    placeTileAction!.execute()!.cb(moonData.moon.spaces[2]);
+    const placeTileAction = cast(game.deferredActions.peek(), PlaceMoonMineTile);
+    placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.miningRate).eq(1);
     expect(player.getTerraformRating()).eq(15);

--- a/tests/cards/moon/MoonRoadStandardProject.spec.ts
+++ b/tests/cards/moon/MoonRoadStandardProject.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
+import {cast, setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MoonRoadStandardProject} from '../../../src/server/cards/moon/MoonRoadStandardProject';
 import {expect} from 'chai';
@@ -44,12 +44,12 @@ describe('MoonRoadStandardProject', () => {
 
   it('has discount', () => {
     card.action(player);
-    let payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    let payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     expect(payAction.amount).eq(18);
 
     player.playedCards.push(new MooncrateBlockFactory());
     card.action(player);
-    payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     expect(payAction.amount).eq(14);
   });
 
@@ -58,14 +58,14 @@ describe('MoonRoadStandardProject', () => {
     expect(player.getTerraformRating()).eq(14);
 
     card.action(player);
-    const payAction = game.deferredActions.pop() as SelectPaymentDeferred;
+    const payAction = cast(game.deferredActions.pop(), SelectPaymentDeferred);
     payAction.options.afterPay!();
 
     expect(player.steel).eq(2);
     expect(moonData.logisticRate).eq(0);
 
-    const placeTileAction = game.deferredActions.peek() as PlaceMoonRoadTile;
-    placeTileAction!.execute()!.cb(moonData.moon.spaces[2]);
+    const placeTileAction = cast(game.deferredActions.peek(), PlaceMoonRoadTile);
+    placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.logisticRate).eq(1);
     expect(player.getTerraformRating()).eq(15);

--- a/tests/cards/moon/MooncrateConvoysToMars.spec.ts
+++ b/tests/cards/moon/MooncrateConvoysToMars.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MooncrateConvoysToMars} from '../../../src/server/cards/moon/MooncrateConvoysToMars';
 import {expect} from 'chai';
@@ -54,7 +54,7 @@ describe('MooncrateConvoysToMars', () => {
 
     expect(moonData.logisticRate).eq(1);
 
-    const firstSale = game.deferredActions.pop()!.execute() as SelectAmount;
+    const firstSale = cast(game.deferredActions.pop()!.execute(), SelectAmount);
     expect(firstSale.max).eq(5);
     firstSale.cb(2);
     expect(player1.steel).eq(3);
@@ -63,7 +63,7 @@ describe('MooncrateConvoysToMars', () => {
     const secondSale = game.deferredActions.pop()!.execute();
     expect(secondSale).is.undefined;
 
-    const thirdSale = game.deferredActions.pop()!.execute() as SelectAmount;
+    const thirdSale = cast(game.deferredActions.pop()!.execute(), SelectAmount);
     expect(thirdSale.max).eq(3);
   });
 });

--- a/tests/cards/moon/NanotechIndustries.spec.ts
+++ b/tests/cards/moon/NanotechIndustries.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {NanotechIndustries} from '../../../src/server/cards/moon/NanotechIndustries';
 import {expect} from 'chai';
@@ -36,10 +36,9 @@ describe('NanotechIndustries', () => {
     player.playedCards = [physicsComplex, searchForLife, olympusConference, prideoftheEarthArkship];
     nanotechIndustries.action(player);
 
-    const action: SelectCard<IProjectCard> =
-      player.game.deferredActions.pop()?.execute() as SelectCard<IProjectCard>;
+    const action = cast(player.game.deferredActions.pop()?.execute(), SelectCard<IProjectCard>);
 
-    expect(action!.cards).has.members([nanotechIndustries, olympusConference, prideoftheEarthArkship]);
+    expect(action.cards).has.members([nanotechIndustries, olympusConference, prideoftheEarthArkship]);
 
     olympusConference.resourceCount = 0;
     action.cb([olympusConference]);

--- a/tests/cards/moon/TychoRoadNetwork.spec.ts
+++ b/tests/cards/moon/TychoRoadNetwork.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TychoRoadNetwork} from '../../../src/server/cards/moon/TychoRoadNetwork';
 import {expect} from 'chai';
@@ -45,14 +45,14 @@ describe('TychoRoadNetwork', () => {
     expect(player.steel).eq(0);
     expect(player.production.megacredits).eq(1);
 
-    const deferredAction = game.deferredActions.peek() as PlaceMoonRoadTile;
+    const deferredAction = cast(game.deferredActions.peek(), PlaceMoonRoadTile);
     const selectSpace: SelectSpace = deferredAction.execute()!;
     const roadSpace = selectSpace.availableSpaces[0];
     expect(roadSpace.tile).is.undefined;
     expect(roadSpace.player).is.undefined;
     expect(moonData.logisticRate).eq(0);
 
-    deferredAction!.execute()!.cb(roadSpace);
+    deferredAction.execute()!.cb(roadSpace);
     expect(roadSpace.tile!.tileType).eq(TileType.MOON_ROAD);
     expect(roadSpace.player).eq(player);
 

--- a/tests/cards/pathfinders/AsteroidResources.spec.ts
+++ b/tests/cards/pathfinders/AsteroidResources.spec.ts
@@ -50,8 +50,8 @@ describe('AsteroidResources', function() {
     expect(player.production.steel).eq(0);
     expect(player.titanium).eq(1);
     expect(player.steel).eq(2);
-    const action = player.game.deferredActions.peek()! as PlaceOceanTile;
-    const select = action.execute() as SelectSpace;
+    const action = cast(player.game.deferredActions.peek(), PlaceOceanTile);
+    const select = cast(action.execute(), SelectSpace);
     const space = select.availableSpaces[0];
 
     expect(space.spaceType).eq(SpaceType.OCEAN);

--- a/tests/cards/pathfinders/CharityDonation.spec.ts
+++ b/tests/cards/pathfinders/CharityDonation.spec.ts
@@ -32,9 +32,9 @@ describe('CharityDonation', function() {
     const decomposers = new Decomposers();
     game.dealer.deck.push(decomposers, ceosFavoriteProject, beamFromAThoriumAsteroid, acquiredCompany);
 
-    (player1 as any).waitingFor = undefined;
-    (player2 as any).waitingFor = undefined;
-    (player3 as any).waitingFor = undefined;
+    player1.popWaitingFor();
+    player2.popWaitingFor();
+    player3.popWaitingFor();
 
     // Letting player 2 go first to test the wraparound nature of the algorithm.
     card.play(player2);

--- a/tests/cards/pathfinders/CollegiumCopernicus.spec.ts
+++ b/tests/cards/pathfinders/CollegiumCopernicus.spec.ts
@@ -61,7 +61,7 @@ describe('CollegiumCopernicus', function() {
     card.resourceCount = 10;
 
     card.action(player);
-    const selectColony = game.deferredActions.peek()!.execute() as SelectColony;
+    const selectColony = cast(game.deferredActions.peek()!.execute(), SelectColony);
     selectColony.cb(selectColony.colonies[0]);
     expect(card.resourceCount).to.eq(7);
     expect(player.megaCredits).to.eq(2);

--- a/tests/cards/pathfinders/CrewTraining.spec.ts
+++ b/tests/cards/pathfinders/CrewTraining.spec.ts
@@ -29,7 +29,7 @@ describe('CrewTraining', function() {
 
     expect(game.deferredActions.length).eq(1);
     const action = cast(game.deferredActions.pop(), DeclareCloneTag);
-    const options = cast(action!.execute(), OrOptions);
+    const options = cast(action.execute(), OrOptions);
 
     expect(options.options[0].title).to.match(/earth/);
     expect(game.pathfindersData).deep.eq({

--- a/tests/cards/pathfinders/ExperiencedMartians.spec.ts
+++ b/tests/cards/pathfinders/ExperiencedMartians.spec.ts
@@ -9,7 +9,7 @@ import {Tag} from '../../../src/common/cards/Tag';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {SendDelegateToArea} from '../../../src/server/deferredActions/SendDelegateToArea';
 import {SelectPartyToSendDelegate} from '../../../src/server/inputs/SelectPartyToSendDelegate';
-import {fakeCard} from '../../TestingUtils';
+import {cast, fakeCard} from '../../TestingUtils';
 import {CardName} from '../../../src/common/cards/CardName';
 
 describe('ExperiencedMartians', function() {
@@ -46,9 +46,8 @@ describe('ExperiencedMartians', function() {
     expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(6);
     expect(marsFirst.getDelegates(player.id)).eq(0);
 
-    const action = game.deferredActions.pop()!;
-    expect(action).instanceOf(SendDelegateToArea);
-    const options = action.execute()! as SelectPartyToSendDelegate;
+    const action = cast(game.deferredActions.pop(), SendDelegateToArea);
+    const options = cast(action.execute(), SelectPartyToSendDelegate);
     options.cb(marsFirst.name);
 
     expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(5);

--- a/tests/cards/pathfinders/GeologicalExpedition.spec.ts
+++ b/tests/cards/pathfinders/GeologicalExpedition.spec.ts
@@ -32,8 +32,7 @@ describe('GeologicalExpedition', function() {
     microbeCard = fakeCard({resourceType: CardResource.MICROBE});
     scienceCard = fakeCard({resourceType: CardResource.SCIENCE});
     player.playedCards = [card, microbeCard, scienceCard];
-    (player as any).waitingFor = undefined;
-    (player as any).waitingForCb = undefined;
+    player.popWaitingFor();
   });
 
   it('no bonuses, gain 1 steel', () => {

--- a/tests/cards/pathfinders/LobbyHalls.spec.ts
+++ b/tests/cards/pathfinders/LobbyHalls.spec.ts
@@ -57,7 +57,7 @@ describe('LobbyHalls', function() {
 
     // Next test adds a delegate.
     // This test is brittle - it assumes mars first will be orOptions[0]. But OK.
-    assertAddDelegateAction(game.deferredActions.pop()!);
+    assertAddDelegateAction(cast(game.deferredActions.pop(), SendDelegateToArea));
   });
 
   function assertCloneTagAction(action: DeferredAction) {
@@ -66,14 +66,13 @@ describe('LobbyHalls', function() {
     expect(card.tags).deep.eq([Tag.EARTH, Tag.BUILDING]);
   }
 
-  function assertAddDelegateAction(action: DeferredAction) {
+  function assertAddDelegateAction(action: SendDelegateToArea) {
     const marsFirst = turmoil.getPartyByName(PartyName.MARS)!;
 
     expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(6);
     expect(marsFirst.getDelegates(player.id)).eq(0);
 
-    expect(action).instanceOf(SendDelegateToArea);
-    const options = action.execute()! as SelectPartyToSendDelegate;
+    const options = cast(action.execute(), SelectPartyToSendDelegate);
     options.cb(marsFirst.name);
 
     expect(turmoil.getAvailableDelegateCount(player.id, 'reserve')).eq(5);

--- a/tests/cards/pathfinders/Polaris.spec.ts
+++ b/tests/cards/pathfinders/Polaris.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {Polaris} from '../../../src/server/cards/pathfinders/Polaris';
 import {Game} from '../../../src/server/Game';
-import {runAllActions} from '../../TestingUtils';
+import {cast, runAllActions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {newTestGame, getTestPlayer} from '../../TestGame';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
@@ -24,12 +24,8 @@ describe('Polaris', function() {
   it('initial action', function() {
     card.initialAction(player);
     runAllActions(game);
-    const input = player.getWaitingFor();
-
-    expect(input).instanceOf(SelectSpace);
-
+    const selectSpace = cast(player.getWaitingFor(), SelectSpace);
     const space = game.board.getSpace('06');
-    const selectSpace = input as SelectSpace;
 
     expect(selectSpace.availableSpaces).includes(space);
 

--- a/tests/cards/pathfinders/PrivateSecurity.spec.ts
+++ b/tests/cards/pathfinders/PrivateSecurity.spec.ts
@@ -28,16 +28,15 @@ describe('PrivateSecurity', function() {
 
     opponent2.playedCards = [];
     fish.play(player);
-    let action = player.game.deferredActions.pop()?.execute()! as SelectPlayer;
+    const action = cast(player.game.deferredActions.pop()?.execute(), SelectPlayer);
     // Options for both opponents.
     expect(action.players).has.lengthOf(2);
 
     // Opponent 2 has Private Security
     opponent2.playedCards = [card];
     fish.play(player);
-    action = player.game.deferredActions.pop()?.execute()! as SelectPlayer;
     // Options for only one opponent.
-    expect(action).is.undefined;
+    expect(player.game.deferredActions.pop()?.execute()).is.undefined;
     // And it's the one without Private Security.
     expect(opponent1.production.plants).to.eq(1);
   });

--- a/tests/cards/pathfinders/ReturntoAbandonedTechnology.spec.ts
+++ b/tests/cards/pathfinders/ReturntoAbandonedTechnology.spec.ts
@@ -8,6 +8,7 @@ import {Birds} from '../../../src/server/cards/base/Birds';
 import {Capital} from '../../../src/server/cards/base/Capital';
 import {Decomposers} from '../../../src/server/cards/base/Decomposers';
 import {EarthOffice} from '../../../src/server/cards/base/EarthOffice';
+import {cast} from '../../TestingUtils';
 
 describe('ReturntoAbandonedTechnology', function() {
   let card: ReturntoAbandonedTechnology;
@@ -24,10 +25,8 @@ describe('ReturntoAbandonedTechnology', function() {
   it('play when discard pile is empty', function() {
     game.dealer.discarded = [];
 
-    const action = card.play(player);
-
-    expect(action).instanceof(SelectCard);
-    expect((action as SelectCard<any>).cards).is.empty;
+    const action = cast(card.play(player), SelectCard);
+    expect(action.cards).is.empty;
   });
 
   it('play when discard pile has 1 card', function() {
@@ -35,10 +34,9 @@ describe('ReturntoAbandonedTechnology', function() {
     game.dealer.discarded = [];
     game.dealer.discard(ants);
 
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectCard);
 
-    expect(action).instanceof(SelectCard);
-    expect((action as SelectCard<any>).cards).deep.eq([ants]);
+    expect(action.cards).deep.eq([ants]);
     expect(game.dealer.discarded).is.empty;
   });
 
@@ -56,10 +54,9 @@ describe('ReturntoAbandonedTechnology', function() {
     game.dealer.discard(decomposers);
     game.dealer.discard(earthOffice);
 
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectCard);
 
-    expect(action).instanceof(SelectCard);
-    expect((action as SelectCard<any>).cards).to.have.members([birds, capital, decomposers, earthOffice]);
+    expect(action.cards).to.have.members([birds, capital, decomposers, earthOffice]);
     expect(game.dealer.discarded).deep.eq([ants]);
   });
 });

--- a/tests/cards/pathfinders/SecretLabs.spec.ts
+++ b/tests/cards/pathfinders/SecretLabs.spec.ts
@@ -46,7 +46,7 @@ describe('SecretLabs', function() {
     placeOcean.cb();
     runAllActions(player.game);
 
-    const selectSpace = player.getWaitingFor() as SelectSpace;
+    const selectSpace = cast(player.getWaitingFor(), SelectSpace);
     expect(selectSpace.availableSpaces[0].tile).is.undefined;
 
     selectSpace.cb(selectSpace.availableSpaces[0]);

--- a/tests/cards/pathfinders/SmallComet.spec.ts
+++ b/tests/cards/pathfinders/SmallComet.spec.ts
@@ -4,6 +4,8 @@ import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {TileType} from '../../../src/common/TileType';
+import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
+import {cast} from '../../TestingUtils';
 
 describe('SmallComet', function() {
   let card: SmallComet;
@@ -26,7 +28,7 @@ describe('SmallComet', function() {
     player2.plants = 15;
     player3.plants = 400;
 
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectSpace);
 
     expect(player.getTerraformRating()).eq(22);
     expect(player.game.getTemperature()).eq(-28);
@@ -36,8 +38,8 @@ describe('SmallComet', function() {
     expect(player3.plants).eq(398);
     expect(player.titanium).eq(1);
 
-    const space = action!.availableSpaces[0];
-    expect(action!.availableSpaces.some((space) => space.spaceType !== SpaceType.LAND)).is.false;
+    const space = action.availableSpaces[0];
+    expect(action.availableSpaces.some((space) => space.spaceType !== SpaceType.LAND)).is.false;
     expect(space.tile).is.undefined;
 
     action?.cb(space);

--- a/tests/cards/pathfinders/Solarpedia.spec.ts
+++ b/tests/cards/pathfinders/Solarpedia.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {LunarObservationPost} from '../../../src/server/cards/moon/LunarObservationPost';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
-import {ICard} from '../../../src/server/cards/ICard';
+import {cast} from '../../TestingUtils';
 
 describe('Solarpedia', function() {
   let card: Solarpedia;
@@ -85,9 +85,7 @@ describe('Solarpedia', function() {
   });
 
   function testAddResourcesToCard() {
-    const action = game.deferredActions.pop()?.execute();
-    expect(action).instanceOf(SelectCard);
-    const selectCard = action as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.pop()?.execute(), SelectCard);
     expect(selectCard.cards).eql([lunarObservationPost, card]);
     selectCard.cb([lunarObservationPost]);
     expect(lunarObservationPost.resourceCount).eq(2);

--- a/tests/cards/prelude/EarlySettlement.spec.ts
+++ b/tests/cards/prelude/EarlySettlement.spec.ts
@@ -4,6 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {TileType} from '../../../src/common/TileType';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('EarlySettlement', function() {
   it('Should play', function() {
@@ -12,7 +13,7 @@ describe('EarlySettlement', function() {
     const game = Game.newInstance('gameid', [player], player);
 
     player.simplePlay(card);
-    const selectSpace = game.deferredActions.peek()!.execute() as SelectSpace;
+    const selectSpace = cast(game.deferredActions.peek()!.execute(), SelectSpace);
 
     expect(player.production.plants).to.eq(1);
     expect(selectSpace.cb(selectSpace.availableSpaces[0])).is.undefined;

--- a/tests/cards/prelude/ExperimentalForest.spec.ts
+++ b/tests/cards/prelude/ExperimentalForest.spec.ts
@@ -4,6 +4,7 @@ import {Tag} from '../../../src/common/cards/Tag';
 import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('ExperimentalForest', function() {
   it('Should play', function() {
@@ -13,10 +14,8 @@ describe('ExperimentalForest', function() {
     card.play(player);
 
     // Select Greenery space
-    const selectSpace = game.deferredActions.peek()!.execute() as SelectSpace;
+    const selectSpace = cast(game.deferredActions.peek()!.execute(), SelectSpace);
 
-    expect(selectSpace).is.not.undefined;
-    expect(selectSpace instanceof SelectSpace).is.true;
     expect(selectSpace.cb(selectSpace.availableSpaces[0])).is.undefined;
     expect(player.cardsInHand).has.lengthOf(2);
     expect(player.cardsInHand.filter((card) => card.tags.includes(Tag.PLANT))).has.lengthOf(2);

--- a/tests/cards/prelude/LavaTubeSettlement.spec.ts
+++ b/tests/cards/prelude/LavaTubeSettlement.spec.ts
@@ -7,7 +7,7 @@ import {Resources} from '../../../src/common/Resources';
 import {SpaceName} from '../../../src/server/SpaceName';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {TileType} from '../../../src/common/TileType';
-import {resetBoard} from '../../TestingUtils';
+import {cast, resetBoard} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('LavaTubeSettlement', function() {
@@ -43,7 +43,7 @@ describe('LavaTubeSettlement', function() {
     expect(player.simpleCanPlay(card)).is.true;
 
     card.play(player);
-    const selectSpace = game.deferredActions.peek()!.execute() as SelectSpace;
+    const selectSpace = cast(game.deferredActions.peek()!.execute(), SelectSpace);
     selectSpace.cb(selectSpace.availableSpaces[0]);
 
     expect(selectSpace.availableSpaces[0].tile && selectSpace.availableSpaces[0].tile.tileType).to.eq(TileType.CITY);

--- a/tests/cards/promo/AsteroidRights.spec.ts
+++ b/tests/cards/promo/AsteroidRights.spec.ts
@@ -63,7 +63,7 @@ describe('AsteroidRights', function() {
     const cometAiming = new CometAiming();
     player.playedCards.push(cometAiming);
 
-    const action = card.action(player) as SelectCard<ICard>;
+    const action = cast(card.action(player), SelectCard<ICard>);
     action.cb([cometAiming]);
     expect(cometAiming.resourceCount).to.eq(1);
   });
@@ -74,7 +74,6 @@ describe('AsteroidRights', function() {
     player.playedCards.push(cometAiming);
 
     const action = cast(card.action(player), OrOptions);
-    expect(action).instanceOf(OrOptions);
     expect(action.options[0] instanceof SelectOption).is.true;
     expect(action.options[1] instanceof SelectOption).is.true;
     expect(action.options[2] instanceof SelectCard).is.true;

--- a/tests/cards/promo/Astrodrill.spec.ts
+++ b/tests/cards/promo/Astrodrill.spec.ts
@@ -54,7 +54,7 @@ describe('Astrodrill', function() {
     player.playedCards.push(cometAiming);
 
     const action = cast(card.action(player), OrOptions);
-    const addAsteroidOption = action.options[1] as SelectCard<ICard>;
+    const addAsteroidOption = cast(action.options[1], SelectCard<ICard>);
 
     const result = addAsteroidOption.cb([cometAiming]);
     expect(cometAiming.resourceCount).to.eq(1);

--- a/tests/cards/promo/BactoviralResearch.spec.ts
+++ b/tests/cards/promo/BactoviralResearch.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {RegolithEaters} from '../../../src/server/cards/base/RegolithEaters';
 import {Research} from '../../../src/server/cards/base/Research';
 import {Tardigrades} from '../../../src/server/cards/base/Tardigrades';
@@ -26,8 +27,7 @@ describe('BactoviralResearch', function() {
     const card4 = new Tardigrades();
     player.playedCards.push(card2, card3, card4);
 
-    const action = card.play(player) as SelectCard<ICard>;
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard<ICard>);
     action.cb([card3]);
     expect(card3.resourceCount).to.eq(4);
     expect(player.cardsInHand.length).to.eq(1);
@@ -36,7 +36,7 @@ describe('BactoviralResearch', function() {
   it('Should play with single microbe card', function() {
     const card2 = new RegolithEaters();
     player.playedCards.push(card2);
-    card.play(player) as SelectCard<ICard>;
+    expect(card.play(player)).is.undefined;
     expect(card2.resourceCount).to.eq(2);
     expect(player.cardsInHand.length).to.eq(1);
   });

--- a/tests/cards/promo/BioPrintingFacility.spec.ts
+++ b/tests/cards/promo/BioPrintingFacility.spec.ts
@@ -6,6 +6,7 @@ import {Game} from '../../../src/server/Game';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {Player} from '../../../src/server/Player';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('BioPrintingFacility', function() {
   let card: BioPrintingFacility;
@@ -41,14 +42,13 @@ describe('BioPrintingFacility', function() {
     player.playedCards.push(smallanimals);
     player.energy = 2;
 
-    const action = card.action(player);
-    expect(action).instanceOf(OrOptions);
-    expect(action!.options).has.lengthOf(2);
+    const action = cast(card.action(player), OrOptions);
+    expect(action.options).has.lengthOf(2);
 
-    action!.options[0].cb();
+    action.options[0].cb();
     expect(smallanimals.resourceCount).to.eq(1);
 
-    action!.options[1].cb();
+    action.options[1].cb();
     expect(player.plants).to.eq(2);
   });
 
@@ -58,14 +58,13 @@ describe('BioPrintingFacility', function() {
     player.playedCards.push(smallanimals, fish);
     player.energy = 2;
 
-    const action = card.action(player);
-    expect(action).instanceOf(OrOptions);
-    expect(action!.options).has.lengthOf(2);
+    const action = cast(card.action(player), OrOptions);
+    expect(action.options).has.lengthOf(2);
 
-    action!.options[0].cb([smallanimals]);
+    action.options[0].cb([smallanimals]);
     expect(smallanimals.resourceCount).to.eq(1);
 
-    action!.options[0].cb([fish]);
+    action.options[0].cb([fish]);
     expect(fish.resourceCount).to.eq(1);
   });
 });

--- a/tests/cards/promo/CometAiming.spec.ts
+++ b/tests/cards/promo/CometAiming.spec.ts
@@ -39,7 +39,7 @@ describe('CometAiming', function() {
 
     card.action(player);
     expect(player.game.deferredActions).has.lengthOf(1);
-    const selectSpace = player.game.deferredActions.peek()!.execute() as SelectSpace;
+    const selectSpace = cast(player.game.deferredActions.peek()!.execute(), SelectSpace);
     selectSpace.cb(selectSpace.availableSpaces[0]);
     expect(player.getTerraformRating()).to.eq(21);
   });

--- a/tests/cards/promo/DeimosDownPromo.spec.ts
+++ b/tests/cards/promo/DeimosDownPromo.spec.ts
@@ -20,8 +20,7 @@ describe('DeimosDownPromo', function() {
   });
 
   it('Should play without plants', function() {
-    const action = card.play(player);
-    expect(action).instanceOf(SelectSpace);
+    cast(card.play(player), SelectSpace);
     expect(player.game.getTemperature()).to.eq(-24);
     expect(player.steel).to.eq(4);
     const input = player.game.deferredActions.peek()!.execute();
@@ -31,8 +30,7 @@ describe('DeimosDownPromo', function() {
   it('Can remove plants', function() {
     player2.plants = 5;
 
-    const action = card.play(player);
-    expect(action).instanceOf(SelectSpace);
+    cast(card.play(player), SelectSpace);
     expect(player.game.getTemperature()).to.eq(-24);
     expect(player.steel).to.eq(4);
 
@@ -49,8 +47,7 @@ describe('DeimosDownPromo', function() {
     Game.newInstance('gameid', [player], player);
 
     player.plants = 15;
-    const action = card.play(player);
-    expect(action).instanceOf(SelectSpace);
+    cast(card.play(player), SelectSpace);
 
     expect(player.game.getTemperature()).to.eq(-24);
     expect(player.steel).to.eq(4);

--- a/tests/cards/promo/DirectedImpactors.spec.ts
+++ b/tests/cards/promo/DirectedImpactors.spec.ts
@@ -38,7 +38,7 @@ describe('DirectedImpactors', function() {
     // can add resource to itself
     card.action(player);
     expect(game.deferredActions).has.lengthOf(1);
-    const selectPayment = game.deferredActions.peek()!.execute() as SelectPayment;
+    const selectPayment = cast(game.deferredActions.peek()!.execute(), SelectPayment);
     selectPayment.cb({...Payment.EMPTY, titanium: 1, megaCredits: 3});
 
     expect(player.megaCredits).to.eq(0);

--- a/tests/cards/promo/GreatDamPromo.spec.ts
+++ b/tests/cards/promo/GreatDamPromo.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {Player} from '../../../src/server/Player';
 import {TileType} from '../../../src/common/TileType';
-import {maxOutOceans} from '../../TestingUtils';
+import {cast, maxOutOceans} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('GreatDamPromo', function() {
@@ -25,8 +25,7 @@ describe('GreatDamPromo', function() {
   it('Should play', function() {
     maxOutOceans(player, 4);
 
-    const action = card.play(player);
-    expect(action).instanceOf(SelectSpace);
+    cast(card.play(player), SelectSpace);
     expect(player.production.energy).to.eq(2);
     expect(card.getVictoryPoints()).to.eq(1);
   });
@@ -34,8 +33,7 @@ describe('GreatDamPromo', function() {
   it('Works with Ares', function() {
     maxOutOceans(player, 4).forEach((space) => space.tile = {tileType: TileType.OCEAN_CITY});
 
-    const action = card.play(player);
-    expect(action).instanceOf(SelectSpace);
+    cast(card.play(player), SelectSpace);
     expect(player.production.energy).to.eq(2);
     expect(card.getVictoryPoints()).to.eq(1);
   });

--- a/tests/cards/promo/HiTechLab.spec.ts
+++ b/tests/cards/promo/HiTechLab.spec.ts
@@ -5,6 +5,7 @@ import {SelectAmount} from '../../../src/server/inputs/SelectAmount';
 import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('HiTechLab', function() {
   let card: HiTechLab;
@@ -24,11 +25,10 @@ describe('HiTechLab', function() {
     player.addResource(Resources.ENERGY, 5);
     expect(card.canAct(player)).is.true;
 
-    const amount = card.action(player) as SelectAmount;
-    expect(amount instanceof SelectAmount).is.true;
+    const amount = cast(card.action(player), SelectAmount);
 
-        amount!.cb(3);
-        expect(player.getResource(Resources.ENERGY)).to.eq(2);
+    amount.cb(3);
+    expect(player.getResource(Resources.ENERGY)).to.eq(2);
   });
 
   it('Should give victory points', function() {

--- a/tests/cards/promo/ImportedNutrients.spec.ts
+++ b/tests/cards/promo/ImportedNutrients.spec.ts
@@ -1,9 +1,11 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Ants} from '../../../src/server/cards/base/Ants';
 import {Decomposers} from '../../../src/server/cards/base/Decomposers';
 import {ImportedNutrients} from '../../../src/server/cards/promo/ImportedNutrients';
 import {Player} from '../../../src/server/Player';
 import {TestPlayer} from '../../TestPlayer';
+import {SelectCard} from '../../../src/server/inputs/SelectCard';
 
 describe('ImportedNutrients', function() {
   let card: ImportedNutrients;
@@ -34,11 +36,10 @@ describe('ImportedNutrients', function() {
     const decomposers = new Decomposers();
     player.playedCards.push(ants, decomposers);
 
-    const action = card.play(player);
+    const action = cast(card.play(player), SelectCard);
     expect(player.plants).to.eq(4);
 
-    expect(action).is.not.undefined;
-        action!.cb([decomposers]);
-        expect(decomposers.resourceCount).to.eq(4);
+    action.cb([decomposers]);
+    expect(decomposers.resourceCount).to.eq(4);
   });
 });

--- a/tests/cards/promo/LawSuit.spec.ts
+++ b/tests/cards/promo/LawSuit.spec.ts
@@ -5,6 +5,7 @@ import {SelectPlayer} from '../../../src/server/inputs/SelectPlayer';
 import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('LawSuit', () => {
   let card: LawSuit;
@@ -59,9 +60,8 @@ describe('LawSuit', () => {
     // This thief now has has 2MC
     player2.megaCredits = 2;
     player.megaCredits = 0;
-    const play = card.play(player);
-    expect(play).instanceOf(SelectPlayer);
-    (play as SelectPlayer).cb(player2);
+    const play = cast(card.play(player), SelectPlayer);
+    play.cb(player2);
     expect(player.megaCredits).eq(2);
     expect(player2.megaCredits).eq(0);
   });

--- a/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
+++ b/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
@@ -5,6 +5,7 @@ import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('MagneticFieldGeneratorsPromo', function() {
   let card: MagneticFieldGeneratorsPromo;
@@ -26,8 +27,7 @@ describe('MagneticFieldGeneratorsPromo', function() {
     player.production.add(Resources.ENERGY, 4);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).instanceOf(SelectSpace);
+    cast(card.play(player), SelectSpace);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(2);
     expect(player.getTerraformRating()).to.eq(23);

--- a/tests/cards/promo/MoholeLake.spec.ts
+++ b/tests/cards/promo/MoholeLake.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Ants} from '../../../src/server/cards/base/Ants';
 import {Fish} from '../../../src/server/cards/base/Fish';
 import {ICard} from '../../../src/server/cards/ICard';
@@ -24,7 +25,7 @@ describe('MoholeLake', function() {
     card.play(player);
 
     expect(player.game.deferredActions).has.lengthOf(1);
-    const selectSpace = player.game.deferredActions.peek()!.execute() as SelectSpace;
+    const selectSpace = cast(player.game.deferredActions.peek()!.execute(), SelectSpace);
     selectSpace.cb(selectSpace.availableSpaces[0]);
 
     expect(player.game.getTemperature()).to.eq(-28);
@@ -55,7 +56,7 @@ describe('MoholeLake', function() {
 
     card.play(player);
     expect(card.canAct()).is.true;
-    const action = card.action(player) as SelectCard<ICard>;
+    const action = cast(card.action(player), SelectCard<ICard>);
 
     action.cb([ants]);
     expect(ants.resourceCount).to.eq(1);

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -11,7 +11,7 @@ import {ViralEnhancers} from '../../../src/server/cards/base/ViralEnhancers';
 import {PharmacyUnion} from '../../../src/server/cards/promo/PharmacyUnion';
 import {Tag} from '../../../src/common/cards/Tag';
 import {Game} from '../../../src/server/Game';
-import {AndOptions} from '../../../src/server/inputs/AndOptions';
+import {SelectInitialCards} from '../../../src/server/inputs/SelectInitialCards';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {TestPlayer} from '../../TestPlayer';
 import {Virus} from '../../../src/server/cards/base/Virus';
@@ -34,7 +34,7 @@ describe('PharmacyUnion', function() {
   it('Should play', function() {
     player.corporations.length = 0; // Resetting so when setting the corproation it doesn't do anything flaky.
     Game.newInstance('gameid', [player], player);
-    const pi = player.getWaitingFor() as AndOptions;
+    const pi = cast(player.getWaitingFor(), SelectInitialCards);
     pi.options[0].cb([card]);
     pi.options[1].cb([]);
     pi.cb();

--- a/tests/cards/promo/Philares.spec.ts
+++ b/tests/cards/promo/Philares.spec.ts
@@ -85,7 +85,7 @@ describe('Philares', () => {
     game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
-    const options = action?.execute() as AndOptions;
+    const options = cast(action?.execute(), AndOptions);
     // Options are ordered 0-5, MC to heat.
     expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
@@ -97,7 +97,7 @@ describe('Philares', () => {
     game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
-    const options = action?.execute() as AndOptions;
+    const options = cast(action?.execute(), AndOptions);
     // Options are ordered 0-5, MC to heat.
     expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
@@ -112,7 +112,7 @@ describe('Philares', () => {
     game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
     const action = game.deferredActions.pop();
-    const options = action?.execute() as AndOptions;
+    const options = cast(action?.execute(), AndOptions);
     // Options are ordered 0-5, MC to heat.
     expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
@@ -128,7 +128,7 @@ describe('Philares', () => {
     game.addTile(otherPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
     const action = game.deferredActions.pop();
-    const options = action?.execute() as AndOptions;
+    const options = cast(action?.execute(), AndOptions);
     // Options are ordered 0-5, MC to heat.
     expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
@@ -142,7 +142,7 @@ describe('Philares', () => {
     game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
     game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
-    const options = action?.execute() as AndOptions;
+    const options = cast(action?.execute(), AndOptions);
     // Options are ordered 0-5, MC to heat.
     expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
@@ -184,13 +184,12 @@ describe('Philares', () => {
 
     // Philares player gains plant and can subsequently place a greenery
     philaresPlayer.takeActionForFinalGreenery();
-    const philaresPlayerResourceSelection = philaresPlayer.getWaitingFor() as AndOptions;
+    const philaresPlayerResourceSelection = cast(philaresPlayer.getWaitingFor(), AndOptions);
     // Option 3 is plants.
     philaresPlayerResourceSelection.options[3].cb(1);
     philaresPlayerResourceSelection.cb();
     expect(philaresPlayer.plants).to.eq(8);
-    (philaresPlayer as any).waitingFor = undefined;
-    (philaresPlayer as any).waitingForCb = undefined;
+    philaresPlayer.popWaitingFor();
     game.gotoFinalGreeneryPlacement();
     const finalGreeneryPlacement = cast(philaresPlayer.getWaitingFor(), OrOptions);
     expect(game.phase).eq(Phase.RESEARCH);

--- a/tests/cards/promo/ProjectInspection.spec.ts
+++ b/tests/cards/promo/ProjectInspection.spec.ts
@@ -45,8 +45,8 @@ describe('ProjectInspection', function() {
     player.addActionThisGeneration(restrictedArea.name);
     expect(card.canPlay(player)).is.true;
 
-    const play = card.play(player);
-    expect(play instanceof SelectCard).is.true;
+    // returns SelectCard.
+    cast(card.play(player), SelectCard);
   });
 
   it('Can not play with Playwrights if there is no other card to chain', function() {
@@ -149,8 +149,7 @@ describe('ProjectInspection', function() {
     player.addResource(Resources.MEGACREDITS, 2);
     expect(playwrights.canAct(player)).is.true; // PW -> PI -> PW -> IW
 
-    const action1 = playwrights.action(player) as SelectCard<IProjectCard>;
-    expect(action1).is.not.undefined;
+    const action1 = cast(playwrights.action(player), SelectCard<IProjectCard>);
     expect(action1.cards).has.lengthOf(2); // PI and IW are available
     expect(action1.cards[0]?.name).eq(card.name);
     action1.cb([card]);
@@ -161,7 +160,6 @@ describe('ProjectInspection', function() {
     expect(play1.cards[0]?.name).eq(playwrights.name);
 
     const action2 = cast(play1.cb([playwrights]), SelectCard<ICard>);
-    expect(action2).is.not.undefined;
     expect(action2.cards).has.lengthOf(1); // Only IW is available, PI has been removed from play
     expect(action2.cards[0]?.name).eq(indenturedWorkers.name);
   });

--- a/tests/cards/promo/SelfReplicatingRobots.spec.ts
+++ b/tests/cards/promo/SelfReplicatingRobots.spec.ts
@@ -47,13 +47,13 @@ describe('SelfReplicatingRobots', function() {
     player.cardsInHand.push(new HousePrinting());
 
     const action = cast(card.action(player), OrOptions);
-    action.options[0].cb([(action.options[0] as SelectCard<IProjectCard>).cards[0]]);
+    action.options[0].cb([cast(action.options[0], SelectCard<IProjectCard>).cards[0]]);
     expect(card.targetCards[0].resourceCount).to.eq(2);
     expect(player.cardsInHand).deep.eq([earthOffice]);
     expect(card.targetCards).has.lengthOf(1);
 
     const action2 = cast(card.action(player), OrOptions);
-    action2.options[0].cb([(action2.options[0] as SelectCard<IProjectCard>).cards[0]]);
+    action2.options[0].cb([cast(action2.options[0], SelectCard<IProjectCard>).cards[0]]);
     expect(card.targetCards[0].resourceCount).to.eq(4);
   });
 });

--- a/tests/cards/turmoil/BannedDelegate.spec.ts
+++ b/tests/cards/turmoil/BannedDelegate.spec.ts
@@ -48,7 +48,7 @@ describe('Banned Delegate', function() {
       selectDelegate.cb(result.players[0]);
     } else {
       const orOptions = cast(result, OrOptions);
-      orOptions.options.forEach((option) => option.cb((option as SelectDelegate).players[0]));
+      orOptions.options.forEach((option) => option.cb(cast(option, SelectDelegate).players[0]));
     }
 
     expect(greens.delegates).has.lengthOf(initialDelegatesCount - 1);

--- a/tests/cards/turmoil/TerralabsResearch.spec.ts
+++ b/tests/cards/turmoil/TerralabsResearch.spec.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {BusinessNetwork} from '../../../src/server/cards/base/BusinessNetwork';
 import {PowerPlant} from '../../../src/server/cards/base/PowerPlant';
-import {IProjectCard} from '../../../src/server/cards/IProjectCard';
 import {TerralabsResearch} from '../../../src/server/cards/turmoil/TerralabsResearch';
 import {Game} from '../../../src/server/Game';
-import {AndOptions} from '../../../src/server/inputs/AndOptions';
+import {SelectInitialCards} from '../../../src/server/inputs/SelectInitialCards';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {TestPlayer} from '../../TestPlayer';
 
@@ -15,7 +15,7 @@ describe('TerralabsResearch', function() {
     const card3 = new BusinessNetwork();
     const player = TestPlayer.BLUE.newPlayer();
     const game = Game.newInstance('gameid', [player], player);
-    const pi = player.getWaitingFor() as AndOptions;
+    const pi = cast(player.getWaitingFor(), SelectInitialCards);
     pi.options[0].cb([card]);
     pi.options[1].cb([card2, card2]);
     pi.cb();
@@ -26,10 +26,8 @@ describe('TerralabsResearch', function() {
     expect(player.getTerraformRating()).to.eq(13);
 
     player.playedCards.push(card3);
-    const action = card3.action(player);
-    expect(action).is.not.undefined;
-    expect(action).instanceOf(SelectCard);
-    (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
+    const action = cast(card3.action(player), SelectCard);
+    action.cb([action.cards[0]]);
     game.deferredActions.runNext();
     expect(player.megaCredits).to.eq(11);
     expect(player.cardsInHand).has.lengthOf(3);

--- a/tests/cards/turmoil/UtopiaInvest.spec.ts
+++ b/tests/cards/turmoil/UtopiaInvest.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {UtopiaInvest} from '../../../src/server/cards/turmoil/UtopiaInvest';
 import {Game} from '../../../src/server/Game';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('UtopiaInvest', function() {
@@ -15,9 +15,7 @@ describe('UtopiaInvest', function() {
     expect(play).is.undefined;
     expect(player.production.titanium).to.eq(1);
     expect(player.production.steel).to.eq(1);
-    const action = card.action(player);
-    expect(action).is.not.undefined;
-    expect(action).instanceOf(OrOptions);
+    const action = cast(card.action(player), OrOptions);
     action.options[2].cb();
     expect(player.titanium).to.eq(4);
     expect(player.production.titanium).to.eq(0);

--- a/tests/cards/venusNext/AerialMappers.spec.ts
+++ b/tests/cards/venusNext/AerialMappers.spec.ts
@@ -29,8 +29,7 @@ describe('AerialMappers', function() {
   it('Should act - multiple targets', function() {
     const card2 = new Dirigibles();
     player.playedCards.push(card2);
-    const action = card.action(player) as SelectCard<ICard>;
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.action(player), SelectCard<ICard>);
 
     action.cb([card]);
     expect(card.resourceCount).to.eq(1);

--- a/tests/cards/venusNext/AirScrappingExpedition.spec.ts
+++ b/tests/cards/venusNext/AirScrappingExpedition.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {ICard} from '../../../src/server/cards/ICard';
 import {AirScrappingExpedition} from '../../../src/server/cards/venusNext/AirScrappingExpedition';
 import {Celestic} from '../../../src/server/cards/venusNext/Celestic';
@@ -15,10 +16,7 @@ describe('AirScrappingExpedition', function() {
     const game = Game.newInstance('gameid', [player, redPlayer], player);
     player.setCorporationForTest(corp);
 
-
-    const selectCard = card.play(player) as SelectCard<ICard>;
-    expect(selectCard).is.not.undefined;
-    expect(selectCard instanceof SelectCard).is.true;
+    const selectCard = cast(card.play(player), SelectCard<ICard>);
 
     selectCard.cb([selectCard.cards[0]]);
     expect(corp.resourceCount).to.eq(3);

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -71,7 +71,7 @@ describe('Atmoscoop', function() {
     expect(game.getVenusScaleLevel()).to.eq(4);
 
     // Then the floaters
-    const selectCard = orOptions.cb() as SelectCard<ICard>;
+    const selectCard = cast(orOptions.cb(), SelectCard<ICard>);
     selectCard.cb([dirigibles]);
     expect(dirigibles.resourceCount).to.eq(2);
     selectCard.cb([floatingHabs]);
@@ -102,8 +102,7 @@ describe('Atmoscoop', function() {
     player.playedCards.push(dirigibles, floatingHabs);
     (game as any).temperature = constants.MAX_TEMPERATURE;
 
-    const action = card.play(player) as SelectCard<ICard>;
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard<ICard>);
 
     action.cb([dirigibles]);
     expect(game.getVenusScaleLevel()).to.eq(4);
@@ -115,8 +114,7 @@ describe('Atmoscoop', function() {
     (game as any).venusScaleLevel = constants.MAX_VENUS_SCALE;
     (game as any).temperature = constants.MAX_TEMPERATURE;
 
-    const action = card.play(player) as SelectCard<ICard>;
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard<ICard>);
     action.cb([dirigibles]);
     expect(dirigibles.resourceCount).to.eq(2);
   });

--- a/tests/cards/venusNext/CorroderSuits.spec.ts
+++ b/tests/cards/venusNext/CorroderSuits.spec.ts
@@ -7,6 +7,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('CorroderSuits', function() {
   let card: CorroderSuits;
@@ -38,12 +39,11 @@ describe('CorroderSuits', function() {
     const card3 = new Dirigibles();
     player.playedCards.push(card2, card3);
 
-    const action = card.play(player);
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard);
 
-        action!.cb([card2]);
-        expect(card2.resourceCount).to.eq(1);
-        expect(player.production.megacredits).to.eq(2);
+    action.cb([card2]);
+    expect(card2.resourceCount).to.eq(1);
+    expect(player.production.megacredits).to.eq(2);
   });
 
   it('Should play - specialized resource type', function() {

--- a/tests/cards/venusNext/Dirigibles.spec.ts
+++ b/tests/cards/venusNext/Dirigibles.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Dirigibles} from '../../../src/server/cards/venusNext/Dirigibles';
 import {FloatingHabs} from '../../../src/server/cards/venusNext/FloatingHabs';
 import {Game} from '../../../src/server/Game';
@@ -34,10 +35,9 @@ describe('Dirigibles', function() {
 
   it('Should act - multiple targets', function() {
     player.playedCards.push(new FloatingHabs());
-    const action = card.action(player);
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.action(player), SelectCard);
+    action.cb([card]);
 
-    action!.cb([card]);
     expect(card.resourceCount).to.eq(1);
   });
 });

--- a/tests/cards/venusNext/Extremophiles.spec.ts
+++ b/tests/cards/venusNext/Extremophiles.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Research} from '../../../src/server/cards/base/Research';
 import {Tardigrades} from '../../../src/server/cards/base/Tardigrades';
 import {Extremophiles} from '../../../src/server/cards/venusNext/Extremophiles';
@@ -37,11 +38,10 @@ describe('Extremophiles', function() {
 
   it('Should act - multiple targets', function() {
     player.playedCards.push(card, new Tardigrades());
-    const action = card.action(player);
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.action(player), SelectCard);
+    action.cb([card]);
 
-        action!.cb([card]);
-        expect(card.resourceCount).to.eq(1);
+    expect(card.resourceCount).to.eq(1);
   });
 
   it('Gives victory points', function() {

--- a/tests/cards/venusNext/FloatingHabs.spec.ts
+++ b/tests/cards/venusNext/FloatingHabs.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Research} from '../../../src/server/cards/base/Research';
-import {ICard} from '../../../src/server/cards/ICard';
 import {Dirigibles} from '../../../src/server/cards/venusNext/Dirigibles';
 import {FloatingHabs} from '../../../src/server/cards/venusNext/FloatingHabs';
 import {Game} from '../../../src/server/Game';
@@ -44,10 +44,8 @@ describe('FloatingHabs', function() {
   it('Should act - multiple targets', function() {
     player.playedCards.push(card, new Dirigibles());
     player.megaCredits = 10;
-    const action = card.action(player);
-    expect(action).instanceOf(SelectCard);
-
-    (action as SelectCard<ICard>).cb([card]);
+    const action = cast(card.action(player), SelectCard);
+    action.cb([card]);
     game.deferredActions.runNext();
     expect(card.resourceCount).to.eq(1);
     expect(player.megaCredits).to.eq(8);

--- a/tests/cards/venusNext/FreyjaBiodomes.spec.ts
+++ b/tests/cards/venusNext/FreyjaBiodomes.spec.ts
@@ -8,6 +8,7 @@ import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('FreyjaBiodomes', function() {
   let card: FreyjaBiodomes;
@@ -52,8 +53,7 @@ describe('FreyjaBiodomes', function() {
     player.production.add(Resources.ENERGY, 1);
     player.playedCards.push(card2, card3);
 
-    const action = card.play(player) as SelectCard<ICard>;
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard<ICard>);
 
     action.cb([card2]);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/venusNext/Gyropolis.spec.ts
+++ b/tests/cards/venusNext/Gyropolis.spec.ts
@@ -9,6 +9,7 @@ import {TileType} from '../../../src/common/TileType';
 import {TestPlayer} from '../../TestPlayer';
 import {EarthEmbassy} from '../../../src/server/cards/moon/EarthEmbassy';
 import {DeepLunarMining} from '../../../src/server/cards/moon/DeepLunarMining';
+import {cast} from '../../TestingUtils';
 
 describe('Gyropolis', function() {
   let card: Gyropolis;
@@ -28,8 +29,7 @@ describe('Gyropolis', function() {
     player.playedCards.push(card1, card2);
     player.production.add(Resources.ENERGY, 2);
     expect(player.canPlayIgnoringCost(card)).is.true;
-    const action = card.play(player) as SelectSpace;
-    expect(action).is.not.undefined;
+    const action = cast(card.play(player), SelectSpace);
     expect(action.cb(action.availableSpaces[0])).is.undefined;
     expect(action.availableSpaces[0].player).to.eq(player);
     expect(action.availableSpaces[0].tile).is.not.undefined;

--- a/tests/cards/venusNext/HydrogenToVenus.spec.ts
+++ b/tests/cards/venusNext/HydrogenToVenus.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {ColonizerTrainingCamp} from '../../../src/server/cards/base/ColonizerTrainingCamp';
 import {ICard} from '../../../src/server/cards/ICard';
 import {DeuteriumExport} from '../../../src/server/cards/venusNext/DeuteriumExport';
@@ -27,8 +28,7 @@ describe('HydrogenToVenus', function() {
     const card4 = new Dirigibles();
     player.playedCards.push(card2, card3, card4);
 
-    const action = card.play(player) as SelectCard<ICard>;
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard<ICard>);
     action.cb([card2]);
     expect(card2.resourceCount).to.eq(1);
     expect(game.getVenusScaleLevel()).to.eq(2);
@@ -40,9 +40,9 @@ describe('HydrogenToVenus', function() {
     const card3 = new ColonizerTrainingCamp();
     player.playedCards.push(card2, card3);
 
-        card.play(player) as SelectCard<ICard>;
-        expect(card2.resourceCount).to.eq(1);
-        expect(game.getVenusScaleLevel()).to.eq(2);
+    expect(card.play(player)).is.undefined;
+    expect(card2.resourceCount).to.eq(1);
+    expect(game.getVenusScaleLevel()).to.eq(2);
   });
 
   it('Should play with no venus cards', function() {

--- a/tests/cards/venusNext/MaxwellBase.spec.ts
+++ b/tests/cards/venusNext/MaxwellBase.spec.ts
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {Birds} from '../../../src/server/cards/base/Birds';
-import {ICard} from '../../../src/server/cards/ICard';
 import {AerialMappers} from '../../../src/server/cards/venusNext/AerialMappers';
 import {MaxwellBase} from '../../../src/server/cards/venusNext/MaxwellBase';
 import {StratosphericBirds} from '../../../src/server/cards/venusNext/StratosphericBirds';
@@ -8,7 +7,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {CardName} from '../../../src/common/cards/CardName';
 import {Tag} from '../../../src/common/cards/Tag';
@@ -69,9 +68,8 @@ describe('MaxwellBase', function() {
     player.playedCards.push(card, card2, card3);
     expect(card.canAct(player)).is.true;
 
-    const action = card.action(player);
-    expect(action).instanceOf(SelectCard);
-    (action as SelectCard<ICard>).cb([card2]);
+    const action = cast(card.action(player), SelectCard);
+    action.cb([card2]);
     expect(card2.resourceCount).to.eq(1);
   });
 

--- a/tests/cards/venusNext/SponsoredAcademies.spec.ts
+++ b/tests/cards/venusNext/SponsoredAcademies.spec.ts
@@ -8,7 +8,7 @@ import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {TestPlayer} from '../../TestPlayer';
 import {DiscardCards} from '../../../src/server/deferredActions/DiscardCards';
 import {DrawCards} from '../../../src/server/deferredActions/DrawCards';
-import {runAllActions} from '../../TestingUtils';
+import {cast, runAllActions} from '../../TestingUtils';
 
 describe('SponsoredAcademies', function() {
   it('Should play', function() {
@@ -24,7 +24,7 @@ describe('SponsoredAcademies', function() {
     expect(player.canPlayIgnoringCost(card)).is.true;
 
     player.playCard(card);
-    const discardCard = game.deferredActions.pop()!.execute() as SelectCard<IProjectCard>;
+    const discardCard = cast(game.deferredActions.pop()!.execute(), SelectCard<IProjectCard>);
     expect(discardCard instanceof SelectCard).is.true;
 
     // No SponsoredAcademies itself suggested to discard

--- a/tests/cards/venusNext/Stratopolis.spec.ts
+++ b/tests/cards/venusNext/Stratopolis.spec.ts
@@ -5,7 +5,7 @@ import {Stratopolis} from '../../../src/server/cards/venusNext/Stratopolis';
 import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {cast, setCustomGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('Stratopolis', function() {
@@ -42,9 +42,9 @@ describe('Stratopolis', function() {
     const card2 = new AerialMappers();
     player.playedCards.push(card, card2);
 
-    const action = card.action(player);
-    expect(action).instanceOf(SelectCard);
-        action!.cb([card2]);
-        expect(card2.resourceCount).to.eq(2);
+    const action = cast(card.action(player), SelectCard);
+    action.cb([card2]);
+
+    expect(card2.resourceCount).to.eq(2);
   });
 });

--- a/tests/cards/venusNext/StratosphericBirds.spec.ts
+++ b/tests/cards/venusNext/StratosphericBirds.spec.ts
@@ -12,6 +12,7 @@ import {TestPlayer} from '../../TestPlayer';
 import {Payment} from '../../../src/common/inputs/Payment';
 import {AerialMappers} from '../../../src/server/cards/venusNext/AerialMappers';
 import {SelectProjectCardToPlay} from '../../../src/server/inputs/SelectProjectCardToPlay';
+import {cast} from '../../TestingUtils';
 
 describe('StratosphericBirds', () => {
   let card: StratosphericBirds;
@@ -76,7 +77,7 @@ describe('StratosphericBirds', () => {
     player.addResourceTo(extractorBalloons, 1);
 
     card.play(player);
-    const selectCard = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
+    const selectCard = cast(game.deferredActions.pop()!.execute(), SelectCard<ICard>);
     expect(selectCard.cards).has.lengthOf(2);
 
     selectCard.cb([deuteriumExport]);

--- a/tests/cards/venusNext/VenusSoils.spec.ts
+++ b/tests/cards/venusNext/VenusSoils.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Thermophiles} from '../../../src/server/cards/venusNext/Thermophiles';
 import {VenusianInsects} from '../../../src/server/cards/venusNext/VenusianInsects';
 import {VenusSoils} from '../../../src/server/cards/venusNext/VenusSoils';
@@ -34,12 +35,11 @@ describe('VenusSoils', function() {
     const card3 = new VenusianInsects();
     player.playedCards.push(card2, card3);
 
-    const action = card.play(player);
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard);
+    action.cb([card2]);
 
-        action!.cb([card2]);
-        expect(card2.resourceCount).to.eq(2);
-        expect(player.production.plants).to.eq(1);
-        expect(game.getVenusScaleLevel()).to.eq(2);
+    expect(card2.resourceCount).to.eq(2);
+    expect(player.production.plants).to.eq(1);
+    expect(game.getVenusScaleLevel()).to.eq(2);
   });
 });

--- a/tests/cards/venusNext/VenusianPlants.spec.ts
+++ b/tests/cards/venusNext/VenusianPlants.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../../TestingUtils';
 import {Thermophiles} from '../../../src/server/cards/venusNext/Thermophiles';
 import {VenusianAnimals} from '../../../src/server/cards/venusNext/VenusianAnimals';
 import {VenusianPlants} from '../../../src/server/cards/venusNext/VenusianPlants';
@@ -32,12 +33,11 @@ describe('VenusianPlants', function() {
     const card3 = new VenusianAnimals();
     player.playedCards.push(card2, card3);
 
-    const action = card.play(player);
-    expect(action).instanceOf(SelectCard);
+    const action = cast(card.play(player), SelectCard);
+    action.cb([card2]);
 
-        action!.cb([card2]);
-        expect(card2.resourceCount).to.eq(1);
-        expect(game.getVenusScaleLevel()).to.eq(18);
+    expect(card2.resourceCount).to.eq(1);
+    expect(game.getVenusScaleLevel()).to.eq(18);
   });
 
   it('Should play - single target', function() {

--- a/tests/colonies/Colony.spec.ts
+++ b/tests/colonies/Colony.spec.ts
@@ -335,18 +335,15 @@ describe('Colony', function() {
     });
     expect(callbackWasCalled).to.be.false;
 
-    const input = player.getWaitingFor()! as SelectCard<IProjectCard>;
-    expect(input).to.be.an.instanceof(SelectCard);
+    cast(player.getWaitingFor()!, SelectCard<IProjectCard>);
     player.process([['Dust Seals']]); // Discard a card
     expect(callbackWasCalled).to.be.false;
 
-    const input2 = player2.getWaitingFor()! as SelectCard<IProjectCard>;
-    expect(input2).to.be.an.instanceof(SelectCard);
+    cast(player2.getWaitingFor()!, SelectCard<IProjectCard>);
     player2.process([['Dust Seals']]); // Discard a card
     expect(callbackWasCalled).to.be.false;
 
-    const input3 = player3.getWaitingFor()! as SelectCard<IProjectCard>;
-    expect(input3).to.be.an.instanceof(SelectCard);
+    cast(player3.getWaitingFor()!, SelectCard<IProjectCard>);
     player3.process([['Dust Seals']]); // Discard a card
     expect(callbackWasCalled).to.be.true;
   });

--- a/tests/colonies/Pluto.spec.ts
+++ b/tests/colonies/Pluto.spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import {cast} from '../TestingUtils';
 import {IProjectCard} from '../../src/server/cards/IProjectCard';
 import {Pluto} from '../../src/server/colonies/Pluto';
 import {Game} from '../../src/server/Game';
@@ -41,8 +42,7 @@ describe('Pluto', function() {
 
     runAllActions(game);
 
-    const input = player.getWaitingFor() as SelectCard<IProjectCard>;
-    expect(input).to.be.an.instanceof(SelectCard);
+    const input = cast(player.getWaitingFor(), SelectCard<IProjectCard>);
     input.cb([input.cards[0]]); // Discard a card
 
     expect(player.cardsInHand).has.lengthOf(2);

--- a/tests/deferredActions/DrawCards.spec.ts
+++ b/tests/deferredActions/DrawCards.spec.ts
@@ -52,9 +52,9 @@ describe('DrawCards', function() {
 
   it('draws 2 from 4', function() {
     const action = cast(DrawCards.keepSome(player, 4, {keepMax: 2}).execute(), SelectCard);
-    expect(action!.config.min).to.eq(2);
-    expect(action!.config.max).to.eq(2);
-    action!.cb([action!.cards[0], action!.cards[2]]);
+    expect(action.config.min).to.eq(2);
+    expect(action.config.max).to.eq(2);
+    action.cb([action.cards[0], action.cards[2]]);
     expect(player.cardsInHand).has.length(2);
     expect(dealer.discarded).has.length(2);
   });
@@ -62,9 +62,9 @@ describe('DrawCards', function() {
   it('buys 1', function() {
     player.megaCredits = 3;
     const action = cast(DrawCards.keepSome(player, 1, {paying: true}).execute(), SelectCard);
-    expect(action!.config.min).to.eq(0);
-    expect(action!.config.max).to.eq(1);
-    action!.cb([action!.cards[0]]);
+    expect(action.config.min).to.eq(0);
+    expect(action.config.max).to.eq(1);
+    action.cb([action.cards[0]]);
     player.game.deferredActions.runNext();
     expect(player.cardsInHand).has.length(1);
     expect(dealer.discarded).has.length(0);
@@ -74,9 +74,9 @@ describe('DrawCards', function() {
   it('cannot buy', function() {
     player.megaCredits = 2;
     const action = cast(DrawCards.keepSome(player, 1, {paying: true}).execute(), SelectCard);
-    expect(action!.config.min).to.eq(0);
-    expect(action!.config.max).to.eq(0);
-    action!.cb([]);
+    expect(action.config.min).to.eq(0);
+    expect(action.config.max).to.eq(0);
+    action.cb([]);
     expect(player.cardsInHand).has.length(0);
     expect(dealer.discarded).has.length(1);
     expect(player.megaCredits).to.eq(2);

--- a/tests/drafting.spec.ts
+++ b/tests/drafting.spec.ts
@@ -387,9 +387,7 @@ describe('drafting', () => {
 });
 
 function getWaitingFor(player: Player): SelectCard<IProjectCard> {
-  const action = player.getWaitingFor();
-  expect(action).instanceof(SelectCard);
-  return action as SelectCard<IProjectCard>;
+  return cast(player.getWaitingFor(), SelectCard<IProjectCard>);
 }
 
 function unshiftCards(deck: Array<IProjectCard>, cards: Array<CardName>) {
@@ -417,8 +415,8 @@ function draftSelection(player: Player) {
   return getWaitingFor(player).cards.map((card) => card.name);
 }
 
-function selectCard<T extends ICard>(player: TestPlayer, cardName: CardName) {
-  const selectCard = player.popWaitingFor() as SelectCard<T>;
+function selectCard(player: TestPlayer, cardName: CardName) {
+  const selectCard = cast(player.popWaitingFor(), SelectCard);
   const cards = selectCard.cards;
   const card = cards.find((c) => c.name === cardName);
   if (card === undefined) throw new Error(`${cardName} isn't in list`);

--- a/tests/globalEvents/CommunicationBoom.spec.ts
+++ b/tests/globalEvents/CommunicationBoom.spec.ts
@@ -50,11 +50,8 @@ describe('CommunicationBoom', function() {
     expect(e.resourceCount).eq(2);
     expect(f.resourceCount).eq(2);
 
-    (player as any).waitingFor = undefined;
-    (player as any).waitingForCb = undefined;
-
-    (player2 as any).waitingFor = undefined;
-    (player2 as any).waitingForCb = undefined;
+    player.popWaitingFor();
+    player2.popWaitingFor();
 
     runAllActions(game);
 

--- a/tests/pathfinders/DeclareCloneTag.spec.ts
+++ b/tests/pathfinders/DeclareCloneTag.spec.ts
@@ -78,7 +78,7 @@ describe('DeclareCloneTag', function() {
 
 
     const action = cast(game.deferredActions.pop(), DeclareCloneTag);
-    const options = cast(action!.execute(), OrOptions);
+    const options = cast(action.execute(), OrOptions);
 
     expect(options.options[0].title).to.match(/earth/);
 

--- a/tests/pathfinders/GrantResourceDeferred.spec.ts
+++ b/tests/pathfinders/GrantResourceDeferred.spec.ts
@@ -27,8 +27,7 @@ describe('GrantResourceDeferred', function() {
   it('grant single bonus', () => {
     const input = cast(new GrantResourceDeferred(player, false).execute(), OrOptions);
     expect(input.options).has.length(1);
-    expect(input.options[0]).instanceOf(SelectResources);
-    const selectOptions = input.options[0] as SelectResources;
+    const selectOptions = cast(input.options[0], SelectResources);
     selectOptions.options[0].cb(0);
     selectOptions.options[1].cb(0);
     selectOptions.options[2].cb(0);
@@ -50,8 +49,7 @@ describe('GrantResourceDeferred', function() {
     const input = cast(new GrantResourceDeferred(player, true).execute(), OrOptions);
     expect(input.options).has.length(2);
     expect(input.options[0]).instanceOf(SelectResources);
-    expect(input.options[1]).instanceOf(SelectCard);
-    const selectCard = input.options[1] as SelectCard<IProjectCard>;
+    const selectCard = cast(input.options[1], SelectCard<IProjectCard>);
     expect(selectCard.cards).has.members([ants, tardigrades]);
     expect(ants.resourceCount).eq(0);
 

--- a/tests/turmoil/Turmoil.spec.ts
+++ b/tests/turmoil/Turmoil.spec.ts
@@ -183,7 +183,7 @@ describe('Turmoil', function() {
 
     player.worldGovernmentTerraforming();
     const action = cast(player.getWaitingFor(), OrOptions);
-    const placeOcean = action.options.find((option) => option.title === 'Add an ocean') as SelectSpace;
+    const placeOcean = cast(action.options.find((option) => option.title === 'Add an ocean'), SelectSpace);
     const steelSpace = placeOcean.availableSpaces.find((space) => space.bonus.includes(SpaceBonus.STEEL));
 
     placeOcean.cb(steelSpace!);

--- a/tests/turmoil/parties/Kelvinists.spec.ts
+++ b/tests/turmoil/parties/Kelvinists.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
 import {ISpace} from '../../../src/server/boards/ISpace';
-import {setCustomGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
+import {cast, setCustomGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Kelvinists, KELVINISTS_BONUS_1, KELVINISTS_BONUS_2, KELVINISTS_POLICY_1, KELVINISTS_POLICY_2, KELVINISTS_POLICY_3, KELVINISTS_POLICY_4} from '../../../src/server/turmoil/parties/Kelvinists';
 import {Resources} from '../../../src/common/Resources';
@@ -88,8 +88,8 @@ describe('Kelvinists', function() {
     expect(kelvinistsPolicy.canAct(player)).to.be.true;
 
     const action = kelvinistsPolicy.action(player) as AndOptions;
-    const heatOption = action.options[0] as SelectAmount;
-    const floaterOption = action.options[1] as SelectAmount;
+    const heatOption = cast(action.options[0], SelectAmount);
+    const floaterOption = cast(action.options[1], SelectAmount);
 
     heatOption.cb(4);
     floaterOption.cb(1);


### PR DESCRIPTION
1. Replace instances of const x = expr as Y with const x = cast(expr, Y).

The latter actually asserts the type.

2. Replace many instances of "expect(x).instanceof(Y)" with const x = cast(..., Y);

Turns out that expect(undefined).instanceof(Y) passes. ???

2. Remove some uses of (x as any) when TestPlayer can help.
3. Remove superfluous uses of ! non-null assertions