### PR TITLE
Fix Viron bug that creates stack overflow.

### DIFF
--- a/src/server/cards/venusNext/Viron.ts
+++ b/src/server/cards/venusNext/Viron.ts
@@ -35,6 +35,9 @@ export class Viron extends Card implements ICard, ICorporationCard {
   private getActionCards(player: Player): Array<IActionCard & ICard> {
     const result: Array<IActionCard & ICard> = [];
     for (const playedCard of player.tableau) {
+      if (playedCard === this) {
+        continue;
+      }
       if (isIActionCard(playedCard) &&
           player.getActionsThisGeneration().has(playedCard.name) &&
           playedCard.canAct(player)) {

--- a/tests/cards/venusNext/Viron.spec.ts
+++ b/tests/cards/venusNext/Viron.spec.ts
@@ -3,22 +3,51 @@ import {RestrictedArea} from '../../../src/server/cards/base/RestrictedArea';
 import {Viron} from '../../../src/server/cards/venusNext/Viron';
 import {getTestPlayer, newTestGame} from '../../TestGame';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
+import {TestPlayer} from '../../TestPlayer';
+import {Game} from '../../../src/server/Game';
+import {cast} from '../../TestingUtils';
 
 describe('Viron', function() {
+  let card: Viron;
+  let game: Game;
+  let player: TestPlayer;
+
+  beforeEach(function() {
+    card = new Viron();
+    game = newTestGame(1);
+    player = getTestPlayer(game, 0);
+  });
+
   it('Should act', function() {
-    const card = new Viron();
-    const game = newTestGame(1);
-    const player = getTestPlayer(game, 0);
     const action = card.play(player);
+
     expect(action).is.undefined;
+
     player.setCorporationForTest(card);
-    player.playedCards.push(new RestrictedArea());
-    player.addActionThisGeneration(new RestrictedArea().name);
+    const restrictedArea = new RestrictedArea();
+    player.playedCards.push(restrictedArea);
+    player.addActionThisGeneration(restrictedArea.name);
+
     expect(card.canAct(player)).is.not.true;
+
     player.megaCredits += 2;
+
     expect(card.canAct(player)).is.true;
-    const action2 = card.action(player);
-    expect(action2).is.not.undefined;
-    expect(action2 instanceof SelectCard).is.true;
+
+    const selectCard = cast(card.action(player), SelectCard);
+    expect(selectCard.cards).deep.eq([restrictedArea]);
+  });
+
+  it('Cannot act once Viron is used', function() {
+    card.play(player);
+
+    player.setCorporationForTest(card);
+    const restrictedArea = new RestrictedArea();
+    player.playedCards.push(restrictedArea);
+    player.addActionThisGeneration(restrictedArea.name);
+    player.addActionThisGeneration(card.name);
+    player.megaCredits += 2;
+
+    expect(card.canAct(player)).is.not.true;
   });
 });


### PR DESCRIPTION
Now that Viron can apply to other corporations thanks to Merger, the card needs to be aware that it cannot apply to itself. OZherwise it creates an infinite loop. Besides, once Viron is played, it can't be replayed through itself anyway.