### PR TITLE
Move the selection checkbox above the card

### DIFF
--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -101,11 +101,13 @@
 input[type="checkbox"] + .filterDiv.card-container,
 input[type="radio"] + .filterDiv.card-container {
     margin-top: 22px;
+    filter: brightness(0.65);
 }
 
 input[type="checkbox"]:checked + .filterDiv,
 input[type="radio"]:checked + .filterDiv {
-    box-shadow: 0 0 0 1px #303030, 0 0 7px 10px #c97e23
+    box-shadow: 0 0 0 1px #303030, 0 0 7px 10px #c97e23;
+    filter: none;
 }
 
 input[type="checkbox"]:checked + .filterDiv::after,

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -98,25 +98,34 @@
     box-shadow: 0 0 2px 1px black;
 }
 
+.filterDiv.card-container {
+    margin-top: 20px;
+}
+
 input[type="checkbox"]:checked + .filterDiv,
 input[type="radio"]:checked + .filterDiv {
-    box-shadow: 0 0 0 2px #303030, 0 0 0px 6px #c97e23;
+    box-shadow: 0 0 0 1px #303030, 0 0 0px 5px #c97e23;
 }
 
 input[type="checkbox"]:checked + .filterDiv::after,
 input[type="radio"]:checked + .filterDiv::after {
     content: "✓";
     position: absolute;
-    width: calc(100% + 12px);
-    height: 50px;
-    line-height: 50px;
-    top: 50%;
-    left: -6px;
+    width: 90px;
+    height: 18px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-top: 1px solid black;
+    border-left: 1px solid black;
+    border-right: 1px solid black;
+    top: -27px;
+    left: calc(50% - 45px);
     text-align: center;
     font-weight: bold;
-    font-size: 36px;
-    background: linear-gradient(to right, #c97e23bb, #e28c22bb, #c97e23bb);
+    font-size: 13px;
+    background: #c97e23;
     color: black;
+    z-index: 1;
 }
 
 .filterDiv3 {
@@ -1408,6 +1417,7 @@ input[type="radio"]:checked + .filterDiv::after {
     );
     border-radius: 7px 7px 2px 2px;
     text-transform: uppercase;
+    z-index: 2;
 }
 
 .corporationEffectBox {
@@ -2712,6 +2722,7 @@ input[type="radio"]:checked + .filterDiv::after {
                     background-color: white;
                     /* margin-top: -6px; */
                     filter: brightness(0.9);
+                    z-index: 2;
                 }
             }
         }

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -98,13 +98,14 @@
     box-shadow: 0 0 2px 1px black;
 }
 
-.filterDiv.card-container {
-    margin-top: 20px;
+input[type="checkbox"] + .filterDiv.card-container,
+input[type="radio"] + .filterDiv.card-container {
+    margin-top: 22px;
 }
 
 input[type="checkbox"]:checked + .filterDiv,
 input[type="radio"]:checked + .filterDiv {
-    box-shadow: 0 0 0 1px #303030, 0 0 0px 5px #c97e23;
+    box-shadow: 0 0 0 1px #303030, 0 0 7px 10px #c97e23
 }
 
 input[type="checkbox"]:checked + .filterDiv::after,
@@ -112,13 +113,13 @@ input[type="radio"]:checked + .filterDiv::after {
     content: "✓";
     position: absolute;
     width: 90px;
-    height: 18px;
+    height: 21px;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
     border-top: 1px solid black;
     border-left: 1px solid black;
     border-right: 1px solid black;
-    top: -27px;
+    top: -30px;
     left: calc(50% - 45px);
     text-align: center;
     font-weight: bold;

--- a/src/styles/colonies.less
+++ b/src/styles/colonies.less
@@ -394,5 +394,7 @@ input[type="radio"]:checked + .colonies::after {
         #c97e23
     );
     height: 47px;
-    border-bottom: none;
+    font-size: 36px;
+    border-radius: 0px;
+    border: none;
 }

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -297,6 +297,17 @@
     margin: -0px -10px -15px -10px;
 }
 
+/*Selection check box room for smaller cards */
+.preferences_small_cards input[type="checkbox"] + .filterDiv.card-container,
+.preferences_small_cards input[type="radio"] + .filterDiv.card-container{
+    margin-top: -8px;
+}
+
+.preferences_small_cards input[type="checkbox"] + .filterDiv.card-standard-project,
+.preferences_small_cards input[type="radio"] + .filterDiv.card-standard-project{
+    margin-top: 0px;
+}
+
 .preferences_small_cards input[type="checkbox"]:checked + .filterDiv,
 .preferences_small_cards input[type="radio"]:checked + .filterDiv {
     transform: scale(0.8);

--- a/src/styles/turmoil.less
+++ b/src/styles/turmoil.less
@@ -698,7 +698,9 @@ input[type="radio"]:checked + .party-container::after {
     width: 149px;
     background: #e28c22;
     height: 47px;
-    border-bottom: none;
+    font-size: 36px;
+    border-radius: 4px;
+    border: none;
 }
 
 .unavailable-party {


### PR DESCRIPTION
Fixes https://github.com/terraforming-mars/terraforming-mars/issues/3211
Alternative approach to https://github.com/terraforming-mars/terraforming-mars/pull/4347

- Checkbox moved above the card. 
- Slightly more room made for it with increasing top margin and reducing the box-shadow. 
- A very slight change to turmoil checkbox to go along the party background with rounded corners. 
- Colony checkbox unchanged. 

Tested with solo play with google chrome and mozilla firefox.

![193094173-be009082-987c-441d-a575-e5c778132a2a](https://user-images.githubusercontent.com/26537065/193346402-33e69cd9-0080-4a62-b10d-523303c78bd7.png)

![193094173-be009082-987c-441d-a575-e5c778132a2a](https://user-images.githubusercontent.com/26537065/193094222-b0c72093-a87d-4620-9f27-a2a2a98bc0a4.png)
![turmoil](https://user-images.githubusercontent.com/26537065/193347388-5d4a7c05-ff39-4ff7-a658-2b0e134f5a39.png)
