### PR TITLE
Remove most uses of setCustomGameOptions.

### DIFF
--- a/tests/Dealer.spec.ts
+++ b/tests/Dealer.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {Dealer} from '../src/server/Dealer';
-import {setCustomGameOptions} from './TestingUtils';
+import {testGameOptions} from './TestingUtils';
 import {GameCards} from '../src/server/GameCards';
 import {DEFAULT_GAME_OPTIONS} from '../src/server/GameOptions';
 import {CardName} from '../src/common/cards/CardName';
@@ -8,7 +8,7 @@ import {ConstRandom} from '../src/server/Random';
 
 describe('Dealer', function() {
   it('deserializes from serialized', () => {
-    const gameOptions = setCustomGameOptions({
+    const gameOptions = testGameOptions({
       corporateEra: false,
       preludeExtension: true,
       venusNextExtension: false,

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -8,7 +8,7 @@ import * as constants from '../src/common/constants';
 import {Birds} from '../src/server/cards/base/Birds';
 import {WaterImportFromEuropa} from '../src/server/cards/base/WaterImportFromEuropa';
 import {Phase} from '../src/common/Phase';
-import {cast, forceGenerationEnd, maxOutOceans, runAllActions, setCustomGameOptions} from './TestingUtils';
+import {cast, forceGenerationEnd, maxOutOceans, runAllActions, testGameOptions} from './TestingUtils';
 import {TestPlayer} from './TestPlayer';
 import {SaturnSystems} from '../src/server/cards/corporation/SaturnSystems';
 import {Resources} from '../src/common/Resources';
@@ -42,7 +42,7 @@ describe('Game', () => {
   it('sets starting production if corporate era not selected', () => {
     const player = TestPlayer.BLUE.newPlayer();
 
-    const gameOptions = setCustomGameOptions({corporateEra: false});
+    const gameOptions = testGameOptions({corporateEra: false});
 
     Game.newInstance('gameid', [player], player, gameOptions);
     expect(player.production.megacredits).to.eq(1);
@@ -326,7 +326,7 @@ describe('Game', () => {
 
   it('Solo player should place final greeneries in TR 63 mode if victory condition is met', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('game-solo2', [player], player, setCustomGameOptions({soloTR: true}));
+    const game = Game.newInstance('game-solo2', [player], player, testGameOptions({soloTR: true}));
 
     // Set up end-game conditions
     game.generation = 14;
@@ -345,7 +345,7 @@ describe('Game', () => {
 
   it('Solo player should not place final greeneries in TR63 mode if victory condition not met', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('game-solo2', [player], player, setCustomGameOptions({soloTR: true}));
+    const game = Game.newInstance('game-solo2', [player], player, testGameOptions({soloTR: true}));
 
     // Set up near end-game conditions
     game.generation = 14;
@@ -557,7 +557,7 @@ describe('Game', () => {
     // the neutral player can't claim the bonus ocean space before our player has a
     // chance.
     const secondPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions({boardName: BoardName.HELLAS});
+    const gameOptions = testGameOptions({boardName: BoardName.HELLAS});
     const game = Game.newInstance('gameid', [player, secondPlayer], player, gameOptions);
 
     // Ensuring that HELLAS_OCEAN_TILE will be available for the test.
@@ -584,7 +584,7 @@ describe('Game', () => {
     // the neutral player can't claim the bonus ocean space before our player has a
     // chance.
     const secondPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions({boardName: BoardName.HELLAS});
+    const gameOptions = testGameOptions({boardName: BoardName.HELLAS});
     const game = Game.newInstance('gameid', [player, secondPlayer], player, gameOptions);
     player.setCorporationForTest(new Helion());
     player.canUseHeatAsMegaCredits = true;
@@ -611,7 +611,7 @@ describe('Game', () => {
   it('Generates random milestones and awards', () => {
     const player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions({boardName: BoardName.HELLAS, randomMA: RandomMAOptionType.UNLIMITED});
+    const gameOptions = testGameOptions({boardName: BoardName.HELLAS, randomMA: RandomMAOptionType.UNLIMITED});
     const game = Game.newInstance('gameid', [player, player2], player, gameOptions);
 
     const prevMilestones = game.milestones.map((m) => m.name).sort();
@@ -635,7 +635,7 @@ describe('Game', () => {
       CardName.TERRALABS_RESEARCH,
       CardName.UTOPIA_INVEST,
     ];
-    const gameOptions = setCustomGameOptions({customCorporationsList: corpsFromTurmoil, turmoilExtension: false});
+    const gameOptions = testGameOptions({customCorporationsList: corpsFromTurmoil, turmoilExtension: false});
     Game.newInstance('gameid', [player, player2], player, gameOptions);
 
     const corpsAssignedToPlayers =
@@ -657,7 +657,7 @@ describe('Game', () => {
       CardName.STRATEGIC_BASE_PLANNING,
       CardName.EXPERIENCED_MARTIANS,
     ];
-    const gameOptions = setCustomGameOptions({preludeExtension: true, customPreludes, pathfindersExpansion: false, promoCardsOption: false});
+    const gameOptions = testGameOptions({preludeExtension: true, customPreludes, pathfindersExpansion: false, promoCardsOption: false});
     Game.newInstance('gameid', [player, player2], player, gameOptions);
 
     const assignedPreludes =
@@ -727,7 +727,7 @@ describe('Game', () => {
 
   it('deserializing a game without moon data still loads', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({moonExpansion: false}));
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: false}));
     const serialized = game.serialize();
     delete serialized['moonData'];
     const deserialized = Game.deserialize(serialized);
@@ -736,7 +736,7 @@ describe('Game', () => {
 
   it('deserializing a game without pathfinders still loads', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({pathfindersExpansion: false}));
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({pathfindersExpansion: false}));
     const serialized = game.serialize();
     (serialized.gameOptions as any).pathfindersData = undefined;
     const deserialized = Game.deserialize(serialized);
@@ -745,7 +745,7 @@ describe('Game', () => {
 
   it('deserializing a game with awards', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({pathfindersExpansion: false}));
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({pathfindersExpansion: false}));
     const serialized = game.serialize();
     const deserialized = Game.deserialize(serialized);
     expect(deserialized.awards).deep.eq(game.awards);
@@ -753,7 +753,7 @@ describe('Game', () => {
 
   it('deserializing a game with milestones', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({pathfindersExpansion: false}));
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({pathfindersExpansion: false}));
     const serialized = game.serialize();
     const deserialized = Game.deserialize(serialized);
     expect(deserialized.milestones).deep.eq(game.milestones);
@@ -763,7 +763,7 @@ describe('Game', () => {
     const toName = (x: IColony) => x.name;
     const player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
-    const game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({coloniesExtension: false}));
+    const game = Game.newInstance('gameid', [player, player2], player, testGameOptions({coloniesExtension: false}));
 
     const colonyNames = game.colonies.map(toName);
     const discardedColonyNames = game.discardedColonies.map(toName);

--- a/tests/GameCards.spec.ts
+++ b/tests/GameCards.spec.ts
@@ -1,14 +1,14 @@
 import {expect} from 'chai';
 import {COMMUNITY_CARD_MANIFEST} from '../src/server/cards/community/CommunityCardManifest';
 import {CardFinder} from '../src/server/CardFinder';
-import {setCustomGameOptions} from './TestingUtils';
+import {testGameOptions} from './TestingUtils';
 import {GameCards} from '../src/server/GameCards';
 import {CardName} from '../src/common/cards/CardName';
 
 describe('GameCards', function() {
   it('correctly removes projectCardsToRemove', function() {
     // include corporate era
-    const gameOptions = setCustomGameOptions({
+    const gameOptions = testGameOptions({
       corporateEra: false,
       preludeExtension: false,
       venusNextExtension: false,
@@ -25,7 +25,7 @@ describe('GameCards', function() {
 
   it('correctly separates 71 corporate era cards', function() {
     // include corporate era
-    const gameOptions = setCustomGameOptions({
+    const gameOptions = testGameOptions({
       corporateEra: true,
       preludeExtension: false,
       venusNextExtension: false,
@@ -45,7 +45,7 @@ describe('GameCards', function() {
   });
 
   it('excludes expansion-specific preludes if those expansions are not selected ', function() {
-    const gameOptions = setCustomGameOptions({
+    const gameOptions = testGameOptions({
       corporateEra: true,
       preludeExtension: false,
       venusNextExtension: false,

--- a/tests/MilestoneAwardSelector.spec.ts
+++ b/tests/MilestoneAwardSelector.spec.ts
@@ -5,7 +5,7 @@ import {MilestoneAwardSelector} from '../src/server/MilestoneAwardSelector';
 import {IMilestone} from '../src/server/milestones/IMilestone';
 import {ARABIA_TERRA_MILESTONES, ARES_MILESTONES, ELYSIUM_MILESTONES, HELLAS_MILESTONES, MOON_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES} from '../src/server/milestones/Milestones';
 import {RandomMAOptionType} from '../src/common/ma/RandomMAOptionType';
-import {setCustomGameOptions} from './TestingUtils';
+import {testGameOptions} from './TestingUtils';
 import {intersection} from '../src/common/utils/utils';
 
 function toNames(list: Array<IMilestone | IAward>): Array<string> {
@@ -72,35 +72,35 @@ describe('MilestoneAwardSelector', () => {
   it('Main entrance point', () => {
     // These tests don't test results, they just make sure these calls don't fail.
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.NONE}));
+      testGameOptions({randomMA: RandomMAOptionType.NONE}));
   });
   it('Main entrance point - limited', () => {
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.LIMITED}));
+      testGameOptions({randomMA: RandomMAOptionType.LIMITED}));
   });
   it('Main entrance point - unlimited', () => {
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.UNLIMITED}));
+      testGameOptions({randomMA: RandomMAOptionType.UNLIMITED}));
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.NONE, moonExpansion: true}));
+      testGameOptions({randomMA: RandomMAOptionType.NONE, moonExpansion: true}));
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.LIMITED, moonExpansion: true}));
+      testGameOptions({randomMA: RandomMAOptionType.LIMITED, moonExpansion: true}));
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.UNLIMITED, moonExpansion: true}));
+      testGameOptions({randomMA: RandomMAOptionType.UNLIMITED, moonExpansion: true}));
   });
 
   it('Main entrance point, Ares & Moon enabled', () => {
     // These tests don't test results, they just make sure these calls don't fail.
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.NONE, aresExtension: true, moonExpansion: true}));
+      testGameOptions({randomMA: RandomMAOptionType.NONE, aresExtension: true, moonExpansion: true}));
   });
   it('Main entrance point, Ares & Moon enabled - limited', () => {
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.LIMITED, aresExtension: true, moonExpansion: true}));
+      testGameOptions({randomMA: RandomMAOptionType.LIMITED, aresExtension: true, moonExpansion: true}));
   });
   it('Main entrance point, Ares & Moon enabled - unlimited', () => {
     MilestoneAwardSelector.chooseMilestonesAndAwards(
-      setCustomGameOptions({randomMA: RandomMAOptionType.UNLIMITED, aresExtension: true, moonExpansion: true}));
+      testGameOptions({randomMA: RandomMAOptionType.UNLIMITED, aresExtension: true, moonExpansion: true}));
   });
 
   it('Do not select expansion milestones or awards when they are not selected', () => {
@@ -108,7 +108,7 @@ describe('MilestoneAwardSelector', () => {
     const avoidedMilestones = [...VENUS_MILESTONES, ...ARES_MILESTONES, ...MOON_MILESTONES, ...ARABIA_TERRA_MILESTONES].map((m) => m.name);
     for (let idx = 0; idx < 10000; idx++) {
       const mas = MilestoneAwardSelector.chooseMilestonesAndAwards(
-        setCustomGameOptions({
+        testGameOptions({
           randomMA: RandomMAOptionType.LIMITED,
           venusNextExtension: false,
           aresExtension: false,

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -14,7 +14,7 @@ import {Player} from '../src/server/Player';
 import {Color} from '../src/common/Color';
 import {CardName} from '../src/common/cards/CardName';
 import {GlobalParameter} from '../src/common/GlobalParameter';
-import {formatLogMessage, setCustomGameOptions} from './TestingUtils';
+import {formatLogMessage, testGameOptions} from './TestingUtils';
 import {Units} from '../src/common/Units';
 import {SelfReplicatingRobots} from '../src/server/cards/promo/SelfReplicatingRobots';
 import {Pets} from '../src/server/cards/base/Pets';
@@ -147,7 +147,7 @@ describe('Player', function() {
 
   it('wgt includes all parameters at the game start', () => {
     const player = new Player('blue', Color.BLUE, false, 0, 'p-blue');
-    const gameOptions = setCustomGameOptions({venusNextExtension: false});
+    const gameOptions = testGameOptions({venusNextExtension: false});
     Game.newInstance('gameid', [player], player, gameOptions);
     player.worldGovernmentTerraforming();
     const parameters = waitingForGlobalParameters(player);
@@ -159,7 +159,7 @@ describe('Player', function() {
 
   it('wgt includes all parameters at the game start, with Venus', () => {
     const player = new Player('blue', Color.BLUE, false, 0, 'p-blue');
-    const gameOptions = setCustomGameOptions({venusNextExtension: true});
+    const gameOptions = testGameOptions({venusNextExtension: true});
     Game.newInstance('gameid', [player], player, gameOptions);
     player.worldGovernmentTerraforming();
     const parameters = waitingForGlobalParameters(player);
@@ -172,7 +172,7 @@ describe('Player', function() {
 
   it('wgt includes all parameters at the game start, with The Moon', () => {
     const player = new Player('blue', Color.BLUE, false, 0, 'p-blue');
-    const gameOptions = setCustomGameOptions({venusNextExtension: false, moonExpansion: true});
+    const gameOptions = testGameOptions({venusNextExtension: false, moonExpansion: true});
     Game.newInstance('gameid', [player], player, gameOptions);
     player.worldGovernmentTerraforming();
     const parameters = waitingForGlobalParameters(player);

--- a/tests/TestGame.ts
+++ b/tests/TestGame.ts
@@ -1,6 +1,6 @@
 import {Game} from '../src/server/Game';
 import {GameOptions} from '../src/server/GameOptions';
-import {setCustomGameOptions} from './TestingUtils';
+import {testGameOptions} from './TestingUtils';
 import {TestPlayer} from './TestPlayer';
 
 export function newTestGame(count: number, customOptions?: Partial<GameOptions>, idSuffix = ''): Game {
@@ -17,7 +17,7 @@ export function newTestGame(count: number, customOptions?: Partial<GameOptions>,
 
   const options: GameOptions | undefined = customOptions === undefined ?
     undefined :
-    setCustomGameOptions(customOptions);
+    testGameOptions(customOptions);
   return Game.newInstance(`game-id${idSuffix}`, players, players[0], options);
 }
 

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -55,6 +55,11 @@ export function resetBoard(game: Game): void {
   });
 }
 
+export function testGameOptions(options: Partial<GameOptions>): GameOptions {
+  return {...DEFAULT_GAME_OPTIONS, ...options};
+}
+
+// Use gameOptions, which doesn't hide that certain features are on.
 export function setCustomGameOptions(options: Partial<GameOptions> = {}): GameOptions {
   const defaultOptions = {
     ...DEFAULT_GAME_OPTIONS,

--- a/tests/ares/AresTestHelper.ts
+++ b/tests/ares/AresTestHelper.ts
@@ -5,15 +5,15 @@ import {Resources} from '../../src/common/Resources';
 import {SpaceType} from '../../src/common/boards/SpaceType';
 import {TileType} from '../../src/common/TileType';
 import {ISpace} from '../../src/server/boards/ISpace';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {AresHandler} from '../../src/server/ares/AresHandler';
 
-export const ARES_OPTIONS_NO_HAZARDS = setCustomGameOptions({
+export const ARES_OPTIONS_NO_HAZARDS = testGameOptions({
   aresExtension: true,
   aresHazards: false,
 });
 
-export const ARES_OPTIONS_WITH_HAZARDS = setCustomGameOptions({
+export const ARES_OPTIONS_WITH_HAZARDS = testGameOptions({
   aresExtension: true,
   aresHazards: true,
 });

--- a/tests/awards/Landlord.spec.ts
+++ b/tests/awards/Landlord.spec.ts
@@ -11,7 +11,7 @@ import {EmptyBoard} from '../ares/EmptyBoard';
 import {_AresHazardPlacement} from '../../src/server/ares/AresHazards';
 import {TileType} from '../../src/common/TileType';
 import {LandClaim} from '../../src/server/cards/base/LandClaim';
-import {cast, setCustomGameOptions} from '../TestingUtils';
+import {cast, testGameOptions} from '../TestingUtils';
 import {SelectSpace} from '../../src/server/inputs/SelectSpace';
 
 describe('Landlord', () => {
@@ -38,7 +38,7 @@ describe('Landlord', () => {
   });
 
   it('Includes The Moon', () => {
-    const game = Game.newInstance('gameid', [player, otherPlayer], player, setCustomGameOptions({moonExpansion: true}));
+    const game = Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({moonExpansion: true}));
 
     expect(award.getScore(player)).to.eq(0);
 
@@ -53,7 +53,7 @@ describe('Landlord', () => {
   });
 
   it('Exclude Landclaimed Ares hazard tile from land-based award', function() {
-    const game = Game.newInstance('gameid', [player, otherPlayer], player, setCustomGameOptions({aresExtension: true}));
+    const game = Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({aresExtension: true}));
 
     const firstSpace = game.board.getAvailableSpacesOnLand(player)[0];
     _AresHazardPlacement.putHazardAt(firstSpace, TileType.DUST_STORM_MILD);

--- a/tests/boards/ArabiaTerraBoard.spec.ts
+++ b/tests/boards/ArabiaTerraBoard.spec.ts
@@ -8,7 +8,7 @@ import {SpaceType} from '../../src/common/boards/SpaceType';
 import {TestPlayer} from '../TestPlayer';
 import {SeededRandom} from '../../src/server/Random';
 import {SpaceBonus} from '../../src/common/boards/SpaceBonus';
-import {setCustomGameOptions, runAllActions, cast} from '../TestingUtils';
+import {testGameOptions, runAllActions, cast} from '../TestingUtils';
 import {BoardName} from '../../src/common/boards/BoardName';
 import {ProcessorFactory} from '../../src/server/cards/moon/ProcessorFactory';
 import {SearchForLife} from '../../src/server/cards/base/SearchForLife';
@@ -26,7 +26,7 @@ describe('ArabiaTerraBoard', function() {
     board = ArabiaTerraBoard.newInstance(DEFAULT_GAME_OPTIONS, new SeededRandom(0));
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameId', [player, player2], player, setCustomGameOptions({boardName: BoardName.ARABIA_TERRA}));
+    game = Game.newInstance('gameId', [player, player2], player, testGameOptions({boardName: BoardName.ARABIA_TERRA}));
   });
 
   it('Can place an ocean in a cove', () => {

--- a/tests/boards/VastitasBorealisBoard.spec.ts
+++ b/tests/boards/VastitasBorealisBoard.spec.ts
@@ -6,7 +6,7 @@ import {Player} from '../../src/server/Player';
 import {TileType} from '../../src/common/TileType';
 import {TestPlayer} from '../TestPlayer';
 import {SeededRandom} from '../../src/server/Random';
-import {setCustomGameOptions, runAllActions} from '../TestingUtils';
+import {testGameOptions, runAllActions} from '../TestingUtils';
 import {BoardName} from '../../src/common/boards/BoardName';
 import {SpaceName} from '../../src/server/SpaceName';
 
@@ -20,7 +20,7 @@ describe('VastitasBorealisBoard', function() {
     board = VastitasBorealisBoard.newInstance(DEFAULT_GAME_OPTIONS, new SeededRandom(0));
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({boardName: BoardName.ARABIA_TERRA}));
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({boardName: BoardName.ARABIA_TERRA}));
   });
 
   it('Grants temperature bonus', () => {

--- a/tests/cards/CardMetadata.spec.ts
+++ b/tests/cards/CardMetadata.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Game} from '../../src/server/Game';
 import {Player} from '../../src/server/Player';
 import {ALL_CARD_MANIFESTS} from '../../src/server/cards/AllCards';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 
 describe('CardMetadata', function() {
@@ -11,7 +11,7 @@ describe('CardMetadata', function() {
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    Game.newInstance('gameid', [player, redPlayer], player, setCustomGameOptions({moonExpansion: true}));
+    Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({moonExpansion: true}));
   });
 
   it('should have a VP icon', function() {

--- a/tests/cards/CardRequirements.spec.ts
+++ b/tests/cards/CardRequirements.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {CardRequirements} from '../../src/server/cards/CardRequirements';
-import {setCustomGameOptions, runAllActions, cast, addGreenery} from '../TestingUtils';
+import {testGameOptions, runAllActions, cast, addGreenery} from '../TestingUtils';
 import {Game} from '../../src/server/Game';
 import {AdaptationTechnology} from '../../src/server/cards/base/AdaptationTechnology';
 import {TileType} from '../../src/common/TileType';
@@ -23,9 +23,8 @@ describe('CardRequirements', function() {
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
 
-    Game.newInstance('gameid', [player, player2], player, gameOptions);
+    Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('satisfies properly for oceans', function() {

--- a/tests/cards/ares/GeologicalSurvey.spec.ts
+++ b/tests/cards/ares/GeologicalSurvey.spec.ts
@@ -11,7 +11,7 @@ import {TileType} from '../../../src/common/TileType';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
 import {EmptyBoard} from '../../ares/EmptyBoard';
 import {MarsFirst} from '../../../src/server/turmoil/parties/MarsFirst';
-import {addGreenery, resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, runAllActions, cast} from '../../TestingUtils';
+import {addGreenery, resetBoard, testGameOptions, setRulingPartyAndRulingPolicy, runAllActions, cast} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {OceanCity} from '../../../src/server/cards/ares/OceanCity';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
@@ -135,8 +135,7 @@ describe('GeologicalSurvey', () => {
 
   it('Works with Mars First policy', () => {
     player = TestPlayer.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player], player, gameOptions);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     const marsFirst = new MarsFirst();
 

--- a/tests/cards/base/AquiferPumping.spec.ts
+++ b/tests/cards/base/AquiferPumping.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {AquiferPumping, OCEAN_COST} from '../../../src/server/cards/base/AquiferPumping';
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {maxOutOceans, setCustomGameOptions} from '../../TestingUtils';
+import {maxOutOceans, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Phase} from '../../../src/common/Phase';
 import {Greens} from '../../../src/server/turmoil/parties/Greens';
@@ -46,7 +46,7 @@ describe('AquiferPumping', function() {
 
   it('Cannot act if cannot afford reds tax', function() {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
 
@@ -68,7 +68,7 @@ describe('AquiferPumping', function() {
 
   it('Steel does not satisfy the reds tax', function() {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
 

--- a/tests/cards/base/LandClaim.spec.ts
+++ b/tests/cards/base/LandClaim.spec.ts
@@ -5,7 +5,7 @@ import * as constants from '../../../src/common/constants';
 import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {SpaceName} from '../../../src/server/SpaceName';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('LandClaim', function() {
@@ -24,7 +24,7 @@ describe('LandClaim', function() {
     const card = new LandClaim();
     const player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
-    Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({
+    Game.newInstance('gameid', [player, player2], player, testGameOptions({
       boardName: BoardName.HELLAS,
     }));
     const action = cast(card.play(player), SelectSpace);

--- a/tests/cards/base/StripMine.spec.ts
+++ b/tests/cards/base/StripMine.spec.ts
@@ -7,7 +7,7 @@ import {Resources} from '../../../src/common/Resources';
 import {Reds} from '../../../src/server/turmoil/parties/Reds';
 import {PoliticalAgendas} from '../../../src/server/turmoil/PoliticalAgendas';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('StripMine', function() {
@@ -20,9 +20,8 @@ describe('StripMine', function() {
     card = new StripMine();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
 
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
   });
 

--- a/tests/cards/base/TerraformingGanymede.spec.ts
+++ b/tests/cards/base/TerraformingGanymede.spec.ts
@@ -5,7 +5,7 @@ import {Phase} from '../../../src/common/Phase';
 import {PoliticalAgendas} from '../../../src/server/turmoil/PoliticalAgendas';
 import {TestPlayer} from '../../TestPlayer';
 import {Reds} from '../../../src/server/turmoil/parties/Reds';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 
 describe('TerraformingGanymede', function() {
   let card: TerraformingGanymede;
@@ -17,7 +17,7 @@ describe('TerraformingGanymede', function() {
     card = new TerraformingGanymede();
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions());
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('Should play', function() {

--- a/tests/cards/base/standardActions/ConvertHeat.spec.ts
+++ b/tests/cards/base/standardActions/ConvertHeat.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {ConvertHeat} from '../../../../src/server/cards/base/standardActions/ConvertHeat';
 import {Phase} from '../../../../src/common/Phase';
 import {Player} from '../../../../src/server/Player';
-import {setCustomGameOptions} from '../../../TestingUtils';
+import {testGameOptions} from '../../../TestingUtils';
 import {TestPlayer} from '../../../TestPlayer';
 import {Game} from '../../../../src/server/Game';
 import {PoliticalAgendas} from '../../../../src/server/turmoil/PoliticalAgendas';
@@ -17,7 +17,7 @@ describe('ConvertHeat', function() {
     card = new ConvertHeat();
     player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
-    Game.newInstance('gameid', [player, player2], player, setCustomGameOptions());
+    Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('Can not act without heat', function() {

--- a/tests/cards/base/standardActions/ConvertPlants.spec.ts
+++ b/tests/cards/base/standardActions/ConvertPlants.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {ConvertPlants} from '../../../../src/server/cards/base/standardActions/ConvertPlants';
 import {Phase} from '../../../../src/common/Phase';
 import {Player} from '../../../../src/server/Player';
-import {setCustomGameOptions} from '../../../TestingUtils';
+import {testGameOptions} from '../../../TestingUtils';
 import {TestPlayer} from '../../../TestPlayer';
 import {Game} from '../../../../src/server/Game';
 import {PoliticalAgendas} from '../../../../src/server/turmoil/PoliticalAgendas';
@@ -17,7 +17,7 @@ describe('ConvertPlants', function() {
     card = new ConvertPlants();
     player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
-    Game.newInstance('gameid', [player, player2], player, setCustomGameOptions());
+    Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('Can not act without plants', function() {

--- a/tests/cards/base/standardProjects/AquiferStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/AquiferStandardProject.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {cast} from '../../../TestingUtils';
 import {AquiferStandardProject} from '../../../../src/server/cards/base/standardProjects/AquiferStandardProject';
-import {maxOutOceans, setCustomGameOptions, runAllActions} from '../../../TestingUtils';
+import {maxOutOceans, testGameOptions, runAllActions} from '../../../TestingUtils';
 import {TestPlayer} from '../../../TestPlayer';
 import {Game} from '../../../../src/server/Game';
 import {PoliticalAgendas} from '../../../../src/server/turmoil/PoliticalAgendas';
@@ -58,7 +58,7 @@ describe('AquiferStandardProject', function() {
 
   it('Can not act with reds', () => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, setCustomGameOptions({turmoilExtension: true}));
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
 
     player.megaCredits = card.cost;
     player.game.phase = Phase.ACTION;

--- a/tests/cards/base/standardProjects/AsteroidStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/AsteroidStandardProject.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {AsteroidStandardProject} from '../../../../src/server/cards/base/standardProjects/AsteroidStandardProject';
-import {setCustomGameOptions, runAllActions} from '../../../TestingUtils';
+import {testGameOptions, runAllActions} from '../../../TestingUtils';
 import {TestPlayer} from '../../../TestPlayer';
 import {Game} from '../../../../src/server/Game';
 import {PoliticalAgendas} from '../../../../src/server/turmoil/PoliticalAgendas';
@@ -48,7 +48,7 @@ describe('AsteroidStandardProject', function() {
 
   it('Can not act with reds', () => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, setCustomGameOptions({turmoilExtension: true}));
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
 
     player.megaCredits = card.cost;
     player.game.phase = Phase.ACTION;

--- a/tests/cards/base/standardProjects/GreeneryStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/GreeneryStandardProject.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {cast} from '../../../TestingUtils';
 import {GreeneryStandardProject} from '../../../../src/server/cards/base/standardProjects/GreeneryStandardProject';
-import {setCustomGameOptions, runAllActions} from '../../../TestingUtils';
+import {testGameOptions, runAllActions} from '../../../TestingUtils';
 import {TestPlayer} from '../../../TestPlayer';
 import {Game} from '../../../../src/server/Game';
 import {PoliticalAgendas} from '../../../../src/server/turmoil/PoliticalAgendas';
@@ -62,7 +62,7 @@ describe('GreeneryStandardProject', function() {
 
   it('Can not act with reds', () => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, setCustomGameOptions({turmoilExtension: true}));
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
 
     player.megaCredits = card.cost;
     player.game.phase = Phase.ACTION;

--- a/tests/cards/base/standardProjects/PowerPlantStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/PowerPlantStandardProject.spec.ts
@@ -1,7 +1,6 @@
 import {expect} from 'chai';
 import {PowerPlantStandardProject} from '../../../../src/server/cards/base/standardProjects/PowerPlantStandardProject';
 import {Player} from '../../../../src/server/Player';
-import {setCustomGameOptions} from '../../../TestingUtils';
 import {TestPlayer} from '../../../TestPlayer';
 import {Game} from '../../../../src/server/Game';
 import {StandardTechnology} from '../../../../src/server/cards/base/StandardTechnology';
@@ -15,7 +14,7 @@ describe('PowerPlantStandardProjects', function() {
     card = new PowerPlantStandardProject();
     player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions());
+    game = Game.newInstance('gameid', [player, player2], player);
   });
 
   it('Should act', function() {

--- a/tests/cards/colonies/EcologyResearch.spec.ts
+++ b/tests/cards/colonies/EcologyResearch.spec.ts
@@ -8,7 +8,7 @@ import {Luna} from '../../../src/server/colonies/Luna';
 import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('EcologyResearch', function() {
@@ -21,7 +21,7 @@ describe('EcologyResearch', function() {
     card = new EcologyResearch();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions({coloniesExtension: true});
+    const gameOptions = testGameOptions({coloniesExtension: true});
     game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
 
     colony1 = new Luna();

--- a/tests/cards/colonies/TradingColony.spec.ts
+++ b/tests/cards/colonies/TradingColony.spec.ts
@@ -6,7 +6,7 @@ import {Miranda} from '../../../src/server/colonies/Miranda';
 import {Game} from '../../../src/server/Game';
 import {SelectColony} from '../../../src/server/inputs/SelectColony';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('TradingColony', function() {
@@ -20,7 +20,7 @@ describe('TradingColony', function() {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions({coloniesExtension: true});
+    const gameOptions = testGameOptions({coloniesExtension: true});
     game = Game.newInstance('gameid', [player, player2], player, gameOptions);
     game.colonies = [new Callisto(), new Ceres(), new Miranda()];
   });

--- a/tests/cards/community/AerospaceMission.spec.ts
+++ b/tests/cards/community/AerospaceMission.spec.ts
@@ -8,7 +8,7 @@ import {Luna} from '../../../src/server/colonies/Luna';
 import {Game} from '../../../src/server/Game';
 import {SelectColony} from '../../../src/server/inputs/SelectColony';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('AerospaceMission', function() {
@@ -20,7 +20,7 @@ describe('AerospaceMission', function() {
     card = new AerospaceMission();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions({coloniesExtension: true});
+    const gameOptions = testGameOptions({coloniesExtension: true});
     game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
     // Ignore randomly generated colonies, and add some colonies that can be built independently of cards
     game.colonies = [new Callisto(), new Ceres(), new Io(), new Luna()];

--- a/tests/cards/community/ByElection.spec.ts
+++ b/tests/cards/community/ByElection.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {Player} from '../../../src/server/Player';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {SelectOption} from '../../../src/server/inputs/SelectOption';
 
@@ -17,8 +17,7 @@ describe('ByElection', function() {
     card = new ByElection();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('Should play', function() {

--- a/tests/cards/community/CuriosityII.spec.ts
+++ b/tests/cards/community/CuriosityII.spec.ts
@@ -5,7 +5,7 @@ import {Game} from '../../../src/server/Game';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {Phase} from '../../../src/common/Phase';
 import {TileType} from '../../../src/common/TileType';
-import {setCustomGameOptions, runAllActions, cast} from '../../TestingUtils';
+import {testGameOptions, runAllActions, cast} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 
@@ -19,7 +19,7 @@ describe('CuriosityII', function() {
     card = new CuriosityII();
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({aresExtension: true, aresHazards: false}));
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({aresExtension: true, aresHazards: false}));
     game.phase = Phase.ACTION;
 
     player.setCorporationForTest(card);

--- a/tests/cards/community/ExecutiveOrder.spec.ts
+++ b/tests/cards/community/ExecutiveOrder.spec.ts
@@ -1,9 +1,8 @@
 import {expect} from 'chai';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/server/Game';
-import {GameOptions} from '../../../src/server/GameOptions';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {ExecutiveOrder} from '../../../src/server/cards/community/ExecutiveOrder';
 import {SelectPartyToSendDelegate} from '../../../src/server/inputs/SelectPartyToSendDelegate';
@@ -19,8 +18,7 @@ describe('ExecutiveOrder', function() {
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions() as GameOptions;
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('Should play', function() {

--- a/tests/cards/community/Incite.spec.ts
+++ b/tests/cards/community/Incite.spec.ts
@@ -4,7 +4,7 @@ import {EventAnalysts} from '../../../src/server/cards/turmoil/EventAnalysts';
 import {Game} from '../../../src/server/Game';
 import {SelectPartyToSendDelegate} from '../../../src/server/inputs/SelectPartyToSendDelegate';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('Incite', function() {
@@ -16,8 +16,7 @@ describe('Incite', function() {
     card = new Incite();
     player = TestPlayer.BLUE.newPlayer();
 
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player], player, gameOptions);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
 
     card.play(player);
     player.setCorporationForTest(card);

--- a/tests/cards/community/PoliticalUprising.spec.ts
+++ b/tests/cards/community/PoliticalUprising.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectPartyToSendDelegate} from '../../../src/server/inputs/SelectPartyToSendDelegate';
 import {Player} from '../../../src/server/Player';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('PoliticalUprising', function() {
@@ -16,8 +16,7 @@ describe('PoliticalUprising', function() {
     card = new PoliticalUprising();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('Should play', function() {

--- a/tests/cards/community/TradeAdvance.spec.ts
+++ b/tests/cards/community/TradeAdvance.spec.ts
@@ -3,7 +3,7 @@ import {TradeAdvance} from '../../../src/server/cards/community/TradeAdvance';
 import {ColonyName} from '../../../src/common/colonies/ColonyName';
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions, runAllActions} from '../../TestingUtils';
+import {testGameOptions, runAllActions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('TradeAdvance', function() {
@@ -15,7 +15,7 @@ describe('TradeAdvance', function() {
     card = new TradeAdvance();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions({
+    const gameOptions = testGameOptions({
       coloniesExtension: true,
       customColoniesList: [ColonyName.LUNA, ColonyName.CALLISTO, ColonyName.CERES, ColonyName.IO, ColonyName.TITAN],
     });

--- a/tests/cards/community/VenusFirst.spec.ts
+++ b/tests/cards/community/VenusFirst.spec.ts
@@ -3,7 +3,7 @@ import {VenusFirst} from '../../../src/server/cards/community/VenusFirst';
 import {Tag} from '../../../src/common/cards/Tag';
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('VenusFirst', function() {
@@ -15,8 +15,7 @@ describe('VenusFirst', function() {
     card = new VenusFirst();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({venusNextExtension: true}));
   });
 
   it('Should play', function() {

--- a/tests/cards/corporation/MiningGuild.spec.ts
+++ b/tests/cards/corporation/MiningGuild.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {Phase} from '../../../src/common/Phase';
-import {maxOutOceans, setCustomGameOptions, runAllActions, cast} from '../../TestingUtils';
+import {maxOutOceans, testGameOptions, runAllActions, cast} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {BoardType} from '../../../src/server/boards/BoardType';
 import {TileType} from '../../../src/common/TileType';
@@ -21,7 +21,7 @@ describe('MiningGuild', () => {
     card = new MiningGuild();
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({
       aresExtension: true,
       aresHazards: false,
     }));

--- a/tests/cards/moon/AIControlledMineNetwork.spec.ts
+++ b/tests/cards/moon/AIControlledMineNetwork.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {AIControlledMineNetwork} from '../../../src/server/cards/moon/AIControlledMineNetwork';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('AIControlledMineNetwork', () => {
   let player: Player;
@@ -16,7 +14,7 @@ describe('AIControlledMineNetwork', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new AIControlledMineNetwork();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/AlgaeBioreactors.spec.ts
+++ b/tests/cards/moon/AlgaeBioreactors.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
+import {testGameOptions, testRedsCosts} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {AlgaeBioreactors} from '../../../src/server/cards/moon/AlgaeBioreactors';
 import {expect} from 'chai';
@@ -7,8 +7,6 @@ import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Phase} from '../../../src/common/Phase';
 import {MAX_OXYGEN_LEVEL} from '../../../src/common/constants';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('AlgaeBioreactors', () => {
   let player: TestPlayer;
@@ -18,7 +16,7 @@ describe('AlgaeBioreactors', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new AlgaeBioreactors();
     moonData = MoonExpansion.moonData(game);
   });
@@ -50,7 +48,7 @@ describe('AlgaeBioreactors', () => {
 
   it('canPlay when Reds are in power', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true, turmoilExtension: true}));
     const moonData = MoonExpansion.moonData(game);
     game.phase = Phase.ACTION;
 

--- a/tests/cards/moon/AnOfferYouCantRefuse.spec.ts
+++ b/tests/cards/moon/AnOfferYouCantRefuse.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {AnOfferYouCantRefuse} from '../../../src/server/cards/moon/AnOfferYouCantRefuse';
 import {TestPlayer} from '../../TestPlayer';
 import {NeutralPlayer, Turmoil} from '../../../src/server/turmoil/Turmoil';
@@ -9,7 +9,7 @@ import {PlayerId} from '../../../src/common/Types';
 import {IParty} from '../../../src/server/turmoil/parties/IParty';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 
-const GAME_OPTIONS = setCustomGameOptions({moonExpansion: true, turmoilExtension: true});
+const GAME_OPTIONS = testGameOptions({moonExpansion: true, turmoilExtension: true});
 
 describe('AnOfferYouCantRefuse', () => {
   let player: TestPlayer;

--- a/tests/cards/moon/AncientShipyards.spec.ts
+++ b/tests/cards/moon/AncientShipyards.spec.ts
@@ -1,12 +1,10 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {AncientShipyards} from '../../../src/server/cards/moon/AncientShipyards';
 import {expect} from 'chai';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('AncientShipyards', () => {
   let game: Game;
@@ -17,7 +15,7 @@ describe('AncientShipyards', () => {
   beforeEach(() => {
     bluePlayer = TestPlayer.BLUE.newPlayer();
     redPlayer = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [bluePlayer, redPlayer], bluePlayer, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [bluePlayer, redPlayer], bluePlayer, testGameOptions({moonExpansion: true}));
     card = new AncientShipyards();
   });
 
@@ -56,7 +54,7 @@ describe('AncientShipyards', () => {
 
   it('act solo', () => {
     redPlayer = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [redPlayer], redPlayer, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [redPlayer], redPlayer, testGameOptions({moonExpansion: true}));
 
     expect(card.resourceCount).eq(0);
     redPlayer.megaCredits = 10;

--- a/tests/cards/moon/ArchimedesHydroponicsStation.spec.ts
+++ b/tests/cards/moon/ArchimedesHydroponicsStation.spec.ts
@@ -1,10 +1,8 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {ArchimedesHydroponicsStation} from '../../../src/server/cards/moon/ArchimedesHydroponicsStation';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('ArchimedesHydroponicsStation', () => {
   let player: TestPlayer;
@@ -12,7 +10,7 @@ describe('ArchimedesHydroponicsStation', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new ArchimedesHydroponicsStation();
   });
 

--- a/tests/cards/moon/AristarchusRoadNetwork.spec.ts
+++ b/tests/cards/moon/AristarchusRoadNetwork.spec.ts
@@ -2,14 +2,12 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {AristarchusRoadNetwork} from '../../../src/server/cards/moon/AristarchusRoadNetwork';
 import {expect} from 'chai';
 import {TileType} from '../../../src/common/TileType';
 import {PlaceMoonRoadTile} from '../../../src/server/moon/PlaceMoonRoadTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('AristarchusRoadNetwork', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('AristarchusRoadNetwork', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new AristarchusRoadNetwork();
   });

--- a/tests/cards/moon/BasicInfrastructure.spec.ts
+++ b/tests/cards/moon/BasicInfrastructure.spec.ts
@@ -2,13 +2,11 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {BasicInfrastructure} from '../../../src/server/cards/moon/BasicInfrastructure';
 import {expect} from 'chai';
 import {PlaceMoonRoadTile} from '../../../src/server/moon/PlaceMoonRoadTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('BasicInfrastructure', () => {
   let game: Game;
@@ -18,7 +16,7 @@ describe('BasicInfrastructure', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new BasicInfrastructure();
   });

--- a/tests/cards/moon/ColonistShuttles.spec.ts
+++ b/tests/cards/moon/ColonistShuttles.spec.ts
@@ -2,12 +2,10 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {ColonistShuttles} from '../../../src/server/cards/moon/ColonistShuttles';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('ColonistShuttles', () => {
   let game: Game;
@@ -17,7 +15,7 @@ describe('ColonistShuttles', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new ColonistShuttles();
   });

--- a/tests/cards/moon/CopernicusSolarArrays.spec.ts
+++ b/tests/cards/moon/CopernicusSolarArrays.spec.ts
@@ -1,11 +1,9 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {CopernicusSolarArrays} from '../../../src/server/cards/moon/CopernicusSolarArrays';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('CopernicusSolarArrays', () => {
   let player: Player;
@@ -13,7 +11,7 @@ describe('CopernicusSolarArrays', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new CopernicusSolarArrays();
   });
 

--- a/tests/cards/moon/CopernicusTower.spec.ts
+++ b/tests/cards/moon/CopernicusTower.spec.ts
@@ -1,11 +1,9 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {CopernicusTower} from '../../../src/server/cards/moon/CopernicusTower';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('CopernicusTower', () => {
   let player: TestPlayer;
@@ -13,7 +11,7 @@ describe('CopernicusTower', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new CopernicusTower();
   });
 

--- a/tests/cards/moon/CoreMine.spec.ts
+++ b/tests/cards/moon/CoreMine.spec.ts
@@ -2,13 +2,11 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {CoreMine} from '../../../src/server/cards/moon/CoreMine';
 import {expect} from 'chai';
 import {PlaceMoonMineTile} from '../../../src/server/moon/PlaceMoonMineTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('CoreMine', () => {
   let game: Game;
@@ -18,7 +16,7 @@ describe('CoreMine', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new CoreMine();
   });

--- a/tests/cards/moon/CosmicRadiation.spec.ts
+++ b/tests/cards/moon/CosmicRadiation.spec.ts
@@ -1,14 +1,12 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {CosmicRadiation} from '../../../src/server/cards/moon/CosmicRadiation';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('CosmicRadiation', () => {
   let player1: Player;
@@ -21,7 +19,7 @@ describe('CosmicRadiation', () => {
     player1 = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
     player3 = TestPlayer.YELLOW.newPlayer();
-    const game = Game.newInstance('gameid', [player1, player2, player3], player1, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player1, player2, player3], player1, testGameOptions({moonExpansion: true}));
     card = new CosmicRadiation();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/CrescentResearchAssociation.spec.ts
+++ b/tests/cards/moon/CrescentResearchAssociation.spec.ts
@@ -1,12 +1,10 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {CrescentResearchAssociation} from '../../../src/server/cards/moon/CrescentResearchAssociation';
 import {TestPlayer} from '../../TestPlayer';
 import {MareNectarisMine} from '../../../src/server/cards/moon/MareNectarisMine';
 import {Predators} from '../../../src/server/cards/base/Predators';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('CrescentResearchAssociation', () => {
   let player: TestPlayer;
@@ -15,7 +13,7 @@ describe('CrescentResearchAssociation', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new CrescentResearchAssociation();
   });
 

--- a/tests/cards/moon/DarksideIncubationPlant.spec.ts
+++ b/tests/cards/moon/DarksideIncubationPlant.spec.ts
@@ -1,12 +1,10 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {DarksideIncubationPlant} from '../../../src/server/cards/moon/DarksideIncubationPlant';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('DarksideIncubationPlant', () => {
   let player: TestPlayer;
@@ -15,7 +13,7 @@ describe('DarksideIncubationPlant', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new DarksideIncubationPlant();
   });
 

--- a/tests/cards/moon/DarksideMeteorBombardment.spec.ts
+++ b/tests/cards/moon/DarksideMeteorBombardment.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {DarksideMeteorBombardment} from '../../../src/server/cards/moon/DarksideMeteorBombardment';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('DarksideMeteorBombardment', () => {
   let player: Player;
@@ -16,7 +14,7 @@ describe('DarksideMeteorBombardment', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new DarksideMeteorBombardment();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/DarksideMiningSyndicate.spec.ts
+++ b/tests/cards/moon/DarksideMiningSyndicate.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {DarksideMiningSyndicate} from '../../../src/server/cards/moon/DarksideMiningSyndicate';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('DarksideMiningSyndicate', () => {
   let player: Player;
@@ -16,7 +14,7 @@ describe('DarksideMiningSyndicate', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new DarksideMiningSyndicate();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/DarksideObservatory.spec.ts
+++ b/tests/cards/moon/DarksideObservatory.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {DarksideObservatory} from '../../../src/server/cards/moon/DarksideObservatory';
 import {expect} from 'chai';
@@ -9,8 +9,6 @@ import {OlympusConference} from '../../../src/server/cards/base/OlympusConferenc
 import {PrideoftheEarthArkship} from '../../../src/server/cards/moon/PrideoftheEarthArkship';
 import {ProcessorFactory} from '../../../src/server/cards/moon/ProcessorFactory';
 import {NanotechIndustries} from '../../../src/server/cards/moon/NanotechIndustries';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('DarksideObservatory', () => {
   let player: TestPlayer;
@@ -31,7 +29,7 @@ describe('DarksideObservatory', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new DarksideObservatory();
   });
 

--- a/tests/cards/moon/DeepLunarMining.spec.ts
+++ b/tests/cards/moon/DeepLunarMining.spec.ts
@@ -2,12 +2,10 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {DeepLunarMining} from '../../../src/server/cards/moon/DeepLunarMining';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('DeepLunarMining', () => {
   let game: Game;
@@ -17,7 +15,7 @@ describe('DeepLunarMining', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new DeepLunarMining();
   });

--- a/tests/cards/moon/EarthEmbassy.spec.ts
+++ b/tests/cards/moon/EarthEmbassy.spec.ts
@@ -1,13 +1,11 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {fakeCard, setCustomGameOptions} from '../../TestingUtils';
+import {fakeCard, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {EarthEmbassy} from '../../../src/server/cards/moon/EarthEmbassy';
 import {Tag} from '../../../src/common/cards/Tag';
 import {LunaGovernor} from '../../../src/server/cards/colonies/LunaGovernor';
 import {BusinessNetwork} from '../../../src/server/cards/base/BusinessNetwork';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('EarthEmbassy', () => {
   let player: TestPlayer;
@@ -15,7 +13,7 @@ describe('EarthEmbassy', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     earthEmbassy = new EarthEmbassy();
   });
 

--- a/tests/cards/moon/FirstLunarSettlement.spec.ts
+++ b/tests/cards/moon/FirstLunarSettlement.spec.ts
@@ -2,13 +2,11 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {FirstLunarSettlement} from '../../../src/server/cards/moon/FirstLunarSettlement';
 import {expect} from 'chai';
 import {PlaceMoonColonyTile} from '../../../src/server/moon/PlaceMoonColonyTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('FirstLunarSettlement', () => {
   let game: Game;
@@ -18,7 +16,7 @@ describe('FirstLunarSettlement', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new FirstLunarSettlement();
   });

--- a/tests/cards/moon/GeodesicTents.spec.ts
+++ b/tests/cards/moon/GeodesicTents.spec.ts
@@ -1,11 +1,9 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {GeodesicTents} from '../../../src/server/cards/moon/GeodesicTents';
 import {PlaceMoonColonyTile} from '../../../src/server/moon/PlaceMoonColonyTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('GeodesicTents', () => {
   let player: TestPlayer;
@@ -13,7 +11,7 @@ describe('GeodesicTents', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new GeodesicTents();
   });
 

--- a/tests/cards/moon/GrandLunaAcademy.spec.ts
+++ b/tests/cards/moon/GrandLunaAcademy.spec.ts
@@ -1,10 +1,8 @@
 import {expect} from 'chai';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {GrandLunaAcademy} from '../../../src/server/cards/moon/GrandLunaAcademy';
 import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/server/Game';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('GrandLunaAcademy', () => {
   let player: TestPlayer;
@@ -12,7 +10,7 @@ describe('GrandLunaAcademy', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new GrandLunaAcademy();
   });
 

--- a/tests/cards/moon/HE3FusionPlant.spec.ts
+++ b/tests/cards/moon/HE3FusionPlant.spec.ts
@@ -1,13 +1,11 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {HE3FusionPlant} from '../../../src/server/cards/moon/HE3FusionPlant';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('HE3FusionPlant', () => {
   let player: TestPlayer;
@@ -16,7 +14,7 @@ describe('HE3FusionPlant', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new HE3FusionPlant();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/HE3Lobbyists.spec.ts
+++ b/tests/cards/moon/HE3Lobbyists.spec.ts
@@ -1,10 +1,8 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {HE3Lobbyists} from '../../../src/server/cards/moon/HE3Lobbyists';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('HE3Lobbyists', () => {
   let player: TestPlayer;
@@ -12,7 +10,7 @@ describe('HE3Lobbyists', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new HE3Lobbyists();
   });
 

--- a/tests/cards/moon/HE3ProductionQuotas.spec.ts
+++ b/tests/cards/moon/HE3ProductionQuotas.spec.ts
@@ -1,6 +1,6 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {HE3ProductionQuotas} from '../../../src/server/cards/moon/HE3ProductionQuotas';
 import {expect} from 'chai';
@@ -10,8 +10,6 @@ import {TileType} from '../../../src/common/TileType';
 import {Kelvinists} from '../../../src/server/turmoil/parties/Kelvinists';
 import {Greens} from '../../../src/server/turmoil/parties/Greens';
 
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
-
 describe('HE3ProductionQuotas', () => {
   let player: Player;
   let game: Game;
@@ -20,7 +18,7 @@ describe('HE3ProductionQuotas', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true, turmoilExtension: true}));
     card = new HE3ProductionQuotas();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/HE3Refinery.spec.ts
+++ b/tests/cards/moon/HE3Refinery.spec.ts
@@ -1,12 +1,10 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {HE3Refinery} from '../../../src/server/cards/moon/HE3Refinery';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('HE3Refinery', () => {
   let player: TestPlayer;
@@ -15,7 +13,7 @@ describe('HE3Refinery', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new HE3Refinery();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/Habitat14.spec.ts
+++ b/tests/cards/moon/Habitat14.spec.ts
@@ -1,11 +1,9 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Habitat14} from '../../../src/server/cards/moon/Habitat14';
 import {PlaceMoonColonyTile} from '../../../src/server/moon/PlaceMoonColonyTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('Habitat14', () => {
   let player: TestPlayer;
@@ -13,7 +11,7 @@ describe('Habitat14', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new Habitat14();
   });
 

--- a/tests/cards/moon/HeavyDutyRovers.spec.ts
+++ b/tests/cards/moon/HeavyDutyRovers.spec.ts
@@ -1,13 +1,11 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {HeavyDutyRovers} from '../../../src/server/cards/moon/HeavyDutyRovers';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('HeavyDutyRovers', () => {
   let player: TestPlayer;
@@ -16,7 +14,7 @@ describe('HeavyDutyRovers', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new HeavyDutyRovers();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/HeliostatMirrorArray.spec.ts
+++ b/tests/cards/moon/HeliostatMirrorArray.spec.ts
@@ -1,10 +1,8 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {HeliostatMirrorArray} from '../../../src/server/cards/moon/HeliostatMirrorArray';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('HeliostatMirrorArray', () => {
   let player: TestPlayer;
@@ -12,7 +10,7 @@ describe('HeliostatMirrorArray', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new HeliostatMirrorArray();
   });
 

--- a/tests/cards/moon/HypersensitiveSiliconChipFactory.spec.ts
+++ b/tests/cards/moon/HypersensitiveSiliconChipFactory.spec.ts
@@ -1,13 +1,11 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {HypersensitiveSiliconChipFactory} from '../../../src/server/cards/moon/HypersensitiveSiliconChipFactory';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {TileType} from '../../../src/common/TileType';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('HypersensitiveSiliconChipFactory', () => {
   let player: TestPlayer;
@@ -16,7 +14,7 @@ describe('HypersensitiveSiliconChipFactory', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new HypersensitiveSiliconChipFactory();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/ImprovedMoonConcrete.spec.ts
+++ b/tests/cards/moon/ImprovedMoonConcrete.spec.ts
@@ -2,15 +2,13 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {ImprovedMoonConcrete} from '../../../src/server/cards/moon/ImprovedMoonConcrete';
 import {expect} from 'chai';
 import {MareSerenitatisMine} from '../../../src/server/cards/moon/MareSerenitatisMine';
 import {CardName} from '../../../src/common/cards/CardName';
 import {MoonMineStandardProject} from '../../../src/server/cards/moon/MoonMineStandardProject';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('ImprovedMoonConcrete', () => {
   let game: Game;
@@ -20,7 +18,7 @@ describe('ImprovedMoonConcrete', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new ImprovedMoonConcrete();
   });

--- a/tests/cards/moon/IntragenSanctuaryHeadquarters.spec.ts
+++ b/tests/cards/moon/IntragenSanctuaryHeadquarters.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {IntragenSanctuaryHeadquarters} from '../../../src/server/cards/moon/IntragenSanctuaryHeadquarters';
 import {expect} from 'chai';
 import {MicroMills} from '../../../src/server/cards/base/MicroMills';
 import {MartianZoo} from '../../../src/server/cards/colonies/MartianZoo';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('IntragenSanctuaryHeadquarters', () => {
   let player: Player;
@@ -17,7 +15,7 @@ describe('IntragenSanctuaryHeadquarters', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    Game.newInstance('gameid', [player, player2], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player, player2], player, testGameOptions({moonExpansion: true}));
     card = new IntragenSanctuaryHeadquarters();
   });
 

--- a/tests/cards/moon/IronExtractionCenter.spec.ts
+++ b/tests/cards/moon/IronExtractionCenter.spec.ts
@@ -2,12 +2,10 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {IronExtractionCenter} from '../../../src/server/cards/moon/IronExtractionCenter';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('IronExtractionCenter', () => {
   let game: Game;
@@ -17,7 +15,7 @@ describe('IronExtractionCenter', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new IronExtractionCenter();
   });

--- a/tests/cards/moon/LTFHeadquarters.spec.ts
+++ b/tests/cards/moon/LTFHeadquarters.spec.ts
@@ -1,14 +1,12 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {LTFHeadquarters} from '../../../src/server/cards/moon/LTFHeadquarters';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {BuildColony} from '../../../src/server/deferredActions/BuildColony';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LTFHeadquarters', () => {
   let player: Player;
@@ -17,7 +15,7 @@ describe('LTFHeadquarters', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LTFHeadquarters();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/LTFPrivileges.spec.ts
+++ b/tests/cards/moon/LTFPrivileges.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LTFPrivileges} from '../../../src/server/cards/moon/LTFPrivileges';
 import {expect} from 'chai';
 import {CardName} from '../../../src/common/cards/CardName';
 import {AristarchusRoadNetwork} from '../../../src/server/cards/moon/AristarchusRoadNetwork';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LTFPrivileges', () => {
   let player: Player;
@@ -15,7 +13,7 @@ describe('LTFPrivileges', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LTFPrivileges();
   });
 

--- a/tests/cards/moon/LunaArchives.spec.ts
+++ b/tests/cards/moon/LunaArchives.spec.ts
@@ -1,11 +1,9 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {LunaArchives} from '../../../src/server/cards/moon/LunaArchives';
 import {EarthEmbassy} from '../../../src/server/cards/moon/EarthEmbassy';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaArchives', () => {
   let player: TestPlayer;
@@ -13,7 +11,7 @@ describe('LunaArchives', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunaArchives();
     player.playedCards.push(card);
   });

--- a/tests/cards/moon/LunaConference.spec.ts
+++ b/tests/cards/moon/LunaConference.spec.ts
@@ -1,6 +1,6 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaConference} from '../../../src/server/cards/moon/LunaConference';
 import {expect} from 'chai';
@@ -10,8 +10,6 @@ import {TileType} from '../../../src/common/TileType';
 import {Scientists} from '../../../src/server/turmoil/parties/Scientists';
 import {Greens} from '../../../src/server/turmoil/parties/Greens';
 
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
-
 describe('LunaConference', () => {
   let player: Player;
   let game: Game;
@@ -20,7 +18,7 @@ describe('LunaConference', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true, turmoilExtension: true}));
     card = new LunaConference();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/LunaEcumenopolis.spec.ts
+++ b/tests/cards/moon/LunaEcumenopolis.spec.ts
@@ -2,15 +2,13 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaEcumenopolis} from '../../../src/server/cards/moon/LunaEcumenopolis';
 import {expect} from 'chai';
 import {TileType} from '../../../src/common/TileType';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 // import {Phase} from '../../../src/server/Phase';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaEcumenopolis', () => {
   let game: Game;
@@ -20,7 +18,7 @@ describe('LunaEcumenopolis', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new LunaEcumenopolis();
   });
@@ -132,7 +130,7 @@ describe('LunaEcumenopolis', () => {
 
   // it('canPlay when Reds are in power', () => {
   //   const player = TestPlayer.BLUE.newPlayer();
-  //   const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+  //   const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
   //   const moonData = MoonExpansion.moonData(game);
   //   game.phase = Phase.ACTION;
 

--- a/tests/cards/moon/LunaFirstIncorporated.spec.ts
+++ b/tests/cards/moon/LunaFirstIncorporated.spec.ts
@@ -1,11 +1,9 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {LunaFirstIncorporated} from '../../../src/server/cards/moon/LunaFirstIncorporated';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {TestPlayer} from '../../TestPlayer';
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
-
 describe('LunaFirstIncorporated', () => {
   let player: TestPlayer;
   let otherPlayer: TestPlayer;
@@ -14,7 +12,7 @@ describe('LunaFirstIncorporated', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     otherPlayer = TestPlayer.RED.newPlayer();
-    Game.newInstance('gameid', [player, otherPlayer], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({moonExpansion: true}));
     card = new LunaFirstIncorporated();
   });
 

--- a/tests/cards/moon/LunaHyperloopCorporation.spec.ts
+++ b/tests/cards/moon/LunaHyperloopCorporation.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaHyperloopCorporation} from '../../../src/server/cards/moon/LunaHyperloopCorporation';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaHyperloopCorporation', () => {
   let player: Player;
@@ -16,7 +14,7 @@ describe('LunaHyperloopCorporation', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunaHyperloopCorporation();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/LunaMiningHub.spec.ts
+++ b/tests/cards/moon/LunaMiningHub.spec.ts
@@ -2,14 +2,12 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaMiningHub} from '../../../src/server/cards/moon/LunaMiningHub';
 import {expect} from 'chai';
 import {TileType} from '../../../src/common/TileType';
 import {PlaceSpecialMoonTile} from '../../../src/server/moon/PlaceSpecialMoonTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaMiningHub', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('LunaMiningHub', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new LunaMiningHub();
   });

--- a/tests/cards/moon/LunaPoliticalInstitute.spec.ts
+++ b/tests/cards/moon/LunaPoliticalInstitute.spec.ts
@@ -1,6 +1,6 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {cast, fakeCard, setCustomGameOptions} from '../../TestingUtils';
+import {cast, fakeCard, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaPoliticalInstitute} from '../../../src/server/cards/moon/LunaPoliticalInstitute';
 import {expect} from 'chai';
@@ -8,8 +8,6 @@ import {SelectPartyToSendDelegate} from '../../../src/server/inputs/SelectPartyT
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
 import {Tag} from '../../../src/common/cards/Tag';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaPoliticalInstitute', () => {
   let player: Player;
@@ -19,7 +17,7 @@ describe('LunaPoliticalInstitute', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true, moonExpansion: true}));
     card = new LunaPoliticalInstitute();
     turmoil = game.turmoil!;
   });

--- a/tests/cards/moon/LunaProjectOffice.spec.ts
+++ b/tests/cards/moon/LunaProjectOffice.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {cast, finishGeneration, setCustomGameOptions} from '../../TestingUtils';
+import {cast, finishGeneration, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaProjectOffice} from '../../../src/server/cards/moon/LunaProjectOffice';
 import {expect} from 'chai';
@@ -7,12 +7,10 @@ import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {IProjectCard} from '../../../src/server/cards/IProjectCard';
 import {Player} from '../../../src/server/Player';
 
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
-
 describe('LunaProjectOffice', () => {
   it('can play', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     const card = new LunaProjectOffice();
 
     player.cardsInHand = [card];
@@ -31,7 +29,7 @@ describe('LunaProjectOffice', () => {
       'gameid',
       [player],
       player,
-      setCustomGameOptions({
+      testGameOptions({
         moonExpansion: true,
         turmoilExtension: false,
       }));
@@ -79,7 +77,7 @@ describe('LunaProjectOffice', () => {
       'gameid',
       [player, redPlayer],
       player,
-      setCustomGameOptions({
+      testGameOptions({
         moonExpansion: true,
         draftVariant: true,
         turmoilExtension: false,
@@ -135,7 +133,7 @@ describe('LunaProjectOffice', () => {
       'gameid',
       [player, redPlayer],
       player,
-      setCustomGameOptions({
+      testGameOptions({
         moonExpansion: true,
         draftVariant: false,
         turmoilExtension: false,

--- a/tests/cards/moon/LunaResort.spec.ts
+++ b/tests/cards/moon/LunaResort.spec.ts
@@ -2,12 +2,10 @@ import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaResort} from '../../../src/server/cards/moon/LunaResort';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaResort', () => {
   let game: Game;
@@ -17,7 +15,7 @@ describe('LunaResort', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new LunaResort();
   });

--- a/tests/cards/moon/LunaSenate.spec.ts
+++ b/tests/cards/moon/LunaSenate.spec.ts
@@ -1,10 +1,8 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaSenate} from '../../../src/server/cards/moon/LunaSenate';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaSenate', () => {
   let player: TestPlayer;
@@ -14,7 +12,7 @@ describe('LunaSenate', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.PURPLE.newPlayer();
-    Game.newInstance('gameid', [player, player2], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player, player2], player, testGameOptions({moonExpansion: true}));
     card = new LunaSenate();
   });
 

--- a/tests/cards/moon/LunaStagingStation.spec.ts
+++ b/tests/cards/moon/LunaStagingStation.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaStagingStation} from '../../../src/server/cards/moon/LunaStagingStation';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaStagingStation', () => {
   let player: Player;
@@ -16,7 +14,7 @@ describe('LunaStagingStation', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunaStagingStation();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/LunaTradeStation.spec.ts
+++ b/tests/cards/moon/LunaTradeStation.spec.ts
@@ -2,14 +2,12 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaTradeStation} from '../../../src/server/cards/moon/LunaTradeStation';
 import {expect} from 'chai';
 import {MoonSpaces} from '../../../src/server/moon/MoonSpaces';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaTradeStation', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('LunaTradeStation', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new LunaTradeStation();
   });

--- a/tests/cards/moon/LunaTrainStation.spec.ts
+++ b/tests/cards/moon/LunaTrainStation.spec.ts
@@ -2,14 +2,12 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunaTrainStation} from '../../../src/server/cards/moon/LunaTrainStation';
 import {expect} from 'chai';
 import {TileType} from '../../../src/common/TileType';
 import {PlaceSpecialMoonTile} from '../../../src/server/moon/PlaceSpecialMoonTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunaTrainStation', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('LunaTrainStation', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new LunaTrainStation();
   });

--- a/tests/cards/moon/LunarDustProcessingPlant.spec.ts
+++ b/tests/cards/moon/LunarDustProcessingPlant.spec.ts
@@ -2,15 +2,13 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunarDustProcessingPlant} from '../../../src/server/cards/moon/LunarDustProcessingPlant';
 import {expect} from 'chai';
 import {MareSerenitatisMine} from '../../../src/server/cards/moon/MareSerenitatisMine';
 import {CardName} from '../../../src/common/cards/CardName';
 import {MoonRoadStandardProject} from '../../../src/server/cards/moon/MoonRoadStandardProject';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunarDustProcessingPlant', () => {
   let game: Game;
@@ -20,7 +18,7 @@ describe('LunarDustProcessingPlant', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new LunarDustProcessingPlant();
   });

--- a/tests/cards/moon/LunarIndustryComplex.spec.ts
+++ b/tests/cards/moon/LunarIndustryComplex.spec.ts
@@ -1,14 +1,12 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunarIndustryComplex} from '../../../src/server/cards/moon/LunarIndustryComplex';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {Units} from '../../../src/common/Units';
 import {PlaceMoonMineTile} from '../../../src/server/moon/PlaceMoonMineTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunarIndustryComplex', () => {
   let player: TestPlayer;
@@ -18,7 +16,7 @@ describe('LunarIndustryComplex', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunarIndustryComplex();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/LunarMineUrbanization.spec.ts
+++ b/tests/cards/moon/LunarMineUrbanization.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {LunarMineUrbanization} from '../../../src/server/cards/moon/LunarMineUrbanization';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
@@ -9,8 +9,6 @@ import {TestPlayer} from '../../TestPlayer';
 import {VictoryPointsBreakdown} from '../../../src/server/VictoryPointsBreakdown';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
-
 describe('LunarMineUrbanization', () => {
   let player: TestPlayer;
   let card: LunarMineUrbanization;
@@ -18,7 +16,7 @@ describe('LunarMineUrbanization', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunarMineUrbanization();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/LunarObservationPost.spec.ts
+++ b/tests/cards/moon/LunarObservationPost.spec.ts
@@ -1,11 +1,9 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunarObservationPost} from '../../../src/server/cards/moon/LunarObservationPost';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunarObservationPost', () => {
   let game: Game;
@@ -14,7 +12,7 @@ describe('LunarObservationPost', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunarObservationPost();
   });
 

--- a/tests/cards/moon/LunarPlanningOffice.spec.ts
+++ b/tests/cards/moon/LunarPlanningOffice.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunarPlanningOffice} from '../../../src/server/cards/moon/LunarPlanningOffice';
 import {expect} from 'chai';
@@ -9,8 +9,6 @@ import {MicroMills} from '../../../src/server/cards/base/MicroMills';
 import {RoboticWorkforce} from '../../../src/server/cards/base/RoboticWorkforce';
 import {CardName} from '../../../src/common/cards/CardName';
 
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
-
 describe('LunarPlanningOffice', () => {
   let game: Game;
   let player: TestPlayer;
@@ -18,7 +16,7 @@ describe('LunarPlanningOffice', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunarPlanningOffice();
     player.popWaitingFor(); // Removing SelectInitialCards.
   });

--- a/tests/cards/moon/LunarSecurityStations.spec.ts
+++ b/tests/cards/moon/LunarSecurityStations.spec.ts
@@ -2,15 +2,13 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {LunarSecurityStations} from '../../../src/server/cards/moon/LunarSecurityStations';
 import {expect} from 'chai';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {HiredRaiders} from '../../../src/server/cards/base/HiredRaiders';
 import {TileType} from '../../../src/common/TileType';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunarSecurityStations', () => {
   let game: Game;
@@ -24,7 +22,7 @@ describe('LunarSecurityStations', () => {
     player = TestPlayer.BLUE.newPlayer();
     opponent1 = TestPlayer.RED.newPlayer();
     opponent2 = TestPlayer.GREEN.newPlayer();
-    game = Game.newInstance('gameid', [player, opponent1, opponent2], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player, opponent1, opponent2], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new LunarSecurityStations();
   });

--- a/tests/cards/moon/LunarSteel.spec.ts
+++ b/tests/cards/moon/LunarSteel.spec.ts
@@ -1,11 +1,9 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {LunarSteel} from '../../../src/server/cards/moon/LunarSteel';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunarSteel', () => {
   let player: Player;
@@ -13,7 +11,7 @@ describe('LunarSteel', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunarSteel();
   });
 

--- a/tests/cards/moon/LunarTradeFleet.spec.ts
+++ b/tests/cards/moon/LunarTradeFleet.spec.ts
@@ -1,12 +1,10 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {LunarTradeFleet} from '../../../src/server/cards/moon/LunarTradeFleet';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunarTradeFleet', () => {
   let player: TestPlayer;
@@ -15,7 +13,7 @@ describe('LunarTradeFleet', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new LunarTradeFleet();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/MareImbriumMine.spec.ts
+++ b/tests/cards/moon/MareImbriumMine.spec.ts
@@ -2,14 +2,12 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MareImbriumMine} from '../../../src/server/cards/moon/MareImbriumMine';
 import {expect} from 'chai';
 import {MoonSpaces} from '../../../src/server/moon/MoonSpaces';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MareImbriumMine', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('MareImbriumMine', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MareImbriumMine();
   });

--- a/tests/cards/moon/MareNectarisMine.spec.ts
+++ b/tests/cards/moon/MareNectarisMine.spec.ts
@@ -2,14 +2,12 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MareNectarisMine} from '../../../src/server/cards/moon/MareNectarisMine';
 import {expect} from 'chai';
 import {MoonSpaces} from '../../../src/server/moon/MoonSpaces';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MareNectarisMine', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('MareNectarisMine', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MareNectarisMine();
   });

--- a/tests/cards/moon/MareNubiumMine.spec.ts
+++ b/tests/cards/moon/MareNubiumMine.spec.ts
@@ -2,14 +2,12 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MareNubiumMine} from '../../../src/server/cards/moon/MareNubiumMine';
 import {expect} from 'chai';
 import {MoonSpaces} from '../../../src/server/moon/MoonSpaces';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MareNubiumMine', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('MareNubiumMine', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MareNubiumMine();
   });

--- a/tests/cards/moon/MareSerenitatisMine.spec.ts
+++ b/tests/cards/moon/MareSerenitatisMine.spec.ts
@@ -2,15 +2,13 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MareSerenitatisMine} from '../../../src/server/cards/moon/MareSerenitatisMine';
 import {expect} from 'chai';
 import {PlaceMoonRoadTile} from '../../../src/server/moon/PlaceMoonRoadTile';
 import {MoonSpaces} from '../../../src/server/moon/MoonSpaces';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MareSerenitatisMine', () => {
   let game: Game;
@@ -20,7 +18,7 @@ describe('MareSerenitatisMine', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MareSerenitatisMine();
   });

--- a/tests/cards/moon/MicrosingularityPlant.spec.ts
+++ b/tests/cards/moon/MicrosingularityPlant.spec.ts
@@ -1,14 +1,12 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MicrosingularityPlant} from '../../../src/server/cards/moon/MicrosingularityPlant';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MicrosingularityPlant', () => {
   let player: Player;
@@ -17,7 +15,7 @@ describe('MicrosingularityPlant', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new MicrosingularityPlant();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/MiningComplex.spec.ts
+++ b/tests/cards/moon/MiningComplex.spec.ts
@@ -2,15 +2,13 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MiningComplex} from '../../../src/server/cards/moon/MiningComplex';
 import {expect} from 'chai';
 import {PlaceMoonRoadTile} from '../../../src/server/moon/PlaceMoonRoadTile';
 import {PlaceMoonMineTile} from '../../../src/server/moon/PlaceMoonMineTile';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MiningComplex', () => {
   let game: Game;
@@ -20,7 +18,7 @@ describe('MiningComplex', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MiningComplex();
   });

--- a/tests/cards/moon/MiningRobotsManufCenter.spec.ts
+++ b/tests/cards/moon/MiningRobotsManufCenter.spec.ts
@@ -2,12 +2,10 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MiningRobotsManufCenter} from '../../../src/server/cards/moon/MiningRobotsManufCenter';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MiningRobotsManufCenter', () => {
   let game: Game;
@@ -17,7 +15,7 @@ describe('MiningRobotsManufCenter', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MiningRobotsManufCenter();
   });

--- a/tests/cards/moon/MomentumViriumHabitat.spec.ts
+++ b/tests/cards/moon/MomentumViriumHabitat.spec.ts
@@ -2,14 +2,12 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MomentumViriumHabitat} from '../../../src/server/cards/moon/MomentumViriumHabitat';
 import {expect} from 'chai';
 import {MoonSpaces} from '../../../src/server/moon/MoonSpaces';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MomentumViriumHabitat', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('MomentumViriumHabitat', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MomentumViriumHabitat();
   });

--- a/tests/cards/moon/MoonColonyStandardProject.spec.ts
+++ b/tests/cards/moon/MoonColonyStandardProject.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
+import {cast, testGameOptions, testRedsCosts} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MoonColonyStandardProject} from '../../../src/server/cards/moon/MoonColonyStandardProject';
 import {expect} from 'chai';
@@ -10,8 +10,6 @@ import {SelectPaymentDeferred} from '../../../src/server/deferredActions/SelectP
 import {PlaceMoonColonyTile} from '../../../src/server/moon/PlaceMoonColonyTile';
 import {MooncrateBlockFactory} from '../../../src/server/cards/moon/MooncrateBlockFactory';
 import {Phase} from '../../../src/common/Phase';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MoonColonyStandardProject', () => {
   let game: Game;
@@ -21,7 +19,7 @@ describe('MoonColonyStandardProject', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MoonColonyStandardProject();
   });
@@ -76,7 +74,7 @@ describe('MoonColonyStandardProject', () => {
 
   it('can act when Reds are in power.', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true, turmoilExtension: true}));
     const moonData = MoonExpansion.moonData(game);
     game.phase = Phase.ACTION;
 

--- a/tests/cards/moon/MoonMineStandardProject.spec.ts
+++ b/tests/cards/moon/MoonMineStandardProject.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
+import {cast, testGameOptions, testRedsCosts} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MoonMineStandardProject} from '../../../src/server/cards/moon/MoonMineStandardProject';
 import {expect} from 'chai';
@@ -10,8 +10,6 @@ import {SelectPaymentDeferred} from '../../../src/server/deferredActions/SelectP
 import {PlaceMoonMineTile} from '../../../src/server/moon/PlaceMoonMineTile';
 import {MooncrateBlockFactory} from '../../../src/server/cards/moon/MooncrateBlockFactory';
 import {Phase} from '../../../src/common/Phase';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MoonMineStandardProject', () => {
   let game: Game;
@@ -21,7 +19,7 @@ describe('MoonMineStandardProject', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MoonMineStandardProject();
   });
@@ -75,7 +73,7 @@ describe('MoonMineStandardProject', () => {
 
   it('can act when Reds are in power.', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true, turmoilExtension: true}));
     const moonData = MoonExpansion.moonData(game);
     game.phase = Phase.ACTION;
 

--- a/tests/cards/moon/MoonRoadStandardProject.spec.ts
+++ b/tests/cards/moon/MoonRoadStandardProject.spec.ts
@@ -2,7 +2,7 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions, testRedsCosts} from '../../TestingUtils';
+import {cast, testGameOptions, testRedsCosts} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MoonRoadStandardProject} from '../../../src/server/cards/moon/MoonRoadStandardProject';
 import {expect} from 'chai';
@@ -10,8 +10,6 @@ import {SelectPaymentDeferred} from '../../../src/server/deferredActions/SelectP
 import {PlaceMoonRoadTile} from '../../../src/server/moon/PlaceMoonRoadTile';
 import {MooncrateBlockFactory} from '../../../src/server/cards/moon/MooncrateBlockFactory';
 import {Phase} from '../../../src/common/Phase';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MoonRoadStandardProject', () => {
   let game: Game;
@@ -21,7 +19,7 @@ describe('MoonRoadStandardProject', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MoonRoadStandardProject();
   });
@@ -74,7 +72,7 @@ describe('MoonRoadStandardProject', () => {
 
   it('can act when Reds are in power.', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true, turmoilExtension: true}));
     const moonData = MoonExpansion.moonData(game);
     game.phase = Phase.ACTION;
 

--- a/tests/cards/moon/MoonStandardProjectVariants.spec.ts
+++ b/tests/cards/moon/MoonStandardProjectVariants.spec.ts
@@ -1,18 +1,16 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {expect} from 'chai';
 import {MoonColonyStandardProjectVariant2, MoonMineStandardProjectVariant2, MoonRoadStandardProjectVariant2} from '../../../src/server/cards/moon/MoonStandardProjectVariants';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MoonStandardProjectVariants', () => {
   let player: Player;
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
   });
 
   describe('MoonColonyStandardProjectVariant2', () => {

--- a/tests/cards/moon/MoonTether.spec.ts
+++ b/tests/cards/moon/MoonTether.spec.ts
@@ -1,11 +1,9 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
-import {fakeCard, setCustomGameOptions} from '../../TestingUtils';
+import {fakeCard, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MoonTether} from '../../../src/server/cards/moon/MoonTether';
 import {Tag} from '../../../src/common/cards/Tag';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MoonTether', () => {
   let player: TestPlayer;
@@ -13,7 +11,7 @@ describe('MoonTether', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new MoonTether();
   });
 

--- a/tests/cards/moon/MooncrateConvoysToMars.spec.ts
+++ b/tests/cards/moon/MooncrateConvoysToMars.spec.ts
@@ -2,15 +2,13 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MooncrateConvoysToMars} from '../../../src/server/cards/moon/MooncrateConvoysToMars';
 import {expect} from 'chai';
 import {SelectAmount} from '../../../src/server/inputs/SelectAmount';
 import {Reds} from '../../../src/server/turmoil/parties/Reds';
 import {MarsFirst} from '../../../src/server/turmoil/parties/MarsFirst';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MooncrateConvoysToMars', () => {
   let game: Game;
@@ -24,7 +22,7 @@ describe('MooncrateConvoysToMars', () => {
     player1 = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
     player3 = TestPlayer.GREEN.newPlayer();
-    game = Game.newInstance('gameid', [player1, player2, player3], player1, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player1, player2, player3], player1, testGameOptions({moonExpansion: true, turmoilExtension: true}));
     moonData = MoonExpansion.moonData(game);
     card = new MooncrateConvoysToMars();
   });

--- a/tests/cards/moon/NanotechIndustries.spec.ts
+++ b/tests/cards/moon/NanotechIndustries.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {NanotechIndustries} from '../../../src/server/cards/moon/NanotechIndustries';
 import {expect} from 'chai';
@@ -9,8 +9,6 @@ import {OlympusConference} from '../../../src/server/cards/base/OlympusConferenc
 import {PrideoftheEarthArkship} from '../../../src/server/cards/moon/PrideoftheEarthArkship';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {IProjectCard} from '../../../src/server/cards/IProjectCard';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('NanotechIndustries', () => {
   let player: TestPlayer;
@@ -27,7 +25,7 @@ describe('NanotechIndustries', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     nanotechIndustries = new NanotechIndustries();
   });
 

--- a/tests/cards/moon/NewColonyPlanningInitiaitives.spec.ts
+++ b/tests/cards/moon/NewColonyPlanningInitiaitives.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {NewColonyPlanningInitiaitives} from '../../../src/server/cards/moon/NewColonyPlanningInitiaitives';
 import {expect} from 'chai';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('NewColonyPlanningInitiaitives', () => {
   let player: Player;
@@ -16,7 +14,7 @@ describe('NewColonyPlanningInitiaitives', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new NewColonyPlanningInitiaitives();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/OffWorldCityLiving.spec.ts
+++ b/tests/cards/moon/OffWorldCityLiving.spec.ts
@@ -1,6 +1,6 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {OffWorldCityLiving} from '../../../src/server/cards/moon/OffWorldCityLiving';
 import {expect} from 'chai';
@@ -8,8 +8,6 @@ import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {TileType} from '../../../src/common/TileType';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('OffWorldCityLiving', () => {
   let player: Player;
@@ -19,7 +17,7 @@ describe('OffWorldCityLiving', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     // Adding a vestigial player to avoid the two starting cities.
-    const game = Game.newInstance('gameid', [player, TestPlayer.RED.newPlayer()], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player, TestPlayer.RED.newPlayer()], player, testGameOptions({moonExpansion: true}));
     card = new OffWorldCityLiving();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/OrbitalPowerGrid.spec.ts
+++ b/tests/cards/moon/OrbitalPowerGrid.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {OrbitalPowerGrid} from '../../../src/server/cards/moon/OrbitalPowerGrid';
 import {expect} from 'chai';
 import {TileType} from '../../../src/common/TileType';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('OrbitalPowerGrid', () => {
   let player: Player;
@@ -15,7 +13,7 @@ describe('OrbitalPowerGrid', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new OrbitalPowerGrid();
   });
 

--- a/tests/cards/moon/PreliminaryDarkside.spec.ts
+++ b/tests/cards/moon/PreliminaryDarkside.spec.ts
@@ -1,12 +1,10 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {PreliminaryDarkside} from '../../../src/server/cards/moon/PreliminaryDarkside';
 import {expect} from 'chai';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('PreliminaryDarkside', () => {
   let player: Player;
@@ -14,7 +12,7 @@ describe('PreliminaryDarkside', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new PreliminaryDarkside();
   });
 

--- a/tests/cards/moon/PrideoftheEarthArkship.spec.ts
+++ b/tests/cards/moon/PrideoftheEarthArkship.spec.ts
@@ -1,10 +1,8 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {PrideoftheEarthArkship} from '../../../src/server/cards/moon/PrideoftheEarthArkship';
 import {expect} from 'chai';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('PrideoftheEarthArkship', () => {
   let player: TestPlayer;
@@ -12,7 +10,7 @@ describe('PrideoftheEarthArkship', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new PrideoftheEarthArkship();
   });
 

--- a/tests/cards/moon/ProcessorFactory.spec.ts
+++ b/tests/cards/moon/ProcessorFactory.spec.ts
@@ -1,11 +1,9 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {runNextAction, setCustomGameOptions} from '../../TestingUtils';
+import {runNextAction, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {ProcessorFactory} from '../../../src/server/cards/moon/ProcessorFactory';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('ProcessorFactory', () => {
   let player: Player;
@@ -13,7 +11,7 @@ describe('ProcessorFactory', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new ProcessorFactory();
   });
 

--- a/tests/cards/moon/RevoltingColonists.spec.ts
+++ b/tests/cards/moon/RevoltingColonists.spec.ts
@@ -1,14 +1,12 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {RevoltingColonists} from '../../../src/server/cards/moon/RevoltingColonists';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('RevoltingColonists', () => {
   let player1: TestPlayer;
@@ -21,7 +19,7 @@ describe('RevoltingColonists', () => {
     player1 = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
     player3 = TestPlayer.YELLOW.newPlayer();
-    const game = Game.newInstance('gameid', [player1, player2, player3], player1, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player1, player2, player3], player1, testGameOptions({moonExpansion: true}));
     card = new RevoltingColonists();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/RoverDriversUnion.spec.ts
+++ b/tests/cards/moon/RoverDriversUnion.spec.ts
@@ -1,12 +1,10 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {RoverDriversUnion} from '../../../src/server/cards/moon/RoverDriversUnion';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('RoverDriversUnion', () => {
   let player: TestPlayer;
@@ -15,7 +13,7 @@ describe('RoverDriversUnion', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new RoverDriversUnion();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/RustEatingBacteria.spec.ts
+++ b/tests/cards/moon/RustEatingBacteria.spec.ts
@@ -1,11 +1,9 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {RustEatingBacteria} from '../../../src/server/cards/moon/RustEatingBacteria';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('RustEatingBacteria', () => {
   let player: Player;
@@ -13,7 +11,7 @@ describe('RustEatingBacteria', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new RustEatingBacteria();
   });
 

--- a/tests/cards/moon/SinusIridiumRoadNetwork.spec.ts
+++ b/tests/cards/moon/SinusIridiumRoadNetwork.spec.ts
@@ -1,11 +1,9 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {SinusIridiumRoadNetwork} from '../../../src/server/cards/moon/SinusIridiumRoadNetwork';
 import {expect} from 'chai';
 import {PlaceMoonRoadTile} from '../../../src/server/moon/PlaceMoonRoadTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('SinusIridiumRoadNetwork', () => {
   let player: TestPlayer;
@@ -13,7 +11,7 @@ describe('SinusIridiumRoadNetwork', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new SinusIridiumRoadNetwork();
   });
 

--- a/tests/cards/moon/SmallDutyRovers.spec.ts
+++ b/tests/cards/moon/SmallDutyRovers.spec.ts
@@ -1,14 +1,12 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {SmallDutyRovers} from '../../../src/server/cards/moon/SmallDutyRovers';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('SmallDutyRovers', () => {
   let player: Player;
@@ -17,7 +15,7 @@ describe('SmallDutyRovers', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new SmallDutyRovers();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/SolarPanelFoundry.spec.ts
+++ b/tests/cards/moon/SolarPanelFoundry.spec.ts
@@ -1,10 +1,8 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {SolarPanelFoundry} from '../../../src/server/cards/moon/SolarPanelFoundry';
 import {expect} from 'chai';
 import {TestPlayer} from '../../TestPlayer';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('SolarPanelFoundry', () => {
   let player: TestPlayer;
@@ -12,7 +10,7 @@ describe('SolarPanelFoundry', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new SolarPanelFoundry();
   });
 

--- a/tests/cards/moon/SphereHabitats.spec.ts
+++ b/tests/cards/moon/SphereHabitats.spec.ts
@@ -1,12 +1,10 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {SphereHabitats} from '../../../src/server/cards/moon/SphereHabitats';
 import {expect} from 'chai';
 import {PlaceMoonColonyTile} from '../../../src/server/moon/PlaceMoonColonyTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('SphereHabitats', () => {
   let player: Player;
@@ -14,7 +12,7 @@ describe('SphereHabitats', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new SphereHabitats();
   });
 

--- a/tests/cards/moon/StagingStationBehemoth.spec.ts
+++ b/tests/cards/moon/StagingStationBehemoth.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {StagingStationBehemoth} from '../../../src/server/cards/moon/StagingStationBehemoth';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('StagingStationBehemoth', () => {
   let player: Player;
@@ -16,7 +14,7 @@ describe('StagingStationBehemoth', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new StagingStationBehemoth();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/SteelMarketMonopolists.spec.ts
+++ b/tests/cards/moon/SteelMarketMonopolists.spec.ts
@@ -2,13 +2,11 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {SteelMarketMonopolists} from '../../../src/server/cards/moon/SteelMarketMonopolists';
 import {expect} from 'chai';
 import {SelectAmount} from '../../../src/server/inputs/SelectAmount';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('SteelMarketMonopolists', () => {
   let game: Game;
@@ -18,7 +16,7 @@ describe('SteelMarketMonopolists', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new SteelMarketMonopolists();
   });

--- a/tests/cards/moon/SubterraneanHabitats.spec.ts
+++ b/tests/cards/moon/SubterraneanHabitats.spec.ts
@@ -1,15 +1,13 @@
 import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {SubterraneanHabitats} from '../../../src/server/cards/moon/SubterraneanHabitats';
 import {expect} from 'chai';
 import {CardName} from '../../../src/common/cards/CardName';
 import {TheWomb} from '../../../src/server/cards/moon/TheWomb';
 import {TestPlayer} from '../../TestPlayer';
 import {MoonColonyStandardProject} from '../../../src/server/cards/moon/MoonColonyStandardProject';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('SubterraneanHabitats', () => {
   let game: Game;
@@ -19,7 +17,7 @@ describe('SubterraneanHabitats', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new SubterraneanHabitats();
   });

--- a/tests/cards/moon/SyndicatePirateRaids.spec.ts
+++ b/tests/cards/moon/SyndicatePirateRaids.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {forceGenerationEnd, setCustomGameOptions} from '../../TestingUtils';
+import {forceGenerationEnd, testGameOptions} from '../../TestingUtils';
 import {expect} from 'chai';
 import {TestPlayer} from '../../TestPlayer';
 import {SyndicatePirateRaids} from '../../../src/server/cards/moon/SyndicatePirateRaids';
@@ -13,7 +13,7 @@ describe('SyndicatePirateRaids', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     otherPlayer = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, otherPlayer], player, setCustomGameOptions({coloniesExtension: true}));
+    game = Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({coloniesExtension: true}));
     card = new SyndicatePirateRaids();
   });
 

--- a/tests/cards/moon/TempestConsultancy.spec.ts
+++ b/tests/cards/moon/TempestConsultancy.spec.ts
@@ -6,7 +6,7 @@ import {Turmoil} from '../../../src/server/turmoil/Turmoil';
 import {TestPlayer} from '../../TestPlayer';
 import {SendDelegateToArea} from '../../../src/server/deferredActions/SendDelegateToArea';
 import {Greens} from '../../../src/server/turmoil/parties/Greens';
-import {runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {runAllActions, testGameOptions} from '../../TestingUtils';
 import {VoteOfNoConfidence} from '../../../src/server/cards/turmoil/VoteOfNoConfidence';
 import {isPlayerId, PlayerId} from '../../../src/common/Types';
 
@@ -20,7 +20,7 @@ describe('TempestConsultancy', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     otherPlayer = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, otherPlayer], player, setCustomGameOptions());
+    game = Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({turmoilExtension: true}));
     card = new TempestConsultancy();
     turmoil = game.turmoil!;
   });

--- a/tests/cards/moon/TheArchaicFoundationInstitute.spec.ts
+++ b/tests/cards/moon/TheArchaicFoundationInstitute.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TheArchaicFoundationInstitute} from '../../../src/server/cards/moon/TheArchaicFoundationInstitute';
 import {expect} from 'chai';
@@ -11,15 +11,13 @@ import {GeodesicTents} from '../../../src/server/cards/moon/GeodesicTents';
 import {DeepLunarMining} from '../../../src/server/cards/moon/DeepLunarMining';
 import {Habitat14} from '../../../src/server/cards/moon/Habitat14';
 
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
-
 describe('TheArchaicFoundationInstitute', () => {
   let player: TestPlayer;
   let card: TheArchaicFoundationInstitute;
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new TheArchaicFoundationInstitute();
   });
 

--- a/tests/cards/moon/TheDarksideofTheMoonSyndicate.spec.ts
+++ b/tests/cards/moon/TheDarksideofTheMoonSyndicate.spec.ts
@@ -1,5 +1,5 @@
 import {Game} from '../../../src/server/Game';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TheDarksideofTheMoonSyndicate} from '../../../src/server/cards/moon/TheDarksideofTheMoonSyndicate';
 import {expect} from 'chai';
@@ -9,8 +9,6 @@ import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {StealResources} from '../../../src/server/deferredActions/StealResources';
 import {TileType} from '../../../src/common/TileType';
 import {Phase} from '../../../src/common/Phase';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('TheDarksideofTheMoonSyndicate', () => {
   let player: TestPlayer;
@@ -22,7 +20,7 @@ describe('TheDarksideofTheMoonSyndicate', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     otherPlayer = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, otherPlayer], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({moonExpansion: true}));
     card = new TheDarksideofTheMoonSyndicate();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/TheGrandLunaCapitalGroup.spec.ts
+++ b/tests/cards/moon/TheGrandLunaCapitalGroup.spec.ts
@@ -1,12 +1,10 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TheGrandLunaCapitalGroup} from '../../../src/server/cards/moon/TheGrandLunaCapitalGroup';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('TheGrandLunaCapitalGroup', () => {
   let player: TestPlayer;
@@ -17,7 +15,7 @@ describe('TheGrandLunaCapitalGroup', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     otherPlayer = TestPlayer.RED.newPlayer();
-    const game = Game.newInstance('gameid', [player, otherPlayer], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({moonExpansion: true}));
     card = new TheGrandLunaCapitalGroup();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/TheWomb.spec.ts
+++ b/tests/cards/moon/TheWomb.spec.ts
@@ -1,11 +1,9 @@
 import {Game} from '../../../src/server/Game';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TheWomb} from '../../../src/server/cards/moon/TheWomb';
 import {expect} from 'chai';
 import {PlaceMoonColonyTile} from '../../../src/server/moon/PlaceMoonColonyTile';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('TheWomb', () => {
   let player: TestPlayer;
@@ -13,7 +11,7 @@ describe('TheWomb', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new TheWomb();
   });
 

--- a/tests/cards/moon/ThoriumRush.spec.ts
+++ b/tests/cards/moon/ThoriumRush.spec.ts
@@ -1,6 +1,6 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {ThoriumRush} from '../../../src/server/cards/moon/ThoriumRush';
 import {expect} from 'chai';
@@ -11,8 +11,6 @@ import {Greens} from '../../../src/server/turmoil/parties/Greens';
 import {PoliticalAgendas} from '../../../src/server/turmoil/PoliticalAgendas';
 import {Reds} from '../../../src/server/turmoil/parties/Reds';
 
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
-
 describe('ThoriumRush', () => {
   let player: Player;
   let game: Game;
@@ -21,7 +19,7 @@ describe('ThoriumRush', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new ThoriumRush();
     moonData = MoonExpansion.moonData(game);
   });
@@ -51,9 +49,9 @@ describe('ThoriumRush', () => {
     expect(player.getTerraformRating()).eq(17);
   });
 
-  it('canPlay when Reds are in power.', () => {
+  it('canPlay when Reds are in power', () => {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true, turmoilExtension: true}));
     const turmoil = game.turmoil!;
     const moonData = MoonExpansion.moonData(game);
     game.phase = Phase.ACTION;

--- a/tests/cards/moon/TitaniumExtractionCenter.spec.ts
+++ b/tests/cards/moon/TitaniumExtractionCenter.spec.ts
@@ -2,12 +2,10 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TitaniumExtractionCenter} from '../../../src/server/cards/moon/TitaniumExtractionCenter';
 import {expect} from 'chai';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('TitaniumExtractionCenter', () => {
   let game: Game;
@@ -17,7 +15,7 @@ describe('TitaniumExtractionCenter', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new TitaniumExtractionCenter();
   });

--- a/tests/cards/moon/TitaniumMarketMonopolists.spec.ts
+++ b/tests/cards/moon/TitaniumMarketMonopolists.spec.ts
@@ -2,13 +2,11 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TitaniumMarketMonopolists} from '../../../src/server/cards/moon/TitaniumMarketMonopolists';
 import {expect} from 'chai';
 import {SelectAmount} from '../../../src/server/inputs/SelectAmount';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('TitaniumMarketMonopolists', () => {
   let game: Game;
@@ -18,7 +16,7 @@ describe('TitaniumMarketMonopolists', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new TitaniumMarketMonopolists();
   });

--- a/tests/cards/moon/TychoRoadNetwork.spec.ts
+++ b/tests/cards/moon/TychoRoadNetwork.spec.ts
@@ -2,15 +2,13 @@ import {Game} from '../../../src/server/Game';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TychoRoadNetwork} from '../../../src/server/cards/moon/TychoRoadNetwork';
 import {expect} from 'chai';
 import {TileType} from '../../../src/common/TileType';
 import {PlaceMoonRoadTile} from '../../../src/server/moon/PlaceMoonRoadTile';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('TychoRoadNetwork', () => {
   let game: Game;
@@ -20,7 +18,7 @@ describe('TychoRoadNetwork', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
     card = new TychoRoadNetwork();
   });

--- a/tests/cards/moon/UndergroundDetonators.spec.ts
+++ b/tests/cards/moon/UndergroundDetonators.spec.ts
@@ -1,13 +1,11 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {UndergroundDetonators} from '../../../src/server/cards/moon/UndergroundDetonators';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('UndergroundDetonators', () => {
   let player: Player;
@@ -16,7 +14,7 @@ describe('UndergroundDetonators', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new UndergroundDetonators();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/UndermoonDrugLordsNetwork.spec.ts
+++ b/tests/cards/moon/UndermoonDrugLordsNetwork.spec.ts
@@ -1,11 +1,9 @@
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {UndermoonDrugLordsNetwork} from '../../../src/server/cards/moon/UndermoonDrugLordsNetwork';
 import {expect} from 'chai';
 import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/server/Game';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('UndermoonDrugLordsNetwork', () => {
   let player: TestPlayer;
@@ -13,7 +11,7 @@ describe('UndermoonDrugLordsNetwork', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new UndermoonDrugLordsNetwork();
   });
 

--- a/tests/cards/moon/WaterTreatmentComplex.spec.ts
+++ b/tests/cards/moon/WaterTreatmentComplex.spec.ts
@@ -1,14 +1,12 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {WaterTreatmentComplex} from '../../../src/server/cards/moon/WaterTreatmentComplex';
 import {expect} from 'chai';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {IMoonData} from '../../../src/server/moon/IMoonData';
 import {TileType} from '../../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('WaterTreatmentComplex', () => {
   let player: Player;
@@ -17,7 +15,7 @@ describe('WaterTreatmentComplex', () => {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, MOON_OPTIONS);
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({moonExpansion: true}));
     card = new WaterTreatmentComplex();
     moonData = MoonExpansion.moonData(game);
   });

--- a/tests/cards/moon/WeGrowAsOne.spec.ts
+++ b/tests/cards/moon/WeGrowAsOne.spec.ts
@@ -1,6 +1,6 @@
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {WeGrowAsOne} from '../../../src/server/cards/moon/WeGrowAsOne';
 import {expect} from 'chai';
@@ -18,9 +18,10 @@ describe('WeGrowAsOne', () => {
       'gameid',
       [player],
       player,
-      setCustomGameOptions({
+      testGameOptions({
         moonExpansion: true,
         coloniesExtension: true,
+        turmoilExtension: true,
       }));
     card = new WeGrowAsOne();
   });

--- a/tests/cards/pathfinders/CeresSpaceport.spec.ts
+++ b/tests/cards/pathfinders/CeresSpaceport.spec.ts
@@ -5,7 +5,7 @@ import {TestPlayer} from '../../TestPlayer';
 import {PlaceOceanTile} from '../../../src/server/deferredActions/PlaceOceanTile';
 import {SpaceName} from '../../../src/server/SpaceName';
 import {Units} from '../../../src/common/Units';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 
 describe('CeresSpaceport', function() {
   let card: CeresSpaceport;
@@ -14,7 +14,7 @@ describe('CeresSpaceport', function() {
   beforeEach(function() {
     card = new CeresSpaceport();
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, setCustomGameOptions({pathfindersExpansion: true}));
+    Game.newInstance('gameid', [player], player, testGameOptions({pathfindersExpansion: true}));
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/CrewTraining.spec.ts
+++ b/tests/cards/pathfinders/CrewTraining.spec.ts
@@ -33,7 +33,7 @@ describe('CrewTraining', function() {
 
     expect(options.options[0].title).to.match(/earth/);
     expect(game.pathfindersData).deep.eq({
-      venus: 0,
+      venus: -1,
       earth: 0,
       mars: 0,
       jovian: 0,
@@ -44,7 +44,7 @@ describe('CrewTraining', function() {
     options.options[0].cb();
 
     expect(game.pathfindersData).deep.eq({
-      venus: 0,
+      venus: -1,
       earth: 2,
       mars: 0,
       jovian: 0,

--- a/tests/cards/pathfinders/DeclarationOfIndependence.spec.ts
+++ b/tests/cards/pathfinders/DeclarationOfIndependence.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {DeclarationOfIndependence} from '../../../src/server/cards/pathfinders/DeclarationOfIndependence';
 import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
-import {cast, runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../../TestingUtils';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {SelectPartyToSendDelegate} from '../../../src/server/inputs/SelectPartyToSendDelegate';
@@ -15,7 +15,7 @@ describe('DeclarationOfIndependence', function() {
   beforeEach(function() {
     card = new DeclarationOfIndependence();
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     turmoil = player.game.turmoil!;
   });
 

--- a/tests/cards/pathfinders/DysonScreens.spec.ts
+++ b/tests/cards/pathfinders/DysonScreens.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {DysonScreens} from '../../../src/server/cards/pathfinders/DysonScreens';
 import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
@@ -13,7 +13,7 @@ describe('DysonScreens', function() {
   beforeEach(function() {
     card = new DysonScreens();
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, setCustomGameOptions({pathfindersExpansion: true}));
+    Game.newInstance('gameid', [player], player, testGameOptions({pathfindersExpansion: true}));
   });
 
   it('play', () => {

--- a/tests/cards/pathfinders/EconomicHelp.spec.ts
+++ b/tests/cards/pathfinders/EconomicHelp.spec.ts
@@ -12,7 +12,7 @@ describe('EconomicHelp', function() {
 
   beforeEach(function() {
     card = new EconomicHelp();
-    game = newTestGame(1, {pathfindersExpansion: true});
+    game = newTestGame(1, {pathfindersExpansion: true, venusNextExtension: true});
     player = getTestPlayer(game, 0);
   });
 

--- a/tests/cards/pathfinders/Kickstarter.spec.ts
+++ b/tests/cards/pathfinders/Kickstarter.spec.ts
@@ -31,7 +31,7 @@ describe('Kickstarter', function() {
 
     expect(options.options[2].title).to.match(/mars/);
     expect(game.pathfindersData).deep.eq({
-      venus: 0,
+      venus: -1,
       earth: 0,
       mars: 0,
       jovian: 0,
@@ -42,7 +42,7 @@ describe('Kickstarter', function() {
     options.options[2].cb();
 
     expect(game.pathfindersData).deep.eq({
-      venus: 0,
+      venus: -1,
       earth: 0,
       mars: 3,
       jovian: 0,

--- a/tests/cards/pathfinders/LunarEmbassy.spec.ts
+++ b/tests/cards/pathfinders/LunarEmbassy.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {Units} from '../../../src/common/Units';
 import {SpaceName} from '../../../src/server/SpaceName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 
 describe('LunarEmbassy', function() {
   let card: LunarEmbassy;
@@ -13,7 +13,7 @@ describe('LunarEmbassy', function() {
   beforeEach(function() {
     card = new LunarEmbassy();
     player = TestPlayer.BLUE.newPlayer();
-    Game.newInstance('gameid', [player], player, setCustomGameOptions({pathfindersExpansion: true}));
+    Game.newInstance('gameid', [player], player, testGameOptions({pathfindersExpansion: true}));
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/NewVenice.spec.ts
+++ b/tests/cards/pathfinders/NewVenice.spec.ts
@@ -6,7 +6,7 @@ import {TileType} from '../../../src/common/TileType';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {Capital} from '../../../src/server/cards/base/Capital';
 import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
-import {addOcean, cast, setCustomGameOptions} from '../../TestingUtils';
+import {addOcean, cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 
@@ -20,7 +20,7 @@ describe('NewVenice', function() {
     card = new NewVenice();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, redPlayer], player, setCustomGameOptions({pathfindersExpansion: true}));
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({pathfindersExpansion: true}));
   });
 
   it('Can play', function() {

--- a/tests/cards/pathfinders/RedCity.spec.ts
+++ b/tests/cards/pathfinders/RedCity.spec.ts
@@ -23,7 +23,7 @@ describe('RedCity', function() {
 
   beforeEach(function() {
     card = new RedCity();
-    game = newTestGame(2, {pathfindersExpansion: true});
+    game = newTestGame(2, {pathfindersExpansion: true, turmoilExtension: true});
     player = getTestPlayer(game, 0);
     player2 = getTestPlayer(game, 1);
     turmoil = game.turmoil!;

--- a/tests/cards/pathfinders/Wetlands.spec.ts
+++ b/tests/cards/pathfinders/Wetlands.spec.ts
@@ -3,7 +3,7 @@ import {Wetlands} from '../../../src/server/cards/pathfinders/Wetlands';
 import {expect} from 'chai';
 import {TileType} from '../../../src/common/TileType';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
-import {cast, fakeCard, runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {cast, fakeCard, runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {EmptyBoard} from '../../ares/EmptyBoard';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
@@ -23,7 +23,7 @@ describe('Wetlands', function() {
     card = new Wetlands();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, redPlayer], player, setCustomGameOptions({pathfindersExpansion: true}));
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({pathfindersExpansion: true}));
     game.board = EmptyBoard.newInstance();
     game.board.getSpace('15').spaceType = SpaceType.OCEAN;
     game.board.getSpace('16').spaceType = SpaceType.OCEAN;

--- a/tests/cards/prelude/BufferGasStandardProject.spec.ts
+++ b/tests/cards/prelude/BufferGasStandardProject.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {BufferGasStandardProject} from '../../../src/server/cards/prelude/BufferGasStandardProject';
-import {runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/server/Game';
 import {PoliticalAgendas} from '../../../src/server/turmoil/PoliticalAgendas';
@@ -38,7 +38,7 @@ describe('BufferGasStandardProject', function() {
 
   it('Can not act with reds', () => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, setCustomGameOptions({turmoilExtension: true}));
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
 
     player.megaCredits = card.cost;
     player.setTerraformRating(20);

--- a/tests/cards/promo/Merger.spec.ts
+++ b/tests/cards/promo/Merger.spec.ts
@@ -3,7 +3,7 @@ import {ICard} from '../../../src/server/cards/ICard';
 import {Merger} from '../../../src/server/cards/promo/Merger';
 import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
-import {cast, runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {ArcadianCommunities} from '../../../src/server/cards/promo/ArcadianCommunities';
 import {SaturnSystems} from '../../../src/server/cards/corporation/SaturnSystems';
@@ -33,7 +33,7 @@ describe('Merger', function() {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions({preludeExtension: true});
+    const gameOptions = testGameOptions({preludeExtension: true});
     game = Game.newInstance('gameid', [player, player2], player, gameOptions);
 
     // Preset corporation deck for testing

--- a/tests/cards/promo/NewPartner.spec.ts
+++ b/tests/cards/promo/NewPartner.spec.ts
@@ -9,7 +9,7 @@ import {SmeltingPlant} from '../../../src/server/cards/prelude/SmeltingPlant';
 import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('NewPartner', function() {
@@ -22,8 +22,7 @@ describe('NewPartner', function() {
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions({preludeExtension: true});
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({preludeExtension: true}));
   });
 
   it('Should play with at least 1 playable prelude', function() {

--- a/tests/cards/turmoil/AerialLenses.spec.ts
+++ b/tests/cards/turmoil/AerialLenses.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {Player} from '../../../src/server/Player';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('AerialLenses', function() {
@@ -18,8 +18,7 @@ describe('AerialLenses', function() {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, player2], player, gameOptions);
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('Can play', function() {

--- a/tests/cards/turmoil/BannedDelegate.spec.ts
+++ b/tests/cards/turmoil/BannedDelegate.spec.ts
@@ -6,7 +6,7 @@ import {SelectDelegate} from '../../../src/server/inputs/SelectDelegate';
 import {Player} from '../../../src/server/Player';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('Banned Delegate', function() {
@@ -21,8 +21,7 @@ describe('Banned Delegate', function() {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, player2], player, gameOptions);
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
   });
 

--- a/tests/cards/turmoil/CulturalMetropolis.spec.ts
+++ b/tests/cards/turmoil/CulturalMetropolis.spec.ts
@@ -7,7 +7,7 @@ import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {TileType} from '../../../src/common/TileType';
 
@@ -23,8 +23,7 @@ describe('Cultural Metropolis', function() {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, player2], player, gameOptions);
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
   });
 

--- a/tests/cards/turmoil/DiasporaMovement.spec.ts
+++ b/tests/cards/turmoil/DiasporaMovement.spec.ts
@@ -8,7 +8,7 @@ import {Resources} from '../../../src/common/Resources';
 import {IParty} from '../../../src/server/turmoil/parties/IParty';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('DiasporaMovement', function() {
@@ -24,8 +24,7 @@ describe('DiasporaMovement', function() {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, player2], player, gameOptions);
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
     reds = turmoil.getPartyByName(PartyName.REDS)!;
   });

--- a/tests/cards/turmoil/EventAnalysts.spec.ts
+++ b/tests/cards/turmoil/EventAnalysts.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {EventAnalysts} from '../../../src/server/cards/turmoil/EventAnalysts';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('EventAnalysts', function() {
   it('Should play', function() {
     const card = new EventAnalysts();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
     expect(player.canPlayIgnoringCost(card)).is.not.true;
 

--- a/tests/cards/turmoil/GMOContract.spec.ts
+++ b/tests/cards/turmoil/GMOContract.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {GMOContract} from '../../../src/server/cards/turmoil/GMOContract';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('GMOContract', function() {
   it('Should play', function() {
     const card = new GMOContract();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
     const turmoil = game.turmoil!;
 

--- a/tests/cards/turmoil/MartianMediaCenter.spec.ts
+++ b/tests/cards/turmoil/MartianMediaCenter.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {MartianMediaCenter} from '../../../src/server/cards/turmoil/MartianMediaCenter';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('MartianMediaCenter', function() {
   it('Should play', function() {
     const card = new MartianMediaCenter();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
 
     expect(card.canPlay(player)).is.not.true;

--- a/tests/cards/turmoil/PROffice.spec.ts
+++ b/tests/cards/turmoil/PROffice.spec.ts
@@ -4,7 +4,7 @@ import {Sponsors} from '../../../src/server/cards/base/Sponsors';
 import {PROffice} from '../../../src/server/cards/turmoil/PROffice';
 import {Resources} from '../../../src/common/Resources';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('PROffice', function() {
@@ -12,7 +12,7 @@ describe('PROffice', function() {
     const card = new PROffice();
     const card2 = new Sponsors();
     const card3 = new AcquiredCompany();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
 
     expect(player.canPlayIgnoringCost(card)).is.not.true;

--- a/tests/cards/turmoil/ParliamentHall.spec.ts
+++ b/tests/cards/turmoil/ParliamentHall.spec.ts
@@ -3,7 +3,7 @@ import {DeepWellHeating} from '../../../src/server/cards/base/DeepWellHeating';
 import {MartianRails} from '../../../src/server/cards/base/MartianRails';
 import {ParliamentHall} from '../../../src/server/cards/turmoil/ParliamentHall';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('ParliamentHall', function() {
@@ -11,7 +11,7 @@ describe('ParliamentHall', function() {
     const card = new ParliamentHall();
     const card2 = new DeepWellHeating();
     const card3 = new MartianRails();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
 
     expect(player.canPlayIgnoringCost(card)).is.not.true;

--- a/tests/cards/turmoil/PoliticalAlliance.spec.ts
+++ b/tests/cards/turmoil/PoliticalAlliance.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('PoliticalAlliance', function() {
@@ -17,8 +17,7 @@ describe('PoliticalAlliance', function() {
     card = new PoliticalAlliance();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
   });
 

--- a/tests/cards/turmoil/PublicCelebrations.spec.ts
+++ b/tests/cards/turmoil/PublicCelebrations.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {PublicCelebrations} from '../../../src/server/cards/turmoil/PublicCelebrations';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('PublicCelebrations', function() {
   it('Should play', function() {
     const card = new PublicCelebrations();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
 
     expect(player.canPlayIgnoringCost(card)).is.not.true;

--- a/tests/cards/turmoil/Recruitment.spec.ts
+++ b/tests/cards/turmoil/Recruitment.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {Recruitment} from '../../../src/server/cards/turmoil/Recruitment';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('Recruitment', function() {
   it('Should play', function() {
     const card = new Recruitment();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
 
     game.turmoil!.parties.forEach((party) => {

--- a/tests/cards/turmoil/RedTourismWave.spec.ts
+++ b/tests/cards/turmoil/RedTourismWave.spec.ts
@@ -4,13 +4,13 @@ import {Resources} from '../../../src/common/Resources';
 import {SpaceName} from '../../../src/server/SpaceName';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('RedTourismWave', function() {
   it('Should play', function() {
     const card = new RedTourismWave();
-    const game = newTestGame(2, setCustomGameOptions());
+    const game = newTestGame(2, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
     expect(player.canPlayIgnoringCost(card)).is.not.true;
 

--- a/tests/cards/turmoil/SeptumTribus.spec.ts
+++ b/tests/cards/turmoil/SeptumTribus.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {SeptumTribus} from '../../../src/server/cards/turmoil/SeptumTribus';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('SeptumTribus', function() {
   it('Should play', function() {
     const card = new SeptumTribus();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
     card.play(player);
 

--- a/tests/cards/turmoil/SponsoredMohole.spec.ts
+++ b/tests/cards/turmoil/SponsoredMohole.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {SponsoredMohole} from '../../../src/server/cards/turmoil/SponsoredMohole';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('SponsoredMohole', function() {
   it('Should play', function() {
     const card = new SponsoredMohole();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
     expect(card.canPlay(player)).is.not.true;
 

--- a/tests/cards/turmoil/SupportedResearch.spec.ts
+++ b/tests/cards/turmoil/SupportedResearch.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {SupportedResearch} from '../../../src/server/cards/turmoil/SupportedResearch';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('SupportedResearch', function() {
   it('Should play', function() {
     const card = new SupportedResearch();
-    const game = newTestGame(2, setCustomGameOptions());
+    const game = newTestGame(2, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
     expect(player.canPlayIgnoringCost(card)).is.not.true;
 

--- a/tests/cards/turmoil/UtopiaInvest.spec.ts
+++ b/tests/cards/turmoil/UtopiaInvest.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {UtopiaInvest} from '../../../src/server/cards/turmoil/UtopiaInvest';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('UtopiaInvest', function() {
   it('Should play', function() {
     const card = new UtopiaInvest();
-    const game = newTestGame(2, setCustomGameOptions());
+    const game = newTestGame(2, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
     const play = card.play(player);
     expect(play).is.undefined;

--- a/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
+++ b/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
@@ -1,14 +1,14 @@
 import {expect} from 'chai';
 import {VoteOfNoConfidence} from '../../../src/server/cards/turmoil/VoteOfNoConfidence';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
-import {runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {runAllActions, testGameOptions} from '../../TestingUtils';
 import {isPlayerId, PlayerId} from '../../../src/common/Types';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 
 describe('VoteOfNoConfidence', function() {
   it('Should play', function() {
     const card = new VoteOfNoConfidence();
-    const game = newTestGame(1, setCustomGameOptions());
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
     const player = getTestPlayer(game, 0);
     const turmoil = game.turmoil!;
     expect(player.canPlayIgnoringCost(card)).is.not.true;

--- a/tests/cards/turmoil/WildlifeDome.spec.ts
+++ b/tests/cards/turmoil/WildlifeDome.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/server/Game';
 import {Phase} from '../../../src/common/Phase';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {PoliticalAgendas} from '../../../src/server/turmoil/PoliticalAgendas';
-import {cast, runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 
@@ -18,8 +18,7 @@ describe('WildlifeDome', function() {
     card = new WildlifeDome();
     player = TestPlayer.BLUE.newPlayer();
     redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({turmoilExtension: true}));
   });
 
   it('Should play: reds', function() {

--- a/tests/cards/venusNext/AirScrappingStandardProject.spec.ts
+++ b/tests/cards/venusNext/AirScrappingStandardProject.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {AirScrappingStandardProject} from '../../../src/server/cards/venusNext/AirScrappingStandardProject';
-import {runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {runAllActions, testGameOptions} from '../../TestingUtils';
 import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {PoliticalAgendas} from '../../../src/server/turmoil/PoliticalAgendas';
@@ -16,7 +16,7 @@ describe('AirScrappingStandardProject', function() {
   beforeEach(function() {
     card = new AirScrappingStandardProject();
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, setCustomGameOptions({altVenusBoard: false}));
+    game = Game.newInstance('gameid', [player], player, testGameOptions({venusNextExtension: true, altVenusBoard: false, turmoilExtension: true}));
   });
 
   it('Can act', function() {

--- a/tests/cards/venusNext/AirScrappingStandardProjectVariant.spec.ts
+++ b/tests/cards/venusNext/AirScrappingStandardProjectVariant.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {CardName} from '../../../src/common/cards/CardName';
 import {AirScrappingStandardProjectVariant} from '../../../src/server/cards/venusNext/AirScrappingStandardProjectVariant';
-import {runAllActions, setCustomGameOptions} from '../../TestingUtils';
+import {runAllActions, testGameOptions} from '../../TestingUtils';
 import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {getTestPlayer, newTestGame} from '../../TestGame';
@@ -13,7 +13,7 @@ describe('AirScrappingStandardProjectVariant', function() {
 
   beforeEach(function() {
     card = new AirScrappingStandardProjectVariant();
-    game = newTestGame(1, setCustomGameOptions({altVenusBoard: true}));
+    game = newTestGame(1, testGameOptions({venusNextExtension: true, altVenusBoard: true}));
     player = getTestPlayer(game, 0);
   });
 
@@ -21,7 +21,7 @@ describe('AirScrappingStandardProjectVariant', function() {
     // Building another game without the alt venus board.
     const game = newTestGame(1);
     const player = getTestPlayer(game, 0);
-    Game.newInstance('gameid', [player], player, setCustomGameOptions({altVenusBoard: false}));
+    Game.newInstance('gameid', [player], player, testGameOptions({venusNextExtension: true, altVenusBoard: false}));
     const cards = player.getStandardProjectOption().cards;
     const names = cards.map((card) => card.name);
     expect(names).to.include(CardName.AIR_SCRAPPING_STANDARD_PROJECT);

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -11,7 +11,7 @@ import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
 import {TestPlayer} from '../../TestPlayer';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {SelectOption} from '../../../src/server/inputs/SelectOption';
 
 describe('Atmoscoop', function() {
@@ -25,7 +25,7 @@ describe('Atmoscoop', function() {
     card = new Atmoscoop();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, redPlayer], player, setCustomGameOptions({venusNextExtension: true}));
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({venusNextExtension: true}));
     dirigibles = new Dirigibles();
     floatingHabs = new FloatingHabs();
   });

--- a/tests/cards/venusNext/DawnCity.spec.ts
+++ b/tests/cards/venusNext/DawnCity.spec.ts
@@ -2,12 +2,12 @@ import {expect} from 'chai';
 import {DawnCity} from '../../../src/server/cards/venusNext/DawnCity';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 import {Resources} from '../../../src/common/Resources';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 
 describe('DawnCity', function() {
   it('Should play', function() {
     const card = new DawnCity();
-    const game = newTestGame(2, setCustomGameOptions());
+    const game = newTestGame(2, testGameOptions({venusNextExtension: true}));
     const player = getTestPlayer(game, 0);
     player.production.add(Resources.ENERGY, 1);
     expect(player.canPlayIgnoringCost(card)).is.not.true;

--- a/tests/cards/venusNext/GiantSolarShade.spec.ts
+++ b/tests/cards/venusNext/GiantSolarShade.spec.ts
@@ -6,7 +6,7 @@ import {Phase} from '../../../src/common/Phase';
 import {Player} from '../../../src/server/Player';
 import {Reds} from '../../../src/server/turmoil/parties/Reds';
 import {PoliticalAgendas} from '../../../src/server/turmoil/PoliticalAgendas';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 let card: GiantSolarShade;
 let player: Player;
@@ -19,8 +19,7 @@ describe('GiantSolarShade', function() {
     player = TestPlayer.BLUE.newPlayer();
     redPlayer = TestPlayer.RED.newPlayer();
 
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({venusNextExtension: true, turmoilExtension: true}));
   });
 
   it('Should play', function() {

--- a/tests/cards/venusNext/LunaMetropolis.spec.ts
+++ b/tests/cards/venusNext/LunaMetropolis.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {LunaMetropolis} from '../../../src/server/cards/venusNext/LunaMetropolis';
 import {getTestPlayer, newTestGame} from '../../TestGame';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 
 describe('LunaMetropolis', function() {
   it('Should play', function() {
     const card = new LunaMetropolis();
-    const game = newTestGame(2, setCustomGameOptions());
+    const game = newTestGame(2, testGameOptions({venusNextExtension: true}));
     const player = getTestPlayer(game, 0);
 
     const action = card.play(player);

--- a/tests/cards/venusNext/MaxwellBase.spec.ts
+++ b/tests/cards/venusNext/MaxwellBase.spec.ts
@@ -7,7 +7,7 @@ import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {CardName} from '../../../src/common/cards/CardName';
 import {Tag} from '../../../src/common/cards/Tag';
@@ -24,8 +24,7 @@ describe('MaxwellBase', function() {
     card = new MaxwellBase();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({venusNextExtension: true}));
   });
 
   it('Can not play without energy production', function() {

--- a/tests/cards/venusNext/Stratopolis.spec.ts
+++ b/tests/cards/venusNext/Stratopolis.spec.ts
@@ -5,7 +5,7 @@ import {Stratopolis} from '../../../src/server/cards/venusNext/Stratopolis';
 import {Game} from '../../../src/server/Game';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {Player} from '../../../src/server/Player';
-import {cast, setCustomGameOptions} from '../../TestingUtils';
+import {cast, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('Stratopolis', function() {
@@ -16,8 +16,7 @@ describe('Stratopolis', function() {
     card = new Stratopolis();
     player = TestPlayer.BLUE.newPlayer();
     const redPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    Game.newInstance('gameid', [player, redPlayer], player, gameOptions);
+    Game.newInstance('gameid', [player, redPlayer], player, testGameOptions({venusNextExtension: true}));
   });
 
   it('Can not play', function() {

--- a/tests/colonies/Colony.spec.ts
+++ b/tests/colonies/Colony.spec.ts
@@ -10,7 +10,7 @@ import {SelectColony} from '../../src/server/inputs/SelectColony';
 import {SelectCard} from '../../src/server/inputs/SelectCard';
 import {IProjectCard} from '../../src/server/cards/IProjectCard';
 import {MAX_COLONY_TRACK_POSITION} from '../../src/common/constants';
-import {cast, runAllActions, setCustomGameOptions} from '../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 import {CardName} from '../../src/common/cards/CardName';
 import {Pallas} from '../../src/server/cards/community/Pallas';
@@ -51,7 +51,7 @@ describe('Colony', function() {
     player2 = TestPlayer.RED.newPlayer();
     player3 = TestPlayer.YELLOW.newPlayer();
     player4 = TestPlayer.GREEN.newPlayer();
-    const gameOptions = setCustomGameOptions({
+    const gameOptions = testGameOptions({
       coloniesExtension: true,
       customColoniesList: [
         ColonyName.LUNA,

--- a/tests/colonies/ColonyDealer.spec.ts
+++ b/tests/colonies/ColonyDealer.spec.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {ColonyDealer} from '../../src/server/colonies/ColonyDealer';
 import {SeededRandom} from '../../src/server/Random';
 
 describe('ColonyDealer', function() {
-  const options = setCustomGameOptions({venusNextExtension: false, coloniesExtension: false, turmoilExtension: false, communityCardsOption: false});
+  const options = testGameOptions({venusNextExtension: false, coloniesExtension: false, turmoilExtension: false, communityCardsOption: false});
 
   it('draw', () => {
     const dealer = new ColonyDealer(new SeededRandom(1), options);

--- a/tests/globalEvents/ConstantStruggle.spec.ts
+++ b/tests/globalEvents/ConstantStruggle.spec.ts
@@ -23,7 +23,7 @@ describe('ConstantStruggle', function() {
     turmoil.dominantParty.delegates.push(player2.id);
 
     expect(game.pathfindersData).deep.eq({
-      venus: 0,
+      venus: -1,
       earth: 0,
       mars: 0,
       jovian: 0,
@@ -37,7 +37,7 @@ describe('ConstantStruggle', function() {
     expect(player2.megaCredits).eq(5);
 
     expect(game.pathfindersData).deep.eq({
-      venus: 2,
+      venus: -1,
       earth: 2,
       mars: 2,
       jovian: 2,

--- a/tests/globalEvents/CorrosiveRain.spec.ts
+++ b/tests/globalEvents/CorrosiveRain.spec.ts
@@ -3,7 +3,7 @@ import {Game} from '../../src/server/Game';
 import {CorrosiveRain} from '../../src/server/turmoil/globalEvents/CorrosiveRain';
 import {Kelvinists} from '../../src/server/turmoil/parties/Kelvinists';
 import {Turmoil} from '../../src/server/turmoil/Turmoil';
-import {cast, runAllActions, setCustomGameOptions} from '../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 import {TitanShuttles} from '../../src/server/cards/colonies/TitanShuttles';
 import {TitanAirScrapping} from '../../src/server/cards/colonies/TitanAirScrapping';
@@ -23,7 +23,7 @@ describe('CorrosiveRain', function() {
     card = new CorrosiveRain();
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({turmoilExtension: true}));
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
     player.popWaitingFor(); // To clear out the SelectInitialCards input.
   });

--- a/tests/globalEvents/MudSlides.spec.ts
+++ b/tests/globalEvents/MudSlides.spec.ts
@@ -5,7 +5,7 @@ import {MudSlides} from '../../src/server/turmoil/globalEvents/MudSlides';
 import {Turmoil} from '../../src/server/turmoil/Turmoil';
 import {TestPlayer} from '../TestPlayer';
 import {getTestPlayer, newTestGame} from '../TestGame';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {ISpace} from '../../src/server/boards/ISpace';
 import {TileType} from '../../src/common/TileType';
 
@@ -37,7 +37,7 @@ describe('MudSlides', function() {
   });
 
   it('resolve play with overplaced tiles', function() {
-    game = newTestGame(2, setCustomGameOptions({aresExtension: true, turmoilExtension: true}));
+    game = newTestGame(2, testGameOptions({aresExtension: true, turmoilExtension: true}));
     player = getTestPlayer(game, 0);
 
     // Find two adjacent ocean spaces

--- a/tests/globalEvents/SpinoffProducts.spec.ts
+++ b/tests/globalEvents/SpinoffProducts.spec.ts
@@ -9,7 +9,7 @@ import {getTestPlayer, newTestGame} from '../TestGame';
 import {TestPlayer} from '../TestPlayer';
 import {HabitatMarte} from '../../src/server/cards/pathfinders/HabitatMarte';
 import {DesignedOrganisms} from '../../src/server/cards/pathfinders/DesignedOrganisms';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 
 describe('SpinoffProducts', function() {
   let card: SpinoffProducts;
@@ -20,7 +20,7 @@ describe('SpinoffProducts', function() {
 
   beforeEach(() => {
     card = new SpinoffProducts();
-    game = newTestGame(2, setCustomGameOptions());
+    game = newTestGame(2, testGameOptions({turmoilExtension: true}));
     player = getTestPlayer(game, 0);
     player2 = getTestPlayer(game, 1);
     turmoil = game.turmoil!;

--- a/tests/integration/PostgreSQL.spec.ts
+++ b/tests/integration/PostgreSQL.spec.ts
@@ -6,7 +6,7 @@ import {PostgreSQL} from '../../src/server/database/PostgreSQL';
 import {TestPlayer} from '../TestPlayer';
 import {SelectOption} from '../../src/server/inputs/SelectOption';
 import {Phase} from '../../src/common/Phase';
-import {runAllActions, setCustomGameOptions} from '../TestingUtils';
+import {runAllActions, testGameOptions} from '../TestingUtils';
 import {Player} from '../../src/server/Player';
 import {GameLoader} from '../../src/server/database/GameLoader';
 
@@ -152,7 +152,7 @@ describeDatabaseSuite({
       const db = dbFunction() as TestPostgreSQL;
       const player = TestPlayer.BLACK.newPlayer(/** beginner */ true);
       const player2 = TestPlayer.RED.newPlayer(/** beginner */ true);
-      const game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({draftVariant: false, undoOption: true}));
+      const game = Game.newInstance('gameid', [player, player2], player, testGameOptions({draftVariant: false, undoOption: true}));
       await db.awaitAllSaves();
 
       expect(await db.getStat('save-count')).eq(1);
@@ -226,7 +226,7 @@ describeDatabaseSuite({
       const db = dbFunction() as TestPostgreSQL;
       const player = TestPlayer.BLACK.newPlayer(/** beginner */ true);
       const player2 = TestPlayer.RED.newPlayer(/** beginner */ true);
-      const game = Game.newInstance('gameid', [player, player2], player2, setCustomGameOptions({draftVariant: false, undoOption: true}));
+      const game = Game.newInstance('gameid', [player, player2], player2, testGameOptions({draftVariant: false, undoOption: true}));
       await db.awaitAllSaves();
 
       // Move into the action phase by having both players complete their research.
@@ -312,7 +312,7 @@ describeDatabaseSuite({
     it('undo works in solo', async () => {
       const db = dbFunction() as TestPostgreSQL;
       const player = TestPlayer.BLACK.newPlayer(/** beginner */ true);
-      const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({undoOption: true}));
+      const game = Game.newInstance('gameid', [player], player, testGameOptions({undoOption: true}));
       await db.awaitAllSaves();
 
       // Move into the action phase. This triggers a save.

--- a/tests/milestones/Diversifier.spec.ts
+++ b/tests/milestones/Diversifier.spec.ts
@@ -6,7 +6,7 @@ import {TestPlayer} from '../TestPlayer';
 import {Game} from '../../src/server/Game';
 import {Player} from '../../src/server/Player';
 import {Leavitt} from '../../src/server/cards/community/Leavitt';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {AntiGravityTechnology} from '../../src/server/cards/base/AntiGravityTechnology';
 
 describe('Diversifier', function() {
@@ -29,7 +29,7 @@ describe('Diversifier', function() {
   });
 
   it('Counts Leavitt science tag placement bonus', function() {
-    const gameOptions = setCustomGameOptions({coloniesExtension: true});
+    const gameOptions = testGameOptions({coloniesExtension: true});
     const game = Game.newInstance('gameid', [player], player, gameOptions);
     const leavitt = new Leavitt();
     game.colonies = [leavitt];

--- a/tests/milestones/Generalist.spec.ts
+++ b/tests/milestones/Generalist.spec.ts
@@ -3,7 +3,7 @@ import {Game} from '../../src/server/Game';
 import {Generalist} from '../../src/server/milestones/Generalist';
 import {Player} from '../../src/server/Player';
 import {Resources} from '../../src/common/Resources';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 
 describe('Generalist', function() {
@@ -28,7 +28,7 @@ describe('Generalist', function() {
   });
 
   it('Cannot claim with +1 of each production in game without corp era', function() {
-    const gameOptions = setCustomGameOptions({corporateEra: false});
+    const gameOptions = testGameOptions({corporateEra: false});
     Game.newInstance('gameid', [player, player2], player, gameOptions);
 
     resources.forEach((resource) => expect(player.production[resource]).to.eq(1));
@@ -36,7 +36,7 @@ describe('Generalist', function() {
   });
 
   it('Can claim with +2 of each production in game without corp era', function() {
-    const gameOptions = setCustomGameOptions({corporateEra: false});
+    const gameOptions = testGameOptions({corporateEra: false});
     Game.newInstance('gameid', [player, player2], player, gameOptions);
     resources.forEach((resource) => player.production.add(resource, 1));
 

--- a/tests/milestones/LandSpecialist.spec.ts
+++ b/tests/milestones/LandSpecialist.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {Game} from '../../src/server/Game';
 import {LandSpecialist} from '../../src/server/milestones/LandSpecialist';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 import {BoardName} from '../../src/common/boards/BoardName';
 import {Board} from '../../src/server/boards/Board';
@@ -21,7 +21,7 @@ describe('LandSpecialist', function() {
     milestone = new LandSpecialist();
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    game = Game.newInstance('gameid', [player, player2], player, setCustomGameOptions({boardName: BoardName.ARABIA_TERRA, moonExpansion: true}));
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({boardName: BoardName.ARABIA_TERRA, moonExpansion: true}));
     board = game.board;
     spaces = board.getAvailableSpacesOnLand(player);
   });

--- a/tests/moon/LunarMagnate.spec.ts
+++ b/tests/moon/LunarMagnate.spec.ts
@@ -3,10 +3,8 @@ import {LunarMagnate} from '../../src/server/moon/LunarMagnate';
 import {Game} from '../../src/server/Game';
 import {MoonExpansion} from '../../src/server/moon/MoonExpansion';
 import {TestPlayer} from '../TestPlayer';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {TileType} from '../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('LunarMagnate', function() {
   let player: TestPlayer;
@@ -15,7 +13,7 @@ describe('LunarMagnate', function() {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     otherPlayer = TestPlayer.PINK.newPlayer();
-    Game.newInstance('gameid', [player, otherPlayer], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({moonExpansion: true}));
   });
 
   it('Basic test', function() {

--- a/tests/moon/Lunarchitect.spec.ts
+++ b/tests/moon/Lunarchitect.spec.ts
@@ -3,10 +3,8 @@ import {Lunarchitect} from '../../src/server/moon/Lunarchitect';
 import {Game} from '../../src/server/Game';
 import {MoonExpansion} from '../../src/server/moon/MoonExpansion';
 import {TestPlayer} from '../TestPlayer';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {TileType} from '../../src/common/TileType';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('Lunarchitect', function() {
   let player: TestPlayer;
@@ -15,7 +13,7 @@ describe('Lunarchitect', function() {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     otherPlayer = TestPlayer.PINK.newPlayer();
-    Game.newInstance('gameid', [player, otherPlayer], player, MOON_OPTIONS);
+    Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({moonExpansion: true}));
   });
 
   it('Basic test', function() {

--- a/tests/moon/MoonExpansion.spec.ts
+++ b/tests/moon/MoonExpansion.spec.ts
@@ -11,12 +11,10 @@ import {MoonExpansion} from '../../src/server/moon/MoonExpansion';
 import {MoonSpaces} from '../../src/server/moon/MoonSpaces';
 import {SpaceName} from '../../src/server/SpaceName';
 import {TileType} from '../../src/common/TileType';
-import {setCustomGameOptions} from '../TestingUtils';
+import {testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 import {Phase} from '../../src/common/Phase';
 import {VictoryPointsBreakdown} from '../../src/server/VictoryPointsBreakdown';
-
-const MOON_OPTIONS = setCustomGameOptions({moonExpansion: true});
 
 describe('MoonExpansion', () => {
   let game: Game;
@@ -27,7 +25,7 @@ describe('MoonExpansion', () => {
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.PINK.newPlayer();
-    game = Game.newInstance('gameid', [player, player2], player, MOON_OPTIONS);
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({moonExpansion: true}));
     moonData = MoonExpansion.moonData(game);
   });
 

--- a/tests/turmoil/PoliticalAgendas.spec.ts
+++ b/tests/turmoil/PoliticalAgendas.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Player} from '../../src/server/Player';
 import {PartyName} from '../../src/common/turmoil/PartyName';
 import {Game} from '../../src/server/Game';
-import {cast, runAllActions, setCustomGameOptions} from '../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 import {PoliticalAgendas} from '../../src/server/turmoil/PoliticalAgendas';
 import {AgendaStyle} from '../../src/common/turmoil/Types';
@@ -28,7 +28,7 @@ describe('PoliticalAgendas', function() {
   deserialized.forEach((deserialize) => {
     const suffix = deserialize ? ', but deserialized' : '';
     it('Standard' + suffix, () => {
-      let game = Game.newInstance('gameid', [player1, player2], player1, setCustomGameOptions({politicalAgendasExtension: AgendaStyle.STANDARD}));
+      let game = Game.newInstance('gameid', [player1, player2], player1, testGameOptions({turmoilExtension: true, politicalAgendasExtension: AgendaStyle.STANDARD}));
       if (deserialize) {
         game = Game.deserialize(game.serialize());
       }
@@ -51,7 +51,7 @@ describe('PoliticalAgendas', function() {
       // For the neutral chairman to always pick the second item in the list.
       PoliticalAgendas.randomElement = (list: Array<any>) => list[1];
 
-      let game = Game.newInstance('gameid', [player1, player2], player1, setCustomGameOptions({politicalAgendasExtension: AgendaStyle.CHAIRMAN}));
+      let game = Game.newInstance('gameid', [player1, player2], player1, testGameOptions({turmoilExtension: true, politicalAgendasExtension: AgendaStyle.CHAIRMAN}));
       if (deserialize) {
         game = Game.deserialize(game.serialize());
         // Get a new copy of player2 who will have a different set of waitingFor.
@@ -88,7 +88,7 @@ describe('PoliticalAgendas', function() {
       // For the neutral chairperson to always pick the second item.
       PoliticalAgendas.randomElement = (list: Array<any>) => list[1];
 
-      let game = Game.newInstance('gameid', [player1, player2], player1, setCustomGameOptions({politicalAgendasExtension: AgendaStyle.CHAIRMAN}));
+      let game = Game.newInstance('gameid', [player1, player2], player1, testGameOptions({turmoilExtension: true, politicalAgendasExtension: AgendaStyle.CHAIRMAN}));
       if (deserialize) {
         game = Game.deserialize(game.serialize());
       }

--- a/tests/turmoil/Turmoil.spec.ts
+++ b/tests/turmoil/Turmoil.spec.ts
@@ -8,7 +8,7 @@ import {OrOptions} from '../../src/server/inputs/OrOptions';
 import {SelectSpace} from '../../src/server/inputs/SelectSpace';
 import {SpaceBonus} from '../../src/common/boards/SpaceBonus';
 import {Turmoil} from '../../src/server/turmoil/Turmoil';
-import {cast, maxOutOceans, runAllActions, setCustomGameOptions} from '../TestingUtils';
+import {cast, maxOutOceans, runAllActions, testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 import {Reds} from '../../src/server/turmoil/parties/Reds';
 import {Greens} from '../../src/server/turmoil/parties/Greens';
@@ -47,9 +47,8 @@ describe('Turmoil', function() {
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
     player2 = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
 
-    game = Game.newInstance('gameid', [player, player2], player, gameOptions);
+    game = Game.newInstance('gameid', [player, player2], player, testGameOptions({turmoilExtension: true}));
     game.phase = Phase.ACTION;
     turmoil = game.turmoil!;
   });
@@ -260,7 +259,7 @@ describe('Turmoil', function() {
   // Strip Mine raises the oxygen level two steps.
     const card = new StripMine();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
     player.production.override({energy: 2}); // Card requirement.
@@ -296,7 +295,7 @@ describe('Turmoil', function() {
   // Strip Mine raises the oxygen level two steps.
     const card = new StripMine();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
     player.production.override({energy: 2}); // Card requirement.
@@ -317,7 +316,7 @@ describe('Turmoil', function() {
     // Strip Mine raises the oxygen level two steps.
     const card = new StripMine();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
     player.production.override({energy: 2}); // Card requirement.
@@ -340,7 +339,7 @@ describe('Turmoil', function() {
     // LavaFlows raises the temperature two steps.
     const card = new LavaFlows();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
 
@@ -377,7 +376,7 @@ describe('Turmoil', function() {
     // LavaFlows raises the temperature two steps.
     const card = new LavaFlows();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
 
@@ -397,7 +396,7 @@ describe('Turmoil', function() {
     // ArtificialLake uses trSource.
     const card = new ArtificialLake();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     (game as any).temperature = -6; // minimum requirement for the card.
     game.phase = Phase.ACTION;
@@ -426,7 +425,7 @@ describe('Turmoil', function() {
     // GiantSolarShade raises venus three steps.
     const card = new GiantSolarShade();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
 
@@ -463,7 +462,7 @@ describe('Turmoil', function() {
     // GiantSolarShade raises venus three steps.
     const card = new GiantSolarShade();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions());
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
 
@@ -483,7 +482,7 @@ describe('Turmoil', function() {
     // Raises the colony rate two steps.
     const card = new WaterTreatmentComplex();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({moonExpansion: true}));
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true, moonExpansion: true}));
     const turmoil = game.turmoil!;
     const moonData = MoonExpansion.moonData(game);
     game.phase = Phase.ACTION;
@@ -523,7 +522,7 @@ describe('Turmoil', function() {
     // Raises the mining rate two steps.
     const card = new DarksideMeteorBombardment();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({moonExpansion: true}));
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true, moonExpansion: true}));
     const turmoil = game.turmoil!;
     const moonData = MoonExpansion.moonData(game);
     game.phase = Phase.ACTION;
@@ -559,7 +558,7 @@ describe('Turmoil', function() {
     // Raises the logistic rate two steps.
     const card = new LunaStagingStation();
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({moonExpansion: true}));
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true, moonExpansion: true}));
     const turmoil = game.turmoil!;
     const moonData = MoonExpansion.moonData(game);
     game.phase = Phase.ACTION;
@@ -597,7 +596,7 @@ describe('Turmoil', function() {
 
   it('Reds: Cannot raise TR directly without the money to back it up', function() {
     const player = TestPlayer.BLUE.newPlayer();
-    const game = Game.newInstance('gameid', [player], player, setCustomGameOptions({moonExpansion: true}));
+    const game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true, moonExpansion: true}));
     const turmoil = game.turmoil!;
     game.phase = Phase.ACTION;
 

--- a/tests/turmoil/globalEvents/GlobalEventDealer.spec.ts
+++ b/tests/turmoil/globalEvents/GlobalEventDealer.spec.ts
@@ -9,7 +9,7 @@ import {SerializedGlobalEventDealer} from '../../../src/server/turmoil/globalEve
 import {SponsoredProjects} from '../../../src/server/turmoil/globalEvents/SponsoredProjects';
 import {SuccessfulOrganisms} from '../../../src/server/turmoil/globalEvents/SuccessfulOrganisms';
 import {WarOnEarth} from '../../../src/server/turmoil/globalEvents/WarOnEarth';
-import {setCustomGameOptions} from '../../TestingUtils';
+import {testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('GlobalEventDealer', () => {
@@ -44,7 +44,7 @@ describe('GlobalEventDealer', () => {
   });
 
   it('getGlobalEventByName can retrieve all cards', () => {
-    const gameOptions = setCustomGameOptions({
+    const gameOptions = testGameOptions({
       preludeExtension: true,
       venusNextExtension: true,
       coloniesExtension: true,

--- a/tests/turmoil/parties/Greens.spec.ts
+++ b/tests/turmoil/parties/Greens.spec.ts
@@ -3,7 +3,7 @@ import {Player} from '../../../src/server/Player';
 import {Game} from '../../../src/server/Game';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
 import {ISpace} from '../../../src/server/boards/ISpace';
-import {cast, setCustomGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
+import {cast, testGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Greens, GREENS_BONUS_1, GREENS_BONUS_2, GREENS_POLICY_4} from '../../../src/server/turmoil/parties/Greens';
 import {Lichen} from '../../../src/server/cards/base/Lichen';
@@ -22,8 +22,7 @@ describe('Greens', function() {
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
     const otherPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, otherPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
     greens = new Greens();
   });

--- a/tests/turmoil/parties/Kelvinists.spec.ts
+++ b/tests/turmoil/parties/Kelvinists.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
 import {ISpace} from '../../../src/server/boards/ISpace';
-import {cast, setCustomGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
+import {cast, testGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Kelvinists, KELVINISTS_BONUS_1, KELVINISTS_BONUS_2, KELVINISTS_POLICY_1, KELVINISTS_POLICY_2, KELVINISTS_POLICY_3, KELVINISTS_POLICY_4} from '../../../src/server/turmoil/parties/Kelvinists';
 import {Resources} from '../../../src/common/Resources';
@@ -19,8 +19,7 @@ describe('Kelvinists', function() {
 
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player], player, gameOptions);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
     kelvinists = new Kelvinists();
   });

--- a/tests/turmoil/parties/MarsFirst.spec.ts
+++ b/tests/turmoil/parties/MarsFirst.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Player} from '../../../src/server/Player';
 import {Game} from '../../../src/server/Game';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {setCustomGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
+import {testGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {MarsFirst, MARS_FIRST_BONUS_1, MARS_FIRST_BONUS_2, MARS_FIRST_POLICY_4} from '../../../src/server/turmoil/parties/MarsFirst';
 import {Mine} from '../../../src/server/cards/base/Mine';
@@ -17,8 +17,7 @@ describe('MarsFirst', function() {
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
     const otherPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, otherPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, otherPlayer], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
     marsFirst = new MarsFirst();
   });

--- a/tests/turmoil/parties/Reds.spec.ts
+++ b/tests/turmoil/parties/Reds.spec.ts
@@ -2,14 +2,14 @@ import {expect} from 'chai';
 import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/server/Game';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {cast, runAllActions, setCustomGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
+import {cast, runAllActions, testGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
 import {Reds, REDS_BONUS_1, REDS_BONUS_2, REDS_POLICY_3} from '../../../src/server/turmoil/parties/Reds';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 
 describe('Reds', function() {
   let player: TestPlayer;
-  let secondPlayer : TestPlayer;
+  let secondPlayer: TestPlayer;
   let game: Game;
   let turmoil: Turmoil;
   let reds: Reds;
@@ -17,8 +17,7 @@ describe('Reds', function() {
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
     secondPlayer = TestPlayer.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player, secondPlayer], player, gameOptions);
+    game = Game.newInstance('gameid', [player, secondPlayer], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
     reds = new Reds();
   });
@@ -96,7 +95,7 @@ describe('Reds', function() {
 
   it('Ruling policy 3: Pay 4 M€ to reduce a non-maxed global parameter 1 step: Moon', function() {
     // Reset the whole game infrastructure to include the Moon
-    const gameOptions = setCustomGameOptions({moonExpansion: true});
+    const gameOptions = testGameOptions({turmoilExtension: true, moonExpansion: true});
     game = Game.newInstance('gameid', [player, secondPlayer], player, gameOptions);
     turmoil = game.turmoil!;
     player.popWaitingFor(); // Remove SelectInitialCards

--- a/tests/turmoil/parties/Scientists.spec.ts
+++ b/tests/turmoil/parties/Scientists.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {setCustomGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
+import {testGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Scientists, SCIENTISTS_BONUS_1, SCIENTISTS_BONUS_2, SCIENTISTS_POLICY_1, SCIENTISTS_POLICY_2, SCIENTISTS_POLICY_3, SCIENTISTS_POLICY_4} from '../../../src/server/turmoil/parties/Scientists';
 import {SearchForLife} from '../../../src/server/cards/base/SearchForLife';
@@ -21,8 +21,7 @@ describe('Scientists', function() {
 
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player], player, gameOptions);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
     scientists = new Scientists();
   });

--- a/tests/turmoil/parties/Unity.spec.ts
+++ b/tests/turmoil/parties/Unity.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Player} from '../../../src/server/Player';
 import {Game} from '../../../src/server/Game';
 import {Turmoil} from '../../../src/server/turmoil/Turmoil';
-import {cast, setCustomGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
+import {cast, testGameOptions, setRulingPartyAndRulingPolicy} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {Unity, UNITY_BONUS_1, UNITY_BONUS_2, UNITY_POLICY_2, UNITY_POLICY_3} from '../../../src/server/turmoil/parties/Unity';
 import {SisterPlanetSupport} from '../../../src/server/cards/venusNext/SisterPlanetSupport';
@@ -19,8 +19,7 @@ describe('Unity', function() {
 
   beforeEach(function() {
     player = TestPlayer.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
-    game = Game.newInstance('gameid', [player], player, gameOptions);
+    game = Game.newInstance('gameid', [player], player, testGameOptions({turmoilExtension: true}));
     turmoil = game.turmoil!;
     unity = new Unity();
   });

--- a/tests/venusNext/AltVenusTrackBonuses.spec.ts
+++ b/tests/venusNext/AltVenusTrackBonuses.spec.ts
@@ -4,7 +4,7 @@
 import {expect} from 'chai';
 import {Player} from '../../src/server/Player';
 import {Game} from '../../src/server/Game';
-import {cast, setCustomGameOptions} from '../TestingUtils';
+import {cast, testGameOptions} from '../TestingUtils';
 import {TestPlayer} from '../TestPlayer';
 import {GrantVenusAltTrackBonusDeferred} from '../../src/server/venusNext/GrantVenusAltTrackBonusDeferred';
 
@@ -14,7 +14,7 @@ describe('AltVenusTrackBonuses', function() {
 
   beforeEach(() => {
     player = TestPlayer.BLUE.newPlayer();
-    game = Game.newInstance('gameid', [player], player, setCustomGameOptions({altVenusBoard: true}));
+    game = Game.newInstance('gameid', [player], player, testGameOptions({altVenusBoard: true}));
   });
 
   function getAction(game: Game) {


### PR DESCRIPTION
setCustomGameOptions was pretty useful in early development, and made it possible to test all the expansions without much extra work. At the time, the structures for setting game options were hidden by private members, and probably not a lot of Typescript savvy (e.g. the spread operator, which helps. A LOT.)

The drawback to setCustomGameOptions is that it hides the actual set of game options used in the test from the reader. It also adds expansions that are not relevant to the tests.