### PR TITLE
Remove the spaceType parameter in addTile.

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -1235,8 +1235,9 @@ export class Game implements Logger {
   // addTile applies to the Mars board, but not the Moon board, see MoonExpansion.addTile for placing
   // a tile on The Moon.
   public addTile(
-    player: Player, spaceType: SpaceType,
-    space: ISpace, tile: Tile): void {
+    player: Player,
+    space: ISpace,
+    tile: Tile): void {
     // Part 1, basic validation checks.
 
     if (space.tile !== undefined && !(this.gameOptions.aresExtension || this.gameOptions.pathfindersExpansion)) {
@@ -1246,15 +1247,6 @@ export class Game implements Logger {
     // Land claim a player can claim land for themselves
     if (space.player !== undefined && space.player !== player) {
       throw new Error('This space is land claimed by ' + space.player.name);
-    }
-
-    let validSpaceType = space.spaceType === spaceType;
-    if (space.spaceType === SpaceType.COVE && (spaceType === SpaceType.LAND || spaceType === SpaceType.OCEAN)) {
-      // Cove is a valid type for land and also ocean.
-      validSpaceType = true;
-    }
-    if (!validSpaceType) {
-      throw new Error(`Select a valid location: ${space.spaceType} is not ${spaceType}`);
     }
 
     if (!AresHandler.canCover(space, tile)) {
@@ -1310,7 +1302,7 @@ export class Game implements Logger {
         AresHandler.earnAdjacencyBonuses(aresData, player, space);
       });
 
-      TurmoilHandler.resolveTilePlacementBonuses(player, spaceType);
+      TurmoilHandler.resolveTilePlacementBonuses(player, space.spaceType);
 
       if (arcadianCommunityBonus) {
         this.defer(new GainResources(player, Resources.MEGACREDITS, {count: 3}));
@@ -1404,9 +1396,8 @@ export class Game implements Logger {
 
   public addGreenery(
     player: Player, spaceId: SpaceId,
-    spaceType: SpaceType = SpaceType.LAND,
     shouldRaiseOxygen: boolean = true): undefined {
-    this.addTile(player, spaceType, this.board.getSpace(spaceId), {
+    this.addTile(player, this.board.getSpace(spaceId), {
       tileType: TileType.GREENERY,
     });
     // Turmoil Greens ruling policy
@@ -1417,10 +1408,10 @@ export class Game implements Logger {
   }
 
   public addCityTile(
-    player: Player, spaceId: SpaceId, spaceType: SpaceType = SpaceType.LAND,
+    player: Player, spaceId: SpaceId,
     cardName: CardName | undefined = undefined): void {
     const space = this.board.getSpace(spaceId);
-    this.addTile(player, spaceType, space, {
+    this.addTile(player, space, {
       tileType: TileType.CITY,
       card: cardName,
     });
@@ -1435,12 +1426,10 @@ export class Game implements Logger {
     return count > 0 && count < constants.MAX_OCEAN_TILES;
   }
 
-  public addOceanTile(
-    player: Player, spaceId: SpaceId,
-    spaceType: SpaceType = SpaceType.OCEAN): void {
+  public addOceanTile(player: Player, spaceId: SpaceId): void {
     if (this.canAddOcean() === false) return;
 
-    this.addTile(player, spaceType, this.board.getSpace(spaceId), {
+    this.addTile(player, this.board.getSpace(spaceId), {
       tileType: TileType.OCEAN,
     });
     if (this.phase !== Phase.SOLAR) {

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -33,7 +33,6 @@ import {SelectSpace} from './inputs/SelectSpace';
 import {RobotCard, SelfReplicatingRobots} from './cards/promo/SelfReplicatingRobots';
 import {SerializedCard} from './SerializedCard';
 import {SerializedPlayer} from './SerializedPlayer';
-import {SpaceType} from '../common/boards/SpaceType';
 import {StormCraftIncorporated} from './cards/colonies/StormCraftIncorporated';
 import {Tag} from '../common/cards/Tag';
 import {VictoryPointsBreakdown} from './VictoryPointsBreakdown';
@@ -820,7 +819,7 @@ export class Player {
         new SelectSpace(
           'Add an ocean',
           game.board.getAvailableSpacesForOcean(this), (space) => {
-            game.addOceanTile(this, space.id, SpaceType.OCEAN);
+            game.addOceanTile(this, space.id);
             game.log('${0} acted as World Government and placed an ocean', (b) => b.player(this));
             return undefined;
           },
@@ -1434,7 +1433,7 @@ export class Player {
           'Select space for greenery',
           this.game.board.getAvailableSpacesForGreenery(this), (space) => {
             // Do not raise oxygen or award TR for final greenery placements
-            this.game.addGreenery(this, space.id, SpaceType.LAND, false);
+            this.game.addGreenery(this, space.id, false);
             this.deductResource(Resources.PLANTS, this.plantsNeededForGreenery);
 
             this.takeActionForFinalGreenery();

--- a/src/server/behavior/Behavior.ts
+++ b/src/server/behavior/Behavior.ts
@@ -7,7 +7,6 @@ import {Tag} from '../../common/cards/Tag';
 // import {CardResource} from '../../common/CardResource';
 // import {TileType} from '../../common/TileType';
 import {SpaceId} from '../../common/Types';
-import {SpaceType} from '../../common/boards/SpaceType';
 import {MoonSpaces} from '../../common/moon/MoonSpaces';
 import {TileType} from '../../common/TileType';
 import {NoAttributes} from './NoAttributes';
@@ -42,7 +41,7 @@ export interface Behavior {
     venus?: 3 | 2 | 1 | -1;
   },
 
-  city?: {space?: SpaceId, type?: SpaceType},
+  city?: {space?: SpaceId},
   /** Places a greenery tile and also raises the oxygen. */
   greenery?: NoAttributes,
   ocean?: NoAttributes,

--- a/src/server/behavior/Executor.ts
+++ b/src/server/behavior/Executor.ts
@@ -172,7 +172,7 @@ export class Executor implements BehaviorExecutor {
     }
     if (behavior.city !== undefined) {
       if (behavior.city.space !== undefined) {
-        player.game.addCityTile(player, behavior.city.space, behavior.city.type);
+        player.game.addCityTile(player, behavior.city.space);
       } else {
         player.game.defer(new PlaceCityTile(player));
       }

--- a/src/server/cards/ares/BiofertilizerFacility.ts
+++ b/src/server/cards/ares/BiofertilizerFacility.ts
@@ -5,7 +5,6 @@ import {ISpace} from '../../boards/ISpace';
 import {Player} from '../../Player';
 import {CardResource} from '../../../common/CardResource';
 import {SpaceBonus} from '../../../common/boards/SpaceBonus';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {TileType} from '../../../common/TileType';
 import {CardType} from '../../../common/cards/CardType';
 import {IProjectCard} from '../IProjectCard';
@@ -47,7 +46,7 @@ export class BiofertilizerFacility extends Card implements IProjectCard {
       'Select space for Biofertilizer Facility tile',
       player.game.board.getAvailableSpacesOnLand(player),
       (space: ISpace) => {
-        player.game.addTile(player, SpaceType.LAND, space, {
+        player.game.addTile(player, space, {
           tileType: TileType.BIOFERTILIZER_FACILITY,
           card: this.name,
         });

--- a/src/server/cards/ares/MetallicAsteroid.ts
+++ b/src/server/cards/ares/MetallicAsteroid.ts
@@ -4,7 +4,6 @@ import {SelectSpace} from '../../inputs/SelectSpace';
 import {ISpace} from '../../boards/ISpace';
 import {Player} from '../../Player';
 import {SpaceBonus} from '../../../common/boards/SpaceBonus';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {TileType} from '../../../common/TileType';
 import {CardType} from '../../../common/cards/CardType';
 import {IProjectCard} from '../IProjectCard';
@@ -39,7 +38,7 @@ export class MetallicAsteroid extends Card implements IProjectCard {
   }
   public override bespokePlay(player: Player) {
     return new SelectSpace('Select space for Metallic Asteroid tile', player.game.board.getAvailableSpacesOnLand(player), (space: ISpace) => {
-      player.game.addTile(player, SpaceType.LAND, space, {
+      player.game.addTile(player, space, {
         tileType: TileType.METALLIC_ASTEROID,
         card: this.name,
       });

--- a/src/server/cards/ares/OceanCity.ts
+++ b/src/server/cards/ares/OceanCity.ts
@@ -46,7 +46,7 @@ export class OceanCity extends Card implements IProjectCard {
           card: this.name,
           covers: space.tile,
         };
-        player.game.addTile(player, space.spaceType, space, tile);
+        player.game.addTile(player, space, tile);
         return undefined;
       },
     );

--- a/src/server/cards/ares/OceanFarm.ts
+++ b/src/server/cards/ares/OceanFarm.ts
@@ -47,7 +47,7 @@ export class OceanFarm extends Card implements IProjectCard {
           card: this.name,
           covers: space.tile,
         };
-        player.game.addTile(player, space.spaceType, space, tile);
+        player.game.addTile(player, space, tile);
         space.adjacency = {bonus: [SpaceBonus.PLANT]};
         return undefined;
       },

--- a/src/server/cards/ares/OceanSanctuary.ts
+++ b/src/server/cards/ares/OceanSanctuary.ts
@@ -49,7 +49,7 @@ export class OceanSanctuary extends Card implements IProjectCard {
           card: this.name,
           covers: space.tile,
         };
-        player.game.addTile(player, space.spaceType, space, tile);
+        player.game.addTile(player, space, tile);
         space.adjacency = {bonus: [SpaceBonus.ANIMAL]};
         return undefined;
       });

--- a/src/server/cards/ares/SolarFarm.ts
+++ b/src/server/cards/ares/SolarFarm.ts
@@ -5,7 +5,6 @@ import {ISpace} from '../../boards/ISpace';
 import {Player} from '../../Player';
 import {Resources} from '../../../common/Resources';
 import {SpaceBonus} from '../../../common/boards/SpaceBonus';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {TileType} from '../../../common/TileType';
 import {CardType} from '../../../common/cards/CardType';
 import {IProjectCard} from '../IProjectCard';
@@ -50,7 +49,7 @@ export class SolarFarm extends Card implements IProjectCard {
       'Select space for Solar Farm tile',
       player.game.board.getAvailableSpacesOnLand(player),
       (space: ISpace) => {
-        player.game.addTile(player, SpaceType.LAND, space, {
+        player.game.addTile(player, space, {
           tileType: TileType.SOLAR_FARM,
           card: this.name,
         });

--- a/src/server/cards/base/ArtificialLake.ts
+++ b/src/server/cards/base/ArtificialLake.ts
@@ -5,7 +5,6 @@ import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {ISpace} from '../../boards/ISpace';
 import {SelectSpace} from '../../inputs/SelectSpace';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
@@ -38,7 +37,7 @@ export class ArtificialLake extends Card implements IProjectCard {
     if (!player.game.canAddOcean()) return undefined;
 
     return new SelectSpace('Select a land space to place an ocean', player.game.board.getAvailableSpacesOnLand(player), (space: ISpace) => {
-      player.game.addOceanTile(player, space.id, SpaceType.LAND);
+      player.game.addOceanTile(player, space.id);
       return undefined;
     });
   }

--- a/src/server/cards/base/Capital.ts
+++ b/src/server/cards/base/Capital.ts
@@ -5,7 +5,6 @@ import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {TileType} from '../../../common/TileType';
 import {SelectSpace} from '../../inputs/SelectSpace';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../../common/cards/CardName';
 import {AdjacencyBonus} from '../../ares/AdjacencyBonus';
@@ -67,7 +66,7 @@ export class Capital extends Card implements IProjectCard {
       'Select space for special city tile',
       player.game.board.getAvailableSpacesForCity(player),
       (space: ISpace) => {
-        player.game.addTile(player, SpaceType.LAND, space, {
+        player.game.addTile(player, space, {
           tileType: TileType.CAPITAL,
           card: this.name,
         });

--- a/src/server/cards/base/CommercialDistrict.ts
+++ b/src/server/cards/base/CommercialDistrict.ts
@@ -62,7 +62,7 @@ export class CommercialDistrict extends Card implements IProjectCard {
       'Select space for special tile',
       player.game.board.getAvailableSpacesOnLand(player),
       (space: ISpace) => {
-        player.game.addTile(player, space.spaceType, space, {
+        player.game.addTile(player, space, {
           tileType: TileType.COMMERCIAL_DISTRICT,
           card: this.name,
         });

--- a/src/server/cards/base/EcologicalZone.ts
+++ b/src/server/cards/base/EcologicalZone.ts
@@ -72,7 +72,7 @@ export class EcologicalZone extends Card implements IProjectCard {
       'Select space next to greenery for special tile',
       this.getAvailableSpaces(player),
       (requestedSpace: ISpace) => {
-        player.game.addTile(player, requestedSpace.spaceType, requestedSpace, {
+        player.game.addTile(player, requestedSpace, {
           tileType: TileType.ECOLOGICAL_ZONE,
         });
         requestedSpace.adjacency = this.adjacencyBonus;

--- a/src/server/cards/base/GanymedeColony.ts
+++ b/src/server/cards/base/GanymedeColony.ts
@@ -4,7 +4,6 @@ import {Card} from '../Card';
 import {VictoryPoints} from '../ICard';
 import {CardType} from '../../../common/cards/CardType';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
@@ -18,7 +17,7 @@ export class GanymedeColony extends Card implements IProjectCard {
 
       victoryPoints: VictoryPoints.tags(Tag.JOVIAN, 1, 1),
       behavior: {
-        city: {space: SpaceName.GANYMEDE_COLONY, type: SpaceType.COLONY},
+        city: {space: SpaceName.GANYMEDE_COLONY},
       },
 
       metadata: {

--- a/src/server/cards/base/IndustrialCenter.ts
+++ b/src/server/cards/base/IndustrialCenter.ts
@@ -48,7 +48,7 @@ export class IndustrialCenter extends Card implements IActionCard, IProjectCard 
   }
   public override bespokePlay(player: Player) {
     return new SelectSpace('Select space adjacent to a city tile', this.getAvailableSpaces(player), (space: ISpace) => {
-      player.game.addTile(player, space.spaceType, space, {tileType: TileType.INDUSTRIAL_CENTER});
+      player.game.addTile(player, space, {tileType: TileType.INDUSTRIAL_CENTER});
       space.adjacency = this.adjacencyBonus;
       return undefined;
     });

--- a/src/server/cards/base/LavaFlows.ts
+++ b/src/server/cards/base/LavaFlows.ts
@@ -1,7 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {Player} from '../../Player';
 import {TileType} from '../../../common/TileType';
 import {ISpace} from '../../boards/ISpace';
@@ -49,7 +48,7 @@ export class LavaFlows extends Card implements IProjectCard {
   public override bespokePlay(player: Player) {
     player.game.increaseTemperature(player, 2);
     return new SelectSpace('Select either Tharsis Tholus, Ascraeus Mons, Pavonis Mons or Arsia Mons', LavaFlows.getVolcanicSpaces(player), (space: ISpace) => {
-      player.game.addTile(player, SpaceType.LAND, space, {tileType: TileType.LAVA_FLOWS});
+      player.game.addTile(player, space, {tileType: TileType.LAVA_FLOWS});
       space.adjacency = this.adjacencyBonus;
       return undefined;
     });

--- a/src/server/cards/base/Mangrove.ts
+++ b/src/server/cards/base/Mangrove.ts
@@ -4,7 +4,6 @@ import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SelectSpace} from '../../inputs/SelectSpace';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
@@ -32,7 +31,7 @@ export class Mangrove extends Card implements IProjectCard {
 
   public override bespokePlay(player: Player) {
     return new SelectSpace('Select ocean space for greenery tile', player.game.board.getAvailableSpacesForOcean(player), (space: ISpace) => {
-      return player.game.addGreenery(player, space.id, SpaceType.OCEAN);
+      return player.game.addGreenery(player, space.id);
     });
   }
 }

--- a/src/server/cards/base/MiningCard.ts
+++ b/src/server/cards/base/MiningCard.ts
@@ -87,7 +87,7 @@ export abstract class MiningCard extends Card implements IProjectCard {
           player.production.add(resource, 1, {log: true});
           this.bonusResource = [resource];
           const spaceBonus = resource === Resources.TITANIUM ? SpaceBonus.TITANIUM : SpaceBonus.STEEL;
-          player.game.addTile(player, space.spaceType, space, {tileType: this.getTileType(spaceBonus)});
+          player.game.addTile(player, space, {tileType: this.getTileType(spaceBonus)});
           space.adjacency = this.getAdjacencyBonus(spaceBonus);
         },
       ));

--- a/src/server/cards/base/MoholeArea.ts
+++ b/src/server/cards/base/MoholeArea.ts
@@ -2,7 +2,6 @@ import {TileType} from '../../../common/TileType';
 import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {IProjectCard} from '../IProjectCard';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {Player} from '../../Player';
 import {Tag} from '../../../common/cards/Tag';
 import {SelectSpace} from '../../inputs/SelectSpace';
@@ -40,7 +39,7 @@ export class MoholeArea extends Card implements IProjectCard {
 
   public override bespokePlay(player: Player) {
     return new SelectSpace('Select an ocean space for special tile', player.game.board.getAvailableSpacesForOcean(player), (space: ISpace) => {
-      player.game.addTile(player, SpaceType.OCEAN, space, {tileType: TileType.MOHOLE_AREA});
+      player.game.addTile(player, space, {tileType: TileType.MOHOLE_AREA});
       space.adjacency = this.adjacencyBonus;
       return undefined;
     });

--- a/src/server/cards/base/NaturalPreserve.ts
+++ b/src/server/cards/base/NaturalPreserve.ts
@@ -49,7 +49,7 @@ export class NaturalPreserve extends Card implements IProjectCard {
   }
   public override bespokePlay(player: Player) {
     return new SelectSpace('Select space for special tile next to no other tile', this.getAvailableSpaces(player), (space: ISpace) => {
-      player.game.addTile(player, space.spaceType, space, {tileType: TileType.NATURAL_PRESERVE});
+      player.game.addTile(player, space, {tileType: TileType.NATURAL_PRESERVE});
       space.adjacency = this.adjacencyBonus;
       return undefined;
     });

--- a/src/server/cards/base/NuclearZone.ts
+++ b/src/server/cards/base/NuclearZone.ts
@@ -41,7 +41,7 @@ export class NuclearZone extends Card implements IProjectCard {
   public override bespokePlay(player: Player) {
     player.game.increaseTemperature(player, 2);
     return new SelectSpace('Select space for special tile', player.game.board.getAvailableSpacesOnLand(player), (space: ISpace) => {
-      player.game.addTile(player, space.spaceType, space, {tileType: TileType.NUCLEAR_ZONE});
+      player.game.addTile(player, space, {tileType: TileType.NUCLEAR_ZONE});
       space.adjacency = this.adjacencyBonus;
       return undefined;
     });

--- a/src/server/cards/base/PhobosSpaceHaven.ts
+++ b/src/server/cards/base/PhobosSpaceHaven.ts
@@ -3,7 +3,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
@@ -18,7 +17,7 @@ export class PhobosSpaceHaven extends Card implements IProjectCard {
 
       behavior: {
         production: {titanium: 1},
-        city: {space: SpaceName.PHOBOS_SPACE_HAVEN, type: SpaceType.COLONY},
+        city: {space: SpaceName.PHOBOS_SPACE_HAVEN},
       },
 
       metadata: {

--- a/src/server/cards/base/ProtectedValley.ts
+++ b/src/server/cards/base/ProtectedValley.ts
@@ -2,7 +2,6 @@ import {IProjectCard} from '../IProjectCard';
 import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {Tag} from '../../../common/cards/Tag';
 import {SelectSpace} from '../../inputs/SelectSpace';
 import {ISpace} from '../../boards/ISpace';
@@ -38,7 +37,7 @@ export class ProtectedValley extends Card implements IProjectCard {
       'Select space reserved for ocean to place greenery tile',
       player.game.board.getAvailableSpacesForOcean(player),
       (space: ISpace) => {
-        return player.game.addGreenery(player, space.id, SpaceType.OCEAN);
+        return player.game.addGreenery(player, space.id);
       },
     );
   }

--- a/src/server/cards/base/RestrictedArea.ts
+++ b/src/server/cards/base/RestrictedArea.ts
@@ -41,7 +41,7 @@ export class RestrictedArea extends Card implements IActionCard, IProjectCard {
   }
   public override bespokePlay(player: Player) {
     return new SelectSpace('Select space for tile', player.game.board.getAvailableSpacesOnLand(player), (space: ISpace) => {
-      player.game.addTile(player, space.spaceType, space, {tileType: TileType.RESTRICTED_AREA});
+      player.game.addTile(player, space, {tileType: TileType.RESTRICTED_AREA});
       space.adjacency = this.adjacencyBonus;
       return undefined;
     });

--- a/src/server/cards/pathfinders/CeresSpaceport.ts
+++ b/src/server/cards/pathfinders/CeresSpaceport.ts
@@ -3,7 +3,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {played} from '../Options';
@@ -20,7 +19,7 @@ export class CeresSpaceport extends Card implements IProjectCard {
       behavior: {
         drawCard: 1,
         ocean: {},
-        city: {space: SpaceName.CERES_SPACEPORT, type: SpaceType.COLONY},
+        city: {space: SpaceName.CERES_SPACEPORT},
         production: {megacredits: 2, titanium: {tag: Tag.JOVIAN, per: 2}},
       },
 

--- a/src/server/cards/pathfinders/DysonScreens.ts
+++ b/src/server/cards/pathfinders/DysonScreens.ts
@@ -10,7 +10,6 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Resources} from '../../../common/Resources';
 import {IActionCard} from '../ICard';
 import {digit} from '../Options';
-import {SpaceType} from '../../../common/boards/SpaceType';
 
 export class DysonScreens extends Card implements IProjectCard, IActionCard {
   constructor() {
@@ -25,7 +24,7 @@ export class DysonScreens extends Card implements IProjectCard, IActionCard {
         production: {energy: 2, heat: 2},
         drawCard: 1,
         global: {temperature: 1},
-        city: {space: SpaceName.DYSON_SCREENS, type: SpaceType.COLONY},
+        city: {space: SpaceName.DYSON_SCREENS},
       },
 
       metadata: {

--- a/src/server/cards/pathfinders/LunarEmbassy.ts
+++ b/src/server/cards/pathfinders/LunarEmbassy.ts
@@ -3,7 +3,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {played} from '../Options';
@@ -19,7 +18,7 @@ export class LunarEmbassy extends Card implements IProjectCard {
 
       behavior: {
         drawCard: 1,
-        city: {space: SpaceName.LUNAR_EMBASSY, type: SpaceType.COLONY},
+        city: {space: SpaceName.LUNAR_EMBASSY},
         production: {megacredits: 3, plants: {tag: Tag.EARTH, per: 2}},
       },
 

--- a/src/server/cards/pathfinders/NewVenice.ts
+++ b/src/server/cards/pathfinders/NewVenice.ts
@@ -54,7 +54,7 @@ export class NewVenice extends Card implements IProjectCard {
           card: this.name,
           covers: space.tile,
         };
-        player.game.addTile(player, space.spaceType, space, tile);
+        player.game.addTile(player, space, tile);
         return undefined;
       },
     );

--- a/src/server/cards/pathfinders/RedCity.ts
+++ b/src/server/cards/pathfinders/RedCity.ts
@@ -53,7 +53,7 @@ export class RedCity extends Card implements IProjectCard {
 
   public override bespokePlay(player: Player) {
     return new SelectSpace('Select space for Red City', this.availableRedCitySpaces(player), (space) => {
-      player.game.addTile(player, space.spaceType, space, {tileType: TileType.RED_CITY, card: this.name});
+      player.game.addTile(player, space, {tileType: TileType.RED_CITY, card: this.name});
       return undefined;
     });
   }

--- a/src/server/cards/pathfinders/SmallComet.ts
+++ b/src/server/cards/pathfinders/SmallComet.ts
@@ -7,7 +7,6 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Resources} from '../../../common/Resources';
 import {Tag} from '../../../common/cards/Tag';
 import {SelectSpace} from '../../inputs/SelectSpace';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {ISpace} from '../../boards/ISpace';
 import {all} from '../Options';
 
@@ -48,7 +47,7 @@ export class SmallComet extends Card implements IProjectCard {
     });
     if (player.game.canAddOcean()) {
       return new SelectSpace('Select a land space to place an ocean', player.game.board.getAvailableSpacesOnLand(player), (space: ISpace) => {
-        player.game.addOceanTile(player, space.id, SpaceType.LAND);
+        player.game.addOceanTile(player, space.id);
         return undefined;
       });
     }

--- a/src/server/cards/pathfinders/VeneraBase.ts
+++ b/src/server/cards/pathfinders/VeneraBase.ts
@@ -11,7 +11,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardRequirements} from '../CardRequirements';
 import {PartyName} from '../../../common/turmoil/PartyName';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 
 export class VeneraBase extends Card implements IProjectCard, IActionCard {
   constructor() {
@@ -26,7 +25,7 @@ export class VeneraBase extends Card implements IProjectCard, IActionCard {
 
       behavior: {
         production: {megacredits: 3},
-        city: {space: SpaceName.VENERA_BASE, type: SpaceType.COLONY},
+        city: {space: SpaceName.VENERA_BASE},
       },
 
       metadata: {

--- a/src/server/cards/pathfinders/Wetlands.ts
+++ b/src/server/cards/pathfinders/Wetlands.ts
@@ -74,7 +74,7 @@ export class Wetlands extends Card implements IProjectCard {
           card: this.name,
           covers: space.tile,
         };
-        player.game.addTile(player, space.spaceType, space, tile);
+        player.game.addTile(player, space, tile);
         player.game.increaseOxygenLevel(player, 1);
         return undefined;
       },

--- a/src/server/cards/promo/DeimosDownPromo.ts
+++ b/src/server/cards/promo/DeimosDownPromo.ts
@@ -44,7 +44,7 @@ export class DeimosDownPromo extends Card implements IProjectCard {
     const availableSpaces = player.game.board.getAvailableSpacesForCity(player);
 
     return new SelectSpace('Select space for tile', availableSpaces, (space: ISpace) => {
-      player.game.addTile(player, space.spaceType, space, {tileType: TileType.DEIMOS_DOWN});
+      player.game.addTile(player, space, {tileType: TileType.DEIMOS_DOWN});
       return undefined;
     });
   }

--- a/src/server/cards/promo/GreatDamPromo.ts
+++ b/src/server/cards/promo/GreatDamPromo.ts
@@ -45,7 +45,7 @@ export class GreatDamPromo extends Card implements IProjectCard {
     if (availableSpaces.length < 1) return undefined;
 
     return new SelectSpace('Select space for tile', availableSpaces, (space: ISpace) => {
-      player.game.addTile(player, space.spaceType, space, {tileType: TileType.GREAT_DAM});
+      player.game.addTile(player, space, {tileType: TileType.GREAT_DAM});
       return undefined;
     });
   }

--- a/src/server/cards/promo/MagneticFieldGeneratorsPromo.ts
+++ b/src/server/cards/promo/MagneticFieldGeneratorsPromo.ts
@@ -44,7 +44,7 @@ export class MagneticFieldGeneratorsPromo extends Card implements IProjectCard {
     if (availableSpaces.length < 1) return undefined;
 
     return new SelectSpace('Select space for tile', availableSpaces, (space: ISpace) => {
-      player.game.addTile(player, space.spaceType, space, {tileType: TileType.MAGNETIC_FIELD_GENERATORS});
+      player.game.addTile(player, space, {tileType: TileType.MAGNETIC_FIELD_GENERATORS});
       return undefined;
     });
   }

--- a/src/server/cards/promo/StanfordTorus.ts
+++ b/src/server/cards/promo/StanfordTorus.ts
@@ -3,7 +3,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
@@ -17,7 +16,7 @@ export class StanfordTorus extends Card implements IProjectCard {
       victoryPoints: 2,
 
       behavior: {
-        city: {space: SpaceName.STANFORD_TORUS, type: SpaceType.COLONY},
+        city: {space: SpaceName.STANFORD_TORUS},
       },
 
       metadata: {

--- a/src/server/cards/venusNext/DawnCity.ts
+++ b/src/server/cards/venusNext/DawnCity.ts
@@ -1,7 +1,6 @@
 import {Tag} from '../../../common/cards/Tag';
 import {CardType} from '../../../common/cards/CardType';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
@@ -20,7 +19,7 @@ export class DawnCity extends Card implements IProjectCard {
       victoryPoints: 3,
       behavior: {
         production: {energy: -1, titanium: 1},
-        city: {space: SpaceName.DAWN_CITY, type: SpaceType.COLONY},
+        city: {space: SpaceName.DAWN_CITY},
       },
 
       metadata: {

--- a/src/server/cards/venusNext/LunaMetropolis.ts
+++ b/src/server/cards/venusNext/LunaMetropolis.ts
@@ -1,7 +1,6 @@
 import {Tag} from '../../../common/cards/Tag';
 import {CardType} from '../../../common/cards/CardType';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Card} from '../Card';
@@ -19,7 +18,7 @@ export class LunaMetropolis extends Card implements IProjectCard {
       victoryPoints: 2,
       behavior: {
         production: {megacredits: {tag: Tag.EARTH}},
-        city: {space: SpaceName.LUNA_METROPOLIS, type: SpaceType.COLONY},
+        city: {space: SpaceName.LUNA_METROPOLIS},
       },
 
       metadata: {

--- a/src/server/cards/venusNext/MaxwellBase.ts
+++ b/src/server/cards/venusNext/MaxwellBase.ts
@@ -2,7 +2,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {IActionCard, ICard} from '../ICard';
 import {SelectCard} from '../../inputs/SelectCard';
 import {CardName} from '../../../common/cards/CardName';
@@ -22,7 +21,7 @@ export class MaxwellBase extends Card implements IActionCard {
       victoryPoints: 3,
       behavior: {
         production: {energy: -1},
-        city: {space: SpaceName.MAXWELL_BASE, type: SpaceType.COLONY},
+        city: {space: SpaceName.MAXWELL_BASE},
       },
 
       metadata: {

--- a/src/server/cards/venusNext/Stratopolis.ts
+++ b/src/server/cards/venusNext/Stratopolis.ts
@@ -2,7 +2,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardType} from '../../../common/cards/CardType';
 import {Player} from '../../Player';
 import {SpaceName} from '../../SpaceName';
-import {SpaceType} from '../../../common/boards/SpaceType';
 import {IActionCard, ICard} from '../ICard';
 import {CardResource} from '../../../common/CardResource';
 import {SelectCard} from '../../inputs/SelectCard';
@@ -26,7 +25,7 @@ export class Stratopolis extends Card implements IActionCard {
 
       behavior: {
         production: {megacredits: 2},
-        city: {space: SpaceName.STRATOPOLIS, type: SpaceType.COLONY},
+        city: {space: SpaceName.STRATOPOLIS},
       },
 
       metadata: {

--- a/src/server/deferredActions/PlaceOceanTile.ts
+++ b/src/server/deferredActions/PlaceOceanTile.ts
@@ -1,7 +1,6 @@
 import {Player} from '../Player';
 import {SelectSpace} from '../inputs/SelectSpace';
 import {ISpace} from '../boards/ISpace';
-import {SpaceType} from '../../common/boards/SpaceType';
 import {DeferredAction, Priority} from './DeferredAction';
 
 export class PlaceOceanTile extends DeferredAction {
@@ -21,7 +20,7 @@ export class PlaceOceanTile extends DeferredAction {
       this.title,
       this.player.game.board.getAvailableSpacesForOcean(this.player),
       (space: ISpace) => {
-        this.player.game.addOceanTile(this.player, space.id, SpaceType.OCEAN);
+        this.player.game.addOceanTile(this.player, space.id);
         return undefined;
       },
     );

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -698,7 +698,7 @@ describe('Game', () => {
     expect(player.plants).eq(0);
     expect(player.titanium).eq(0);
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.GREENERY});
+    game.addTile(player, space, {tileType: TileType.GREENERY});
 
     expect(player.cardsInHand).has.length(4);
     expect(player.plants).eq(1);

--- a/tests/ares/AresHandler.spec.ts
+++ b/tests/ares/AresHandler.spec.ts
@@ -44,7 +44,7 @@ describe('AresHandler', function() {
   it('Get adjacency bonus', function() {
     const firstSpace = game.board.getAvailableSpacesOnLand(player)[0];
     firstSpace.adjacency = {bonus: [SpaceBonus.DRAW_CARD]};
-    game.addTile(otherPlayer, SpaceType.LAND, firstSpace, {tileType: TileType.RESTRICTED_AREA});
+    game.addTile(otherPlayer, firstSpace, {tileType: TileType.RESTRICTED_AREA});
 
     player.megaCredits = 0;
     player.cardsInHand = [];
@@ -52,7 +52,7 @@ describe('AresHandler', function() {
     otherPlayer.cardsInHand = [];
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
 
     // player who placed next to Restricted area gets a card, but no money.
     expect(player.megaCredits).is.eq(0);
@@ -128,13 +128,13 @@ describe('AresHandler', function() {
   it('Pay Adjacency Costs', function() {
     const firstSpace = game.board.getAvailableSpacesOnLand(player)[0];
     firstSpace.adjacency = {bonus: [], cost: 2};
-    game.addTile(otherPlayer, SpaceType.LAND, firstSpace, {tileType: TileType.NUCLEAR_ZONE});
+    game.addTile(otherPlayer, firstSpace, {tileType: TileType.NUCLEAR_ZONE});
 
     player.megaCredits = 2;
     otherPlayer.megaCredits = 0;
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
     game.deferredActions.peek()!.execute();
 
     // player who placed next to Nuclear zone, loses two money.
@@ -147,14 +147,14 @@ describe('AresHandler', function() {
   it('Can\'t afford adjacency costs', function() {
     const firstSpace = game.board.getAvailableSpacesOnLand(player)[0];
     firstSpace.adjacency = {bonus: [], cost: 2};
-    game.addTile(otherPlayer, SpaceType.LAND, firstSpace, {tileType: TileType.NUCLEAR_ZONE});
+    game.addTile(otherPlayer, firstSpace, {tileType: TileType.NUCLEAR_ZONE});
 
     otherPlayer.megaCredits = 0;
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
 
     expect(() => {
-      game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+      game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
     }).to.throw(/Placing here costs 2 M€/);
   });
 
@@ -167,11 +167,11 @@ describe('AresHandler', function() {
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
     expect(() => {
-      game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+      game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
     }).to.throw(/Placing here costs 1 units of production/);
 
     player.production.add(Resources.PLANTS, 7);
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
     runAllActions(game);
     const input = cast(player.getWaitingFor(), SelectProductionToLose);
     expect(input.unitsToLose).eq(1);
@@ -188,13 +188,13 @@ describe('AresHandler', function() {
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
     try {
-      game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+      game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
     } catch (err) {
       expect((err as any).toString()).includes('Placing here costs 2 units of production');
     }
 
     player.production.add(Resources.PLANTS, 7);
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
 
     runAllActions(game);
     const input = cast(player.getWaitingFor(), SelectProductionToLose);
@@ -210,7 +210,7 @@ describe('AresHandler', function() {
     const before = player.production.asUnits();
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.OCEAN});
+    game.addTile(player, adjacentSpace, {tileType: TileType.OCEAN});
     expect(game.deferredActions.peek()).is.undefined;
 
     const after = player.production.asUnits();
@@ -223,7 +223,7 @@ describe('AresHandler', function() {
     player.megaCredits = 8;
     expect(player.getTerraformRating()).eq(20);
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.GREENERY});
+    game.addTile(player, space, {tileType: TileType.GREENERY});
     game.deferredActions.peek()!.execute();
 
     expect(space.tile!.tileType).eq(TileType.GREENERY);
@@ -237,7 +237,7 @@ describe('AresHandler', function() {
     player.megaCredits = 16;
     expect(player.getTerraformRating()).eq(20);
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.GREENERY});
+    game.addTile(player, space, {tileType: TileType.GREENERY});
     game.deferredActions.peek()!.execute();
 
     expect(space.tile!.tileType).eq(TileType.GREENERY);
@@ -398,7 +398,7 @@ describe('AresHandler', function() {
 
     game.addOceanTile(otherPlayer, spaceId);
     // Placing an Ocean City on top of the ocean will not grant player plants.
-    game.addTile(player, SpaceType.OCEAN, space, {tileType: TileType.OCEAN_CITY});
+    game.addTile(player, space, {tileType: TileType.OCEAN_CITY});
 
     expect(otherPlayer.plants).greaterThan(0);
     expect(player.plants).eq(0);
@@ -407,7 +407,7 @@ describe('AresHandler', function() {
   it('No adjacency bonuses during WGT', function() {
     const firstSpace = game.board.getAvailableSpacesOnLand(player)[0];
     firstSpace.adjacency = {bonus: [SpaceBonus.DRAW_CARD]};
-    game.addTile(otherPlayer, SpaceType.LAND, firstSpace, {tileType: TileType.RESTRICTED_AREA});
+    game.addTile(otherPlayer, firstSpace, {tileType: TileType.RESTRICTED_AREA});
     game.phase = Phase.SOLAR;
 
     player.megaCredits = 0;
@@ -416,7 +416,7 @@ describe('AresHandler', function() {
     otherPlayer.cardsInHand = [];
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
 
     // Neither player gets money or a card.
     expect(player.megaCredits).is.eq(0);
@@ -428,14 +428,14 @@ describe('AresHandler', function() {
   it('No adjacency costs during WGT', function() {
     const firstSpace = game.board.getAvailableSpacesOnLand(player)[0];
     firstSpace.adjacency = {bonus: [], cost: 2};
-    game.addTile(otherPlayer, SpaceType.LAND, firstSpace, {tileType: TileType.NUCLEAR_ZONE});
+    game.addTile(otherPlayer, firstSpace, {tileType: TileType.NUCLEAR_ZONE});
     game.phase = Phase.SOLAR;
 
     player.megaCredits = 2;
     otherPlayer.megaCredits = 0;
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
 
     // player who placed next to Nuclear zone, loses nothing.
     expect(player.megaCredits).is.eq(2);
@@ -447,7 +447,7 @@ describe('AresHandler', function() {
     game.phase = Phase.SOLAR;
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
 
     // Not asking you which production to lose.
     expect(game.deferredActions).has.lengthOf(0);
@@ -460,7 +460,7 @@ describe('AresHandler', function() {
     expect(player.getTerraformRating()).eq(20);
     game.phase = Phase.SOLAR;
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.GREENERY});
+    game.addTile(player, space, {tileType: TileType.GREENERY});
 
     expect(space.tile!.tileType).eq(TileType.GREENERY);
 

--- a/tests/ares/AresTestHelper.ts
+++ b/tests/ares/AresTestHelper.ts
@@ -36,11 +36,11 @@ export class AresTestHelper {
     // tile types in this test are irrelevant.
     const firstSpace = player.game.board.getAvailableSpacesOnLand(player)[0];
     firstSpace.adjacency = {bonus: [bonus]};
-    player.game.addTile(player, SpaceType.LAND, firstSpace, {tileType: TileType.RESTRICTED_AREA});
+    player.game.addTile(player, firstSpace, {tileType: TileType.RESTRICTED_AREA});
 
     expect(player.getResource(Resources.MEGACREDITS)).is.eq(0);
     const adjacentSpace = player.game.board.getAdjacentSpaces(firstSpace)[0];
-    player.game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    player.game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
     expect(player.getResource(Resources.MEGACREDITS)).is.eq(expectedMc);
   }
 

--- a/tests/ares/OtherAresTests.spec.ts
+++ b/tests/ares/OtherAresTests.spec.ts
@@ -2,7 +2,6 @@ import {expect} from 'chai';
 import {DesertSettler} from '../../src/server/awards/DesertSettler';
 import {Game} from '../../src/server/Game';
 import {Player} from '../../src/server/Player';
-import {SpaceType} from '../../src/common/boards/SpaceType';
 import {TileType} from '../../src/common/TileType';
 import {TestPlayer} from '../TestPlayer';
 import {ARES_OPTIONS_NO_HAZARDS} from './AresTestHelper';
@@ -27,7 +26,7 @@ describe('OtherAresTests', function() {
     const award = new DesertSettler();
     expect(award.getScore(player)).eq(0);
 
-    game.addTile(player, SpaceType.OCEAN, oceanSpace, {tileType: TileType.OCEAN_CITY});
+    game.addTile(player, oceanSpace, {tileType: TileType.OCEAN_CITY});
 
     expect(award.getScore(player)).eq(1);
   });

--- a/tests/awards/EstateDealer.spec.ts
+++ b/tests/awards/EstateDealer.spec.ts
@@ -1,7 +1,6 @@
 import {expect} from 'chai';
 import {Game} from '../../src/server/Game';
 import {EstateDealer} from '../../src/server/awards/EstateDealer';
-import {SpaceType} from '../../src/common/boards/SpaceType';
 import {TileType} from '../../src/common/TileType';
 import {TestPlayer} from '../TestPlayer';
 
@@ -19,7 +18,7 @@ describe('EstateDealer', function() {
     game.addGreenery(player, '35');
     expect(award.getScore(player)).to.eq(1);
 
-    game.addGreenery(player2, '28', SpaceType.OCEAN); // Greenery on ocean space
+    game.addGreenery(player2, '28'); // Greenery on ocean space
     expect(award.getScore(player)).to.eq(1);
 
     // This tile should not count
@@ -42,7 +41,7 @@ describe('EstateDealer', function() {
     game.addGreenery(player, '35');
     expect(award.getScore(player)).to.eq(1);
 
-    game.addGreenery(player2, '28', SpaceType.OCEAN); // Greenery on ocean space
+    game.addGreenery(player2, '28'); // Greenery on ocean space
     expect(award.getScore(player)).to.eq(1);
 
     // This tile should not count

--- a/tests/behavior/Countable.spec.ts
+++ b/tests/behavior/Countable.spec.ts
@@ -9,7 +9,6 @@ import {IProjectCard} from '../../src/server/cards/IProjectCard';
 import {Units} from '../../src/common/Units';
 import {MoonExpansion} from '../../src/server/moon/MoonExpansion';
 import {SpaceName} from '../../src/server/SpaceName';
-import {SpaceType} from '../../src/common/boards/SpaceType';
 import {OceanCity} from '../../src/server/cards/ares/OceanCity';
 import {SelectSpace} from '../../src/server/inputs/SelectSpace';
 import {Wetlands} from '../../src/server/cards/pathfinders/Wetlands';
@@ -103,7 +102,7 @@ describe('Counter', () => {
     }
     expect(count()).deep.eq({'': 0, 'onmars': 0, 'offmars': 0, 'everywhere': 0});
 
-    game.addCityTile(player, SpaceName.GANYMEDE_COLONY, SpaceType.COLONY);
+    game.addCityTile(player, SpaceName.GANYMEDE_COLONY);
 
     expect(count()).deep.eq({'': 1, 'onmars': 0, 'offmars': 1, 'everywhere': 1});
 
@@ -113,7 +112,7 @@ describe('Counter', () => {
 
     const oceanCity = new OceanCity();
     const oceanSpace = game.board.getAvailableSpacesForOcean(player)[0];
-    game.addOceanTile(player, oceanSpace.id, SpaceType.OCEAN);
+    game.addOceanTile(player, oceanSpace.id);
 
     expect(count()).deep.eq({'': 2, 'onmars': 1, 'offmars': 1, 'everywhere': 2});
 
@@ -131,19 +130,19 @@ describe('Counter', () => {
   it('count cities that you own', () => {
     const count = (player: TestPlayer) => new Counter(player, fake).count({cities: {}, all: false});
 
-    game.addCityTile(player, SpaceName.GANYMEDE_COLONY, SpaceType.COLONY);
+    game.addCityTile(player, SpaceName.GANYMEDE_COLONY);
 
     expect(count(player)).eq(1);
     expect(count(player2)).eq(0);
 
     const landSpace = game.board.getAvailableSpacesForCity(player)[0];
-    game.addCityTile(player, landSpace.id, SpaceType.LAND);
+    game.addCityTile(player, landSpace.id);
 
     expect(count(player)).eq(2);
     expect(count(player2)).eq(0);
 
     const landSpace2 = game.board.getAvailableSpacesForCity(player2)[0];
-    game.addCityTile(player2, landSpace2.id, SpaceType.LAND);
+    game.addCityTile(player2, landSpace2.id);
 
     expect(count(player)).eq(2);
     expect(count(player2)).eq(1);

--- a/tests/boards/ArabiaTerraBoard.spec.ts
+++ b/tests/boards/ArabiaTerraBoard.spec.ts
@@ -34,7 +34,7 @@ describe('ArabiaTerraBoard', function() {
     const availableSpaces = board.getAvailableSpacesForOcean(player);
 
     expect(availableSpaces).includes(coveSpace);
-    game.addTile(player, coveSpace.spaceType, coveSpace, {tileType: TileType.OCEAN});
+    game.addTile(player, coveSpace, {tileType: TileType.OCEAN});
 
     // No further assertions. addTile not throwing is enough.
   });
@@ -44,7 +44,7 @@ describe('ArabiaTerraBoard', function() {
     const availableSpaces = board.getAvailableSpacesForGreenery(player);
 
     expect(availableSpaces).includes(coveSpace);
-    game.addTile(player, coveSpace.spaceType, coveSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, coveSpace, {tileType: TileType.GREENERY});
 
     // No further assertions. addTile not throwing is enough.
   });
@@ -54,7 +54,7 @@ describe('ArabiaTerraBoard', function() {
     player.playedCards.push(card);
     const space = board.spaces.find((space) => space.bonus.includes(SpaceBonus.DATA))!;
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.CITY});
+    game.addTile(player, space, {tileType: TileType.CITY});
     runAllActions(game);
 
     // one map space has data, and it has two of them.
@@ -67,7 +67,7 @@ describe('ArabiaTerraBoard', function() {
     // one map space has science, and it has one of them.
     const space = board.spaces.find((space) => space.bonus.includes(SpaceBonus.SCIENCE))!;
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.CITY});
+    game.addTile(player, space, {tileType: TileType.CITY});
     runAllActions(game);
 
     expect(card.resourceCount).eq(1);
@@ -77,7 +77,7 @@ describe('ArabiaTerraBoard', function() {
     const space = board.spaces.find((space) => space.bonus.includes(SpaceBonus.ENERGY_PRODUCTION))!;
     expect(player.production.energy).eq(0);
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.CITY});
+    game.addTile(player, space, {tileType: TileType.CITY});
     runAllActions(game);
 
     expect(player.production.energy).eq(1);
@@ -89,7 +89,7 @@ describe('ArabiaTerraBoard', function() {
     // one map space has microbes, and it has two of them.
     const space = board.spaces.find((space) => space.bonus.includes(SpaceBonus.MICROBE))!;
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.CITY});
+    game.addTile(player, space, {tileType: TileType.CITY});
     runAllActions(game);
 
     expect(card.resourceCount).eq(2);

--- a/tests/boards/VastitasBorealisBoard.spec.ts
+++ b/tests/boards/VastitasBorealisBoard.spec.ts
@@ -33,7 +33,7 @@ describe('VastitasBorealisBoard', function() {
     expect(board.getAvailableSpacesOnLand(player).map((space) => space.id)).includes(SpaceName.VASTITAS_BOREALIS_NORTH_POLE);
     expect(game.getTemperature()).eq(-30);
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.CITY});
+    game.addTile(player, space, {tileType: TileType.CITY});
     runAllActions(game);
 
     expect(player.megaCredits).eq(0);

--- a/tests/cards/ares/EcologicalSurvey.spec.ts
+++ b/tests/cards/ares/EcologicalSurvey.spec.ts
@@ -79,7 +79,7 @@ describe('EcologicalSurvey', () => {
     animalCard.resourceCount = 0;
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
     runAllActions(game);
 
     expect(player.megaCredits).eq(2);
@@ -113,7 +113,7 @@ describe('EcologicalSurvey', () => {
       SpaceBonus.HEAT,
     ],
     player.playedCards = [card];
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.RESTRICTED_AREA});
+    game.addTile(player, space, {tileType: TileType.RESTRICTED_AREA});
 
     runAllActions(game);
 
@@ -149,7 +149,7 @@ describe('EcologicalSurvey', () => {
     game.board.spaces[5].bonus = [];
 
     player.plants = 0;
-    game.addTile(player, SpaceType.OCEAN, game.board.spaces[5], {tileType: TileType.OCEAN});
+    game.addTile(player, game.board.spaces[5], {tileType: TileType.OCEAN});
     runAllActions(game);
     expect(player.plants).eq(3);
   });
@@ -165,7 +165,7 @@ describe('EcologicalSurvey', () => {
 
     game.phase = Phase.SOLAR;
     player.plants = 0;
-    game.addTile(player, SpaceType.OCEAN, game.board.spaces[5], {tileType: TileType.OCEAN});
+    game.addTile(player, game.board.spaces[5], {tileType: TileType.OCEAN});
     runAllActions(game);
     expect(player.plants).eq(2);
   });
@@ -177,7 +177,7 @@ describe('EcologicalSurvey', () => {
     const space = game.board.getAvailableSpacesOnLand(player)[0];
     space.bonus = [SpaceBonus.MICROBE],
 
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.RESTRICTED_AREA});
+    game.addTile(player, space, {tileType: TileType.RESTRICTED_AREA});
     runAllActions(game);
 
     const msg = game.gameLog.pop()!;

--- a/tests/cards/ares/GeologicalSurvey.spec.ts
+++ b/tests/cards/ares/GeologicalSurvey.spec.ts
@@ -69,7 +69,7 @@ describe('GeologicalSurvey', () => {
       SpaceBonus.ENERGY,
     ],
     };
-    game.addTile(player, SpaceType.LAND, firstSpace, {tileType: TileType.RESTRICTED_AREA});
+    game.addTile(player, firstSpace, {tileType: TileType.RESTRICTED_AREA});
 
     const microbeCard = new Ants();
     const animalCard = new Pets();
@@ -88,7 +88,7 @@ describe('GeologicalSurvey', () => {
     animalCard.resourceCount = 0;
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(player, adjacentSpace, {tileType: TileType.GREENERY});
     runAllActions(game);
 
     expect(player.megaCredits).eq(2);
@@ -122,7 +122,7 @@ describe('GeologicalSurvey', () => {
       SpaceBonus.HEAT,
     ],
     player.playedCards = [card];
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.RESTRICTED_AREA});
+    game.addTile(player, space, {tileType: TileType.RESTRICTED_AREA});
 
     runAllActions(game);
 

--- a/tests/cards/ares/MarketingExperts.spec.ts
+++ b/tests/cards/ares/MarketingExperts.spec.ts
@@ -2,7 +2,6 @@ import {MarketingExperts} from '../../../src/server/cards/ares/MarketingExperts'
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
 import {expect} from 'chai';
-import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {TileType} from '../../../src/common/TileType';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
 import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
@@ -37,13 +36,13 @@ describe('MarketingExperts', function() {
 
     const firstSpace = game.board.getAvailableSpacesOnLand(player)[0];
     firstSpace.adjacency = {bonus: [SpaceBonus.DRAW_CARD]};
-    game.addTile(player, SpaceType.LAND, firstSpace, {tileType: TileType.RESTRICTED_AREA});
+    game.addTile(player, firstSpace, {tileType: TileType.RESTRICTED_AREA});
 
     expect(player.megaCredits).is.eq(0);
     expect(otherPlayer.megaCredits).is.eq(0);
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
-    game.addTile(otherPlayer, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace, {tileType: TileType.GREENERY});
 
     expect(player.megaCredits).is.eq(2);
     expect(otherPlayer.megaCredits).is.eq(0);

--- a/tests/cards/ares/MiningAreaAres.spec.ts
+++ b/tests/cards/ares/MiningAreaAres.spec.ts
@@ -28,7 +28,7 @@ describe('MiningAreaAres', function() {
         const adjacents = game.board.getAdjacentSpaces(land);
         for (const adjacent of adjacents) {
           if (adjacent.tile === undefined && adjacent.bonus.length === 0) {
-            game.addTile(player, adjacent.spaceType, adjacent, {tileType: TileType.MINING_AREA});
+            game.addTile(player, adjacent, {tileType: TileType.MINING_AREA});
           }
         }
       }

--- a/tests/cards/base/Capital.spec.ts
+++ b/tests/cards/base/Capital.spec.ts
@@ -64,7 +64,7 @@ describe('Capital', () => {
 
   it('Capital special tile counts as a city', () => {
     const space = game.board.getNthAvailableLandSpace(2, 1, player);
-    game.addTile(player, SpaceType.LAND, space, {
+    game.addTile(player, space, {
       tileType: TileType.CAPITAL,
       card: card.name,
     });

--- a/tests/cards/base/LavaFlows.spec.ts
+++ b/tests/cards/base/LavaFlows.spec.ts
@@ -3,7 +3,6 @@ import {LavaFlows} from '../../../src/server/cards/base/LavaFlows';
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
 import {SpaceName} from '../../../src/server/SpaceName';
-import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {TileType} from '../../../src/common/TileType';
 import {cast, resetBoard} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
@@ -25,9 +24,9 @@ describe('LavaFlows', function() {
   });
 
   it('Cannot play if no available spaces', function() {
-    game.addTile(player, SpaceType.LAND, game.board.getSpace(SpaceName.THARSIS_THOLUS), {tileType: TileType.LAVA_FLOWS});
-    game.addTile(player, SpaceType.LAND, game.board.getSpace(SpaceName.ARSIA_MONS), {tileType: TileType.LAVA_FLOWS});
-    game.addTile(player, SpaceType.LAND, game.board.getSpace(SpaceName.PAVONIS_MONS), {tileType: TileType.LAVA_FLOWS});
+    game.addTile(player, game.board.getSpace(SpaceName.THARSIS_THOLUS), {tileType: TileType.LAVA_FLOWS});
+    game.addTile(player, game.board.getSpace(SpaceName.ARSIA_MONS), {tileType: TileType.LAVA_FLOWS});
+    game.addTile(player, game.board.getSpace(SpaceName.PAVONIS_MONS), {tileType: TileType.LAVA_FLOWS});
 
     expect(card.canPlay(player)).is.true;
 

--- a/tests/cards/base/MartianRails.spec.ts
+++ b/tests/cards/base/MartianRails.spec.ts
@@ -3,7 +3,6 @@ import {MartianRails} from '../../../src/server/cards/base/MartianRails';
 import {Game} from '../../../src/server/Game';
 import {Player} from '../../../src/server/Player';
 import {SpaceName} from '../../../src/server/SpaceName';
-import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {TestPlayer} from '../../TestPlayer';
 
 describe('MartianRails', () => {
@@ -36,7 +35,7 @@ describe('MartianRails', () => {
   it('Ignores cities off Mars', () => {
     player.energy = 1;
     expect(card.canAct(player)).is.true;
-    game.addCityTile(player, SpaceName.GANYMEDE_COLONY, SpaceType.COLONY);
+    game.addCityTile(player, SpaceName.GANYMEDE_COLONY);
 
     card.action(player);
     expect(player.energy).to.eq(0);

--- a/tests/cards/base/MiningArea.spec.ts
+++ b/tests/cards/base/MiningArea.spec.ts
@@ -30,7 +30,7 @@ describe('MiningArea', function() {
         const adjacents = game.board.getAdjacentSpaces(land);
         for (const adjacent of adjacents) {
           if (adjacent.tile === undefined && adjacent.bonus.length === 0) {
-            game.addTile(player, adjacent.spaceType, adjacent, {tileType: TileType.MINING_AREA});
+            game.addTile(player, adjacent, {tileType: TileType.MINING_AREA});
           }
         }
       }

--- a/tests/cards/base/MiningRights.spec.ts
+++ b/tests/cards/base/MiningRights.spec.ts
@@ -28,7 +28,7 @@ describe('MiningRights', () => {
   it('Cannot play if no available spaces', () => {
     for (const land of game.board.getAvailableSpacesOnLand(player)) {
       if (land.bonus.includes(SpaceBonus.STEEL) || land.bonus.includes(SpaceBonus.TITANIUM)) {
-        game.addTile(player, land.spaceType, land, {tileType: TileType.MINING_RIGHTS});
+        game.addTile(player, land, {tileType: TileType.MINING_RIGHTS});
       }
     }
     expect(card.canPlay(player)).is.not.true;

--- a/tests/cards/base/NaturalPreserve.spec.ts
+++ b/tests/cards/base/NaturalPreserve.spec.ts
@@ -21,7 +21,7 @@ describe('NaturalPreserve', () => {
   it('Cannot play if no spaces available', () => {
     const lands = game.board.getAvailableSpacesOnLand(player);
     for (const land of lands) {
-      game.addTile(player, land.spaceType, land, {tileType: TileType.NATURAL_PRESERVE});
+      game.addTile(player, land, {tileType: TileType.NATURAL_PRESERVE});
     }
 
     expect(card.canPlay(player)).is.not.true;

--- a/tests/cards/corporation/TharsisRepublic.spec.ts
+++ b/tests/cards/corporation/TharsisRepublic.spec.ts
@@ -49,7 +49,7 @@ describe('TharsisRepublic', function() {
   });
 
   it('Does not give MC production for own city off Mars', function() {
-    game.addTile(player, SpaceType.COLONY, game.board.spaces.find((space) => space.spaceType === SpaceType.COLONY)!, {
+    game.addTile(player, game.board.spaces.find((space) => space.spaceType === SpaceType.COLONY)!, {
       tileType: TileType.CITY,
     });
     runAllActions(game);

--- a/tests/cards/pathfinders/GeologicalExpedition.spec.ts
+++ b/tests/cards/pathfinders/GeologicalExpedition.spec.ts
@@ -13,7 +13,6 @@ import {Units} from '../../../src/common/Units';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {SpaceName} from '../../../src/server/SpaceName';
 import {TileType} from '../../../src/common/TileType';
-import {SpaceType} from '../../../src/common/boards/SpaceType';
 
 describe('GeologicalExpedition', function() {
   let card: GeologicalExpedition;
@@ -45,7 +44,7 @@ describe('GeologicalExpedition', function() {
   });
 
   it('City tile on a space colony, no bonus', () => {
-    game.addCityTile(player, SpaceName.GANYMEDE_COLONY, SpaceType.COLONY);
+    game.addCityTile(player, SpaceName.GANYMEDE_COLONY);
 
     expect(game.board.getSpace(SpaceName.GANYMEDE_COLONY).tile?.tileType).eq(TileType.CITY);
 

--- a/tests/cards/pathfinders/MartianMonuments.spec.ts
+++ b/tests/cards/pathfinders/MartianMonuments.spec.ts
@@ -4,7 +4,6 @@ import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {addCity} from '../../TestingUtils';
 import {Units} from '../../../src/common/Units';
-import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {SpaceName} from '../../../src/server/SpaceName';
 
 describe('MartianMonuments', function() {
@@ -27,7 +26,7 @@ describe('MartianMonuments', function() {
     expect(player2.canPlayIgnoringCost(card)).is.false;
 
     // Add a city in space, it shouldn't count.
-    player.game.addCityTile(player2, SpaceName.GANYMEDE_COLONY, SpaceType.COLONY);
+    player.game.addCityTile(player2, SpaceName.GANYMEDE_COLONY);
     expect(player2.canPlayIgnoringCost(card)).is.false;
   });
 

--- a/tests/cards/pathfinders/SoylentSeedlingSystems.spec.ts
+++ b/tests/cards/pathfinders/SoylentSeedlingSystems.spec.ts
@@ -9,7 +9,6 @@ import {Tag} from '../../../src/common/cards/Tag';
 import {Celestic} from '../../../src/server/cards/venusNext/Celestic';
 import {GreeneryStandardProject} from '../../../src/server/cards/base/standardProjects/GreeneryStandardProject';
 import {TileType} from '../../../src/common/TileType';
-import {SpaceType} from '../../../src/common/boards/SpaceType';
 
 describe('SoylentSeedlingSystems', function() {
   let soylent: SoylentSeedlingSystems;
@@ -88,7 +87,6 @@ describe('SoylentSeedlingSystems', function() {
     expect(celestic.resourceCount).eq(0);
     player.game.addTile(
       player,
-      SpaceType.LAND,
       player.game.board.getAvailableSpacesOnLand(player)[0],
       {tileType: TileType.WETLANDS});
     expect(soylent.resourceCount).eq(1);

--- a/tests/cards/pathfinders/Steelaris.spec.ts
+++ b/tests/cards/pathfinders/Steelaris.spec.ts
@@ -63,7 +63,7 @@ describe('Steelaris', function() {
     expect(player.plants).eq(0);
     expect(player.steel).eq(0);
 
-    game.addTile(player, space.spaceType, space, {tileType: TileType.NUCLEAR_ZONE});
+    game.addTile(player, space, {tileType: TileType.NUCLEAR_ZONE});
     runAllActions(game);
 
     expect(player.plants).eq(1);
@@ -77,7 +77,7 @@ describe('Steelaris', function() {
     expect(player.plants).eq(0);
     expect(player.steel).eq(0);
 
-    game.addTile(player2, space.spaceType, space, {tileType: TileType.NUCLEAR_ZONE});
+    game.addTile(player2, space, {tileType: TileType.NUCLEAR_ZONE});
     runAllActions(game);
 
     expect(player.plants).eq(1);

--- a/tests/cards/pathfinders/Wetlands.spec.ts
+++ b/tests/cards/pathfinders/Wetlands.spec.ts
@@ -120,7 +120,7 @@ describe('Wetlands', function() {
     const spaces = game.board.getAvailableSpacesOnLand(player);
     // this is an awkward hack, but because this is using emptyboard, no spaces are dedicated for ocean.
     for (let idx = 0; idx <= 8; idx++) {
-      game.addOceanTile(player, spaces[idx].id, SpaceType.LAND);
+      game.addOceanTile(player, spaces[idx].id);
     }
     (game as any).temperature = MAX_TEMPERATURE;
     (game as any).oxygenLevel = MAX_OXYGEN_LEVEL;

--- a/tests/cards/prelude/LavaTubeSettlement.spec.ts
+++ b/tests/cards/prelude/LavaTubeSettlement.spec.ts
@@ -5,7 +5,6 @@ import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {Player} from '../../../src/server/Player';
 import {Resources} from '../../../src/common/Resources';
 import {SpaceName} from '../../../src/server/SpaceName';
-import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {TileType} from '../../../src/common/TileType';
 import {cast, resetBoard} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
@@ -28,9 +27,9 @@ describe('LavaTubeSettlement', function() {
 
   it('Cannot play if no volcanic spaces left', function() {
     player.production.add(Resources.ENERGY, 1);
-    game.addTile(player, SpaceType.LAND, game.board.getSpace(SpaceName.THARSIS_THOLUS), {tileType: TileType.LAVA_FLOWS});
-    game.addTile(player, SpaceType.LAND, game.board.getSpace(SpaceName.ARSIA_MONS), {tileType: TileType.LAVA_FLOWS});
-    game.addTile(player, SpaceType.LAND, game.board.getSpace(SpaceName.PAVONIS_MONS), {tileType: TileType.LAVA_FLOWS});
+    game.addTile(player, game.board.getSpace(SpaceName.THARSIS_THOLUS), {tileType: TileType.LAVA_FLOWS});
+    game.addTile(player, game.board.getSpace(SpaceName.ARSIA_MONS), {tileType: TileType.LAVA_FLOWS});
+    game.addTile(player, game.board.getSpace(SpaceName.PAVONIS_MONS), {tileType: TileType.LAVA_FLOWS});
 
     const anotherPlayer = TestPlayer.RED.newPlayer();
     game.board.getSpace(SpaceName.ASCRAEUS_MONS).player = anotherPlayer; // land claim

--- a/tests/cards/promo/Philares.spec.ts
+++ b/tests/cards/promo/Philares.spec.ts
@@ -37,53 +37,53 @@ describe('Philares', () => {
   });
 
   it('No bonus when placing next to self', () => {
-    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
   });
 
   it('bonus when placing next to opponent', () => {
-    game.addTile(otherPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
   });
 
   it('bonus when opponent places next to you', () => {
-    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
   });
 
   it('placing ocean tile does not grant bonus', () => {
-    game.addTile(otherPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
     adjacentSpace.spaceType = SpaceType.OCEAN; // Make this space an ocean space.
-    game.addTile(philaresPlayer, SpaceType.OCEAN, adjacentSpace, {tileType: TileType.OCEAN});
+    game.addTile(philaresPlayer, adjacentSpace, {tileType: TileType.OCEAN});
     expect(game.deferredActions).has.length(0);
   });
 
   it('ocean tile next to yours does not grant bonus', () => {
     space.spaceType = SpaceType.OCEAN; // Make this space an ocean space.
-    game.addTile(otherPlayer, SpaceType.OCEAN, space, {tileType: TileType.OCEAN});
+    game.addTile(otherPlayer, space, {tileType: TileType.OCEAN});
     expect(game.deferredActions).has.length(0);
-    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
   });
 
   it('No adjacency bonus during WGT', () => {
-    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
     game.phase = Phase.SOLAR;
-    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
   });
 
   it('one tile one bonus', () => {
-    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
-    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
     const options = cast(action?.execute(), AndOptions);
     // Options are ordered 0-5, MC to heat.
@@ -94,8 +94,8 @@ describe('Philares', () => {
   });
 
   it('one tile one bonus - player is greedy', () => {
-    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
-    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
     const options = cast(action?.execute(), AndOptions);
     // Options are ordered 0-5, MC to heat.
@@ -106,10 +106,10 @@ describe('Philares', () => {
   });
 
   it('Multiple bonuses when placing next to multiple tiles', () => {
-    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
-    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace2, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
     const action = game.deferredActions.pop();
     const options = cast(action?.execute(), AndOptions);
@@ -122,10 +122,10 @@ describe('Philares', () => {
   });
 
   it('Multiple bonuses when opponent places next to multiple of your tiles', () => {
-    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
-    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, adjacentSpace2, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(otherPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
     const action = game.deferredActions.pop();
     const options = cast(action?.execute(), AndOptions);
@@ -138,9 +138,9 @@ describe('Philares', () => {
   });
 
   it('two tiles two bonuses - player is greedy', () => {
-    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
-    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
-    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, adjacentSpace2, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, space, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
     const options = cast(action?.execute(), AndOptions);
     // Options are ordered 0-5, MC to heat.

--- a/tests/globalEvents/MudSlides.spec.ts
+++ b/tests/globalEvents/MudSlides.spec.ts
@@ -64,7 +64,7 @@ describe('MudSlides', function() {
       covers: spaces.second.tile,
     };
     game.gameOptions.aresExtension = true;
-    player.game.addTile(player, spaces.second.spaceType, spaces.second, tile);
+    player.game.addTile(player, spaces.second, tile);
 
     player.megaCredits = 10;
 

--- a/tests/turmoil/parties/Greens.spec.ts
+++ b/tests/turmoil/parties/Greens.spec.ts
@@ -57,7 +57,7 @@ describe('Greens', function() {
     setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[1].id);
 
     const emptySpace: ISpace = game.board.spaces.find((space) => space.spaceType === SpaceType.LAND && space.bonus.length === 0) as ISpace;
-    game.addTile(player, emptySpace.spaceType, emptySpace, {tileType: TileType.NATURAL_PRESERVE});
+    game.addTile(player, emptySpace, {tileType: TileType.NATURAL_PRESERVE});
     expect(player.plants).to.eq(1);
   });
 

--- a/tests/turmoil/parties/Kelvinists.spec.ts
+++ b/tests/turmoil/parties/Kelvinists.spec.ts
@@ -103,7 +103,7 @@ describe('Kelvinists', function() {
     setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, KELVINISTS_POLICY_4.id);
 
     const emptySpace: ISpace = game.board.spaces.find((space) => space.bonus.length === 0) as ISpace;
-    game.addTile(player, emptySpace.spaceType, emptySpace, {tileType: TileType.CITY});
+    game.addTile(player, emptySpace, {tileType: TileType.CITY});
     expect(player.heat).to.eq(2);
   });
 });


### PR DESCRIPTION
spaceType is probably generally useful when confirming that a tile goes on its designated space. But that is managed quite well by the host card, based on the rules it has for placement.