### PR TITLE
Don't count hazard tiles as "special" in the rewarding sense.

### DIFF
--- a/src/server/boards/Board.ts
+++ b/src/server/boards/Board.ts
@@ -334,6 +334,10 @@ export function isSpecialTile(space: ISpace): boolean {
   case TileType.MOON_COLONY:
   case TileType.MOON_MINE:
   case TileType.MOON_ROAD:
+  case TileType.EROSION_MILD: // Hazard tiles are "special" but they don't count for the typical intent of what a special tile represents.
+  case TileType.EROSION_SEVERE:
+  case TileType.DUST_STORM_MILD:
+  case TileType.DUST_STORM_SEVERE:
   case undefined:
     return false;
   default:

--- a/tests/cards/base/LandClaim.spec.ts
+++ b/tests/cards/base/LandClaim.spec.ts
@@ -5,8 +5,10 @@ import * as constants from '../../../src/common/constants';
 import {Game} from '../../../src/server/Game';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {SpaceName} from '../../../src/server/SpaceName';
-import {cast, testGameOptions} from '../../TestingUtils';
+import {cast, runAllActions, testGameOptions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
+import {getTestPlayer, newTestGame} from '../../TestGame';
+import {AresHandler} from '../../../src/server/ares/AresHandler';
 
 describe('LandClaim', function() {
   it('Should play', function() {
@@ -20,6 +22,7 @@ describe('LandClaim', function() {
     expect(landSpace.player).to.eq(player);
     expect(landSpace.tile).is.undefined;
   });
+
   it('can claim south pole on hellas board', function() {
     const card = new LandClaim();
     const player = TestPlayer.BLUE.newPlayer();
@@ -30,5 +33,18 @@ describe('LandClaim', function() {
     const action = cast(card.play(player), SelectSpace);
     expect(player.canAfford(constants.HELLAS_BONUS_OCEAN_COST)).to.be.false;
     expect(action.availableSpaces.some((space) => space.id === SpaceName.HELLAS_OCEAN_TILE)).to.be.true;
+  });
+
+  it('can claim hazard spaces', function() {
+    const game = newTestGame(1, {aresExtension: true, pathfindersExpansion: true});
+    const player = getTestPlayer(game, 0);
+    const hazardSpace = game.board.spaces.filter(AresHandler.hasHazardTile)[0];
+    const landClaim = new LandClaim();
+    player.playCard(landClaim);
+    runAllActions(game);
+    const selectSpace = cast(player.popWaitingFor(), SelectSpace);
+    expect(selectSpace.availableSpaces).includes(hazardSpace);
+    selectSpace.cb(hazardSpace);
+    expect(hazardSpace.player).eq(player);
   });
 });

--- a/tests/cards/pathfinders/RareEarthElements.spec.ts
+++ b/tests/cards/pathfinders/RareEarthElements.spec.ts
@@ -3,6 +3,11 @@ import {RareEarthElements} from '../../../src/server/cards/pathfinders/RareEarth
 import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {TileType} from '../../../src/common/TileType';
+import {getTestPlayer, newTestGame} from '../../TestGame';
+import {LandClaim} from '../../../src/server/cards/base/LandClaim';
+import {AresHandler} from '../../../src/server/ares/AresHandler';
+import {cast, runAllActions} from '../../TestingUtils';
+import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 
 describe('RareEarthElements', function() {
   let card: RareEarthElements;
@@ -53,5 +58,21 @@ describe('RareEarthElements', function() {
     player.production.override({megacredits: 0});
     card.play(player);
     expect(player.production.megacredits).eq(3);
+  });
+
+  it('You do not own hazards you land-claimed', () => {
+    const game = newTestGame(1, {aresExtension: true, pathfindersExpansion: true});
+    const player = getTestPlayer(game, 0);
+    const hazardSpace = game.board.spaces.filter(AresHandler.hasHazardTile)[0];
+    const landClaim = new LandClaim();
+    player.playCard(landClaim);
+    runAllActions(game);
+    const selectSpace = cast(player.popWaitingFor(), SelectSpace);
+    expect(selectSpace.availableSpaces).includes(hazardSpace);
+    selectSpace.cb(hazardSpace);
+
+    player.playCard(card);
+
+    expect(player.production.megacredits).eq(0);
   });
 });

--- a/tests/globalEvents/SpaceRaceToMars.spec.ts
+++ b/tests/globalEvents/SpaceRaceToMars.spec.ts
@@ -65,6 +65,16 @@ describe('SpaceRaceToMars', function() {
     expect(player2.production.megacredits).eq(0);
   });
 
+  it('Land-claimed hazard tile does not count', function() {
+    // Greenery won't doesn't change this card's reward.
+    game.simpleAddTile(player, spaces[3], {tileType: TileType.EROSION_SEVERE});
+
+    card.resolve(game, turmoil);
+
+    expect(player.production.megacredits).eq(0);
+    expect(player2.production.megacredits).eq(0);
+  });
+
   it('Other players special tile', function() {
     game.simpleAddTile(player2, spaces[3], {tileType: TileType.LAVA_FLOWS});
 

--- a/tests/milestones/LandSpecialist.spec.ts
+++ b/tests/milestones/LandSpecialist.spec.ts
@@ -48,6 +48,7 @@ describe('LandSpecialist', function() {
     game.simpleAddTile(player, spaces[0], {tileType: TileType.CITY});
     game.simpleAddTile(player, spaces[1], {tileType: TileType.CITY});
     game.simpleAddTile(player, spaces[2], {tileType: TileType.GREENERY});
+    game.simpleAddTile(player, spaces[3], {tileType: TileType.EROSION_MILD});
     expect(milestone.getScore(player)).eq(0);
     expect(milestone.canClaim(player)).is.false;
   });


### PR DESCRIPTION
Fixes #4947