### PR TITLE
Local Heat Trapping is double-deducting.

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1495,7 +1495,6 @@ export class Player {
   /**
    * Verify if requirements for the card can be met, ignoring the project cost.
    * Only made public for tests.
-   * @deprecated use Card2.
    */
   public simpleCanPlay(card: IProjectCard): boolean {
     if (card.requirements !== undefined && !card.requirements.satisfies(this)) {

--- a/src/server/cards/Card.ts
+++ b/src/server/cards/Card.ts
@@ -20,6 +20,7 @@ import {TileType} from '../../common/TileType';
 import {Behavior} from '../behavior/Behavior';
 import {Behaviors} from '../behavior/Behaviors';
 
+type ReserveUnits = Units & {deduct: boolean};
 /* External representation of card properties. */
 export interface StaticCardProperties {
   adjacencyBonus?: AdjacencyBonus;
@@ -32,7 +33,7 @@ export interface StaticCardProperties {
   metadata: ICardMetadata;
   requirements?: CardRequirements;
   name: CardName;
-  reserveUnits?: Partial<Units>,
+  reserveUnits?: Partial<ReserveUnits>,
   resourceType?: CardResource;
   startingMegaCredits?: number;
   tags?: Array<Tag>;
@@ -45,7 +46,7 @@ export interface StaticCardProperties {
  * Internal representation of card properties.
  */
 type Properties = Omit<StaticCardProperties, 'reserveUnits|behavior'> & {
-  reserveUnits?: Units,
+  reserveUnits?: ReserveUnits,
   behavior: Behavior,
 };
 
@@ -88,7 +89,7 @@ export abstract class Card {
 
       const p: Properties = {
         ...properties,
-        reserveUnits: properties.reserveUnits === undefined ? undefined : Units.of(properties.reserveUnits),
+        reserveUnits: properties.reserveUnits === undefined ? undefined : {...Units.of(properties.reserveUnits), deduct: properties.reserveUnits.deduct ?? true},
         behavior: properties.behavior || {},
       };
       staticCardProperties.set(properties.name, p);
@@ -136,8 +137,8 @@ export abstract class Card {
   public get cardDiscount() {
     return this.properties.cardDiscount;
   }
-  public get reserveUnits(): Units {
-    return this.properties.reserveUnits || Units.EMPTY;
+  public get reserveUnits(): ReserveUnits {
+    return this.properties.reserveUnits || {...Units.EMPTY, deduct: true};
   }
   public get tr(): TRSource | DynamicTRSource {
     return this.properties.tr || {};
@@ -163,7 +164,7 @@ export abstract class Card {
   }
 
   public play(player: Player) {
-    if (!isICorporationCard(this)) {
+    if (!isICorporationCard(this) && this.reserveUnits.deduct === true) {
       const adjustedReserveUnits = MoonExpansion.adjustedReserveCosts(player, this);
       player.deductUnits(adjustedReserveUnits);
     }

--- a/src/server/cards/base/LocalHeatTrapping.ts
+++ b/src/server/cards/base/LocalHeatTrapping.ts
@@ -18,7 +18,8 @@ export class LocalHeatTrapping extends Card implements IProjectCard {
       cardType: CardType.EVENT,
       name: CardName.LOCAL_HEAT_TRAPPING,
       cost: 1,
-      reserveUnits: {heat: 5},
+      // The 5 heat will be deducted in bespokePlay
+      reserveUnits: {heat: 5, deduct: false},
 
       metadata: {
         cardNumber: '190',

--- a/tests/cards/base/LocalHeatTrapping.spec.ts
+++ b/tests/cards/base/LocalHeatTrapping.spec.ts
@@ -20,20 +20,27 @@ describe('LocalHeatTrapping', () => {
   });
 
   it('Cannot play without 5 heat', () => {
+    player.megaCredits = card.cost;
     player.cardsInHand = [card];
-    expect(player.getPlayableCards()).is.empty;
+    expect(player.canPlay(card)).is.false;
+    player.heat = 4;
+    expect(player.canPlay(card)).is.false;
+    player.heat = 5;
+    expect(player.canPlay(card)).is.true;
   });
 
   it('Should play - no animal targets', () => {
-    player.heat = 5;
+    player.megaCredits = card.cost;
+    player.heat = 6;
     player.megaCredits = 1;
     player.cardsInHand = [card];
-    expect(player.getPlayableCards()).does.include(card);
+
+    expect(player.canPlay(card)).is.true;
 
     card.play(player);
-    player.playedCards.push(card);
+
     expect(player.plants).to.eq(4);
-    expect(player.heat).to.eq(0);
+    expect(player.heat).to.eq(1);
   });
 
   it('Should play - single animal target', () => {
@@ -71,8 +78,8 @@ describe('LocalHeatTrapping', () => {
     player.megaCredits = 0;
     player.heat = 5; // have to pay for card with 1 heat
     player.cardsInHand = [card];
-    expect(player.getPlayableCards()).does.not.include(card);
+    expect(player.canPlay(card)).is.false;
     player.megaCredits = 1;
-    expect(player.getPlayableCards()).does.include(card);
+    expect(player.canPlay(card)).is.true;
   });
 });


### PR DESCRIPTION
Moving reserveUnits caused a little trouble in this one place where resources weren't meant to be deducted.