### PR TITLE
Hi-tech lab unnecessary choose when using 1 energy

### DIFF
--- a/src/server/cards/promo/HiTechLab.ts
+++ b/src/server/cards/promo/HiTechLab.ts
@@ -39,6 +39,10 @@ export class HiTechLab extends Card implements IProjectCard {
       (amount: number) => {
         player.deductResource(Resources.ENERGY, amount);
         player.game.log('${0} spent ${1} energy', (b) => b.player(player).number(amount));
+        if (amount === 1) {
+          player.drawCard();
+          return undefined;
+        }
         return player.drawCardKeepSome(amount, {keepMax: 1});
       },
       1,


### PR DESCRIPTION
When using Hi-tech lab with one energy the game asks you to choose a card from one option which is unnecessary. Replaced draw one keep one simply by drawing a card.