### PR TITLE
Remove the well-formed jsdoc requirement.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = { // eslint-disable-line no-undef
     'no-case-declarations': 'off',
     'no-redeclare': 'off', // If we stopped using namespaces, this could be enabled.
     'no-prototype-builtins': 'off', // This could be enabled actually; just fix uses of 'hasOwnProperty'
+    'valid-jsdoc': 'off', // precise valid jsdoc is in the way of taking advantage of partial jsdoc. A case of the perfecct being the enemy of the good.
 
     '@typescript-eslint/prefer-for-of': 'error',
 

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1185,7 +1185,6 @@ export class Player {
     }
   }
 
-  // eslint-disable-next-line valid-jsdoc
   /** @deprecated use card.play */
   public simplePlay(card: IProjectCard | ICorporationCard) {
     return card.play(this);
@@ -1496,7 +1495,6 @@ export class Player {
     return this.simpleCanPlay(card);
   }
 
-  // eslint-disable-next-line valid-jsdoc
   /**
    * Verify if requirements for the card can be met, ignoring the project cost.
    * Only made public for tests.


### PR DESCRIPTION
A case of the perfect being the enemy of the good.