### PR TITLE
Remove problematic reduced brigness in inputs

### DIFF
--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -101,13 +101,11 @@
 input[type="checkbox"] + .filterDiv.card-container,
 input[type="radio"] + .filterDiv.card-container {
     margin-top: 22px;
-    filter: brightness(0.65);
 }
 
 input[type="checkbox"]:checked + .filterDiv,
 input[type="radio"]:checked + .filterDiv {
     box-shadow: 0 0 0 1px #303030, 0 0 7px 10px #c97e23;
-    filter: none;
 }
 
 input[type="checkbox"]:checked + .filterDiv::after,


### PR DESCRIPTION
Remove reduced brightness from unselected cards. Selected cards slightly less distinguishable. I think it is either this or full roll back to old visualization.

![no_brightness_reduced](https://user-images.githubusercontent.com/26537065/197349806-f2c975c6-6acb-4ffe-bc5f-45c692bdcf26.png)

Fixes the problems escpecillay with in initial card selection. 

![init](https://user-images.githubusercontent.com/26537065/197350561-541a547b-7716-4d15-ade6-fa2289878a4f.png)

