### PR TITLE
Make corps handle their own custom serialization.

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1,7 +1,6 @@
 import * as constants from '../common/constants';
 import {PlayerId} from '../common/Types';
 import {DEFAULT_FLOATERS_VALUE, DEFAULT_MICROBES_VALUE, MILESTONE_COST, REDS_RULING_POLICY_COST} from '../common/constants';
-import {Aridor} from './cards/colonies/Aridor';
 import {Board} from './boards/Board';
 import {CardFinder} from './CardFinder';
 import {CardName} from '../common/cards/CardName';
@@ -19,7 +18,6 @@ import {LogMessageDataType} from '../common/logs/LogMessageDataType';
 import {OrOptions} from './inputs/OrOptions';
 import {PartyHooks} from './turmoil/parties/PartyHooks';
 import {PartyName} from '../common/turmoil/PartyName';
-import {PharmacyUnion} from './cards/promo/PharmacyUnion';
 import {Phase} from '../common/Phase';
 import {PlayerInput} from './PlayerInput';
 import {Resources} from '../common/Resources';
@@ -1901,12 +1899,13 @@ export class Player {
     const result: SerializedPlayer = {
       id: this.id,
       corporations: this.corporations.map((corporation) => {
-        return {
+        const serialized = {
           name: corporation.name,
           resourceCount: corporation.resourceCount,
-          allTags: corporation instanceof Aridor ? Array.from(corporation.allTags) : [],
-          isDisabled: corporation instanceof PharmacyUnion && corporation.isDisabled,
+          isDisabled: false,
         };
+        corporation.serialize?.(serialized);
+        return serialized;
       }),
       // Used only during set-up
       pickedCorporationCard: this.pickedCorporationCard?.name,
@@ -2055,16 +2054,7 @@ export class Player {
         if (corporation.resourceCount !== undefined) {
           card.resourceCount = corporation.resourceCount;
         }
-        if (card instanceof Aridor) {
-          if (corporation.allTags !== undefined) {
-            card.allTags = new Set(corporation.allTags);
-          } else {
-            console.warn('did not find allTags for ARIDOR');
-          }
-        }
-        if (card instanceof PharmacyUnion) {
-          card.isDisabled = Boolean(corporation.isDisabled);
-        }
+        card.deserialize?.(corporation);
         player.corporations.push(card);
       }
     }

--- a/src/server/cards/colonies/Aridor.ts
+++ b/src/server/cards/colonies/Aridor.ts
@@ -11,6 +11,7 @@ import {SelectColony} from '../../inputs/SelectColony';
 import {Card} from '../Card';
 import {CardRenderer} from '../render/CardRenderer';
 import {ColoniesHandler} from '../../colonies/ColoniesHandler';
+import {SerializedCard} from '@/server/SerializedCard';
 
 export class Aridor extends Card implements ICorporationCard {
   constructor() {
@@ -83,5 +84,13 @@ export class Aridor extends Card implements ICorporationCard {
       }
     }
     return undefined;
+  }
+
+  public serialize(serialized: SerializedCard) {
+    serialized.allTags = Array.from(this.allTags);
+  }
+
+  public deserialize(serialized: SerializedCard) {
+    this.allTags = new Set(serialized.allTags);
   }
 }

--- a/src/server/cards/corporation/ICorporationCard.ts
+++ b/src/server/cards/corporation/ICorporationCard.ts
@@ -2,6 +2,7 @@ import {ICard} from '../ICard';
 import {Player} from '../../Player';
 import {PlayerInput} from '../../PlayerInput';
 import {CardType} from '../../../common/cards/CardType';
+import {SerializedCard} from '../../SerializedCard';
 
 export interface ICorporationCard extends ICard {
   initialActionText?: string;
@@ -11,6 +12,9 @@ export interface ICorporationCard extends ICard {
   onCorpCardPlayed?: (player: Player, card: ICorporationCard) => PlayerInput | undefined;
   onProductionPhase?: (player: Player) => undefined; // For Pristar
   isDisabled?: boolean;
+
+  serialize?(serialized: SerializedCard): void;
+  deserialize?(serialized: SerializedCard): void;
 }
 
 export function isICorporationCard(card: ICard): card is ICorporationCard {

--- a/src/server/cards/promo/PharmacyUnion.ts
+++ b/src/server/cards/promo/PharmacyUnion.ts
@@ -13,6 +13,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {Resources} from '../../../common/Resources';
 import {all, digit, played} from '../Options';
+import {SerializedCard} from '@/server/SerializedCard';
 
 export class PharmacyUnion extends Card implements ICorporationCard {
   constructor() {
@@ -171,5 +172,13 @@ export class PharmacyUnion extends Card implements ICorporationCard {
     }
 
     return undefined;
+  }
+
+  public serialize(serialized: SerializedCard) {
+    serialized.isDisabled = this.isDisabled;
+  }
+
+  public deserialize(serialized: SerializedCard) {
+    this.isDisabled = Boolean(serialized.isDisabled);
   }
 }

--- a/tests/cards/colonies/Aridor.spec.ts
+++ b/tests/cards/colonies/Aridor.spec.ts
@@ -7,6 +7,9 @@ import {Aridor} from '../../../src/server/cards/colonies/Aridor';
 import {Game} from '../../../src/server/Game';
 import {Venus} from '../../../src/server/cards/community/Venus';
 import {Celestic} from '../../../src/server/cards/venusNext/Celestic';
+import {Tag} from '../../../src/common/cards/Tag';
+import {Player} from '../../../src/server/Player';
+import {cast} from '../../TestingUtils';
 
 let card: Aridor;
 let game: Game;
@@ -82,5 +85,23 @@ describe('Aridor', function() {
 
     expect(game.colonies).includes(venus);
     expect(venus.isActive).is.true;
+  });
+
+  it('serialization test for Player with Aridor', () => {
+    card.play(player);
+    card.onCardPlayed(player, new Predators());
+    card.onCardPlayed(player2, new ResearchOutpost());
+    card.onCardPlayed(player, new ResearchOutpost());
+
+    expect(Array.from(card.allTags)).deep.eq([Tag.ANIMAL, Tag.SCIENCE, Tag.CITY, Tag.BUILDING]);
+
+    const serializedPlayer = player.serialize();
+
+    expect(serializedPlayer.corporations?.[0].allTags).deep.eq([Tag.ANIMAL, Tag.SCIENCE, Tag.CITY, Tag.BUILDING]);
+
+    const reserializedPlayer = Player.deserialize(serializedPlayer);
+    const reserializedAridor = cast(reserializedPlayer.corporations?.[0], Aridor);
+
+    expect(Array.from(reserializedAridor.allTags)).deep.eq([Tag.ANIMAL, Tag.SCIENCE, Tag.CITY, Tag.BUILDING]);
   });
 });

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -16,6 +16,7 @@ import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {TestPlayer} from '../../TestPlayer';
 import {Virus} from '../../../src/server/cards/base/Virus';
 import {cast, runAllActions} from '../../TestingUtils';
+import {Player} from '../../../src/server/Player';
 
 describe('PharmacyUnion', function() {
   let card: PharmacyUnion;
@@ -191,5 +192,28 @@ describe('PharmacyUnion', function() {
     player.playCard(new Virus());
     runAllActions(player.game);
     expect(player.megaCredits).eq(3);
+  });
+
+  it('serialization test for Player with Pharmacy Union, when false', () => {
+    card.play(player);
+    card.isDisabled = false;
+    const serializedPlayer = player.serialize();
+
+    expect(serializedPlayer.corporations?.[0].isDisabled).is.false;
+
+    const reserializedPlayer = Player.deserialize(serializedPlayer);
+    const reserializedPharmacyUnion = cast(reserializedPlayer.corporations?.[0], PharmacyUnion);
+    expect(reserializedPharmacyUnion.isDisabled).is.false;
+  });
+
+  it('serialization test for Player with Pharmacy Union, when true', () => {
+    card.isDisabled = true;
+    const serializedPlayer = player.serialize();
+
+    expect(serializedPlayer.corporations?.[0].isDisabled).is.true;
+
+    const reserializedPlayer = Player.deserialize(serializedPlayer);
+    const reserializedPharmacyUnion = cast(reserializedPlayer.corporations?.[0], PharmacyUnion);
+    expect(reserializedPharmacyUnion.isDisabled).is.true;
   });
 });


### PR DESCRIPTION
While looking to remove some dependencies, I found this small efficiency which seems worth keeping. Could extend this to other cards (I'm looking at you, Robotic Workforce.)