### PR TITLE
CSS to fix language icon positions and layout.

### DIFF
--- a/src/styles/language_icon.less
+++ b/src/styles/language_icon.less
@@ -8,14 +8,14 @@
   height: 30px;
   background: url(assets/flags_responsive.png) no-repeat;
 
-  &--for-switcher {
+  &-for-switcher {
     cursor: pointer;
     border-radius: 50%;
     box-shadow: 0 2px 2px black;
     transition: transform 0.15s;
   }
 
-  &--for-sidebar {
+  &-for-sidebar {
     transform: scale(.85);
     margin-left: -4px;
     margin-top: 3px;


### PR DESCRIPTION
Accidentally used double-hyphen