### PR TITLE
fix i18n trim space

### DIFF
--- a/src/client/directives/i18n.ts
+++ b/src/client/directives/i18n.ts
@@ -80,7 +80,7 @@ export function translateTextWithParams(englishText: string, params: Array<strin
 }
 
 function normalizeText(text: string): string {
-  return text.replace(/[\n\r]/g, '').replace(/[ ]+/g, ' ').trim();
+  return text.replace(/[\n\r]/g, '').replace(/[ ]+/g, ' ');
 }
 
 function translateChildren(node: Node) {


### PR DESCRIPTION
Hi! 

I'm a big fan of the game, and we play this web version quite often, thank you for the great implementation!

I fixed https://github.com/terraforming-mars/terraforming-mars/issues/4349 by removing trim() function from normalizeText() function. This results in identical whitespace placing in both English and translated versions: 

**English version:** 
<img width="544" alt="Screen Shot 2022-09-07 at 16 04 57" src="https://user-images.githubusercontent.com/56271907/188887442-54a5ef0f-aab0-46eb-8e6c-9ff6b18a7a56.png">

**Translated version pre-fix:** 
<img width="545" alt="Screen Shot 2022-09-07 at 16 03 59" src="https://user-images.githubusercontent.com/56271907/188887573-7216f634-8327-4c71-b521-eeea2b89e81d.png">

**Translated version post-fix:** 
<img width="884" alt="Screen Shot 2022-09-07 at 16 08 16" src="https://user-images.githubusercontent.com/56271907/188887637-b2677b5d-9423-47fa-b55a-bbceb9723816.png">

- normalizeText() function is only getting applied to English words (such as max-min) during the client translation, thus this change only covers such English words. 
- Making this change doesn't cause any whitespace problem, as regex in normalizeText() ensures that multiple whitespaces gets reduced to just one whitespace, thus behaving as the English version and making trim() function redundant 

**Regex handling redundant whitespaces:** 
<img width="414" alt="Screen Shot 2022-09-07 at 15 55 29" src="https://user-images.githubusercontent.com/56271907/188888679-330c7516-6d77-44bc-9617-40c2b282f6fb.png">
<img width="612" alt="Screen Shot 2022-09-07 at 15 59 04" src="https://user-images.githubusercontent.com/56271907/188888703-682df1c5-4e0b-4bce-98fa-0b1cfd42ec18.png">

