### PR TITLE
Add Merger Variant (twoCorpsVariant)

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -997,6 +997,25 @@ export default (Vue as WithRefs<Refs>).extend({
         }
       }
 
+      // Check custom corp. count
+      if (customCorporations.length > 0) {
+        if (!this.twoCorpsVariant)
+          let neededCorpsCount = players.length * startingCorporations;
+          if (this.prelude && this.promoCardsOption) neededCorpsCount += 4;
+        } else {
+          // Add an additional 4 for the Merger prelude
+          // Everyone-Merger needs an additional 4 corps per player
+          //  NB: This will not cover the case when no custom corp list is set!
+          //  It _can_ come about if  the number of corps included in all expansions is still not enough.
+          let neededCorpsCount = (players.length * startingCorporations) + (players.length * 4);
+        }
+
+        if (customCorporations.length < neededCorpsCount) {
+          window.alert(translateTextWithParams('Must select more corporations (${0}/${0})', [customCorporations.length, neededCorpsCount.toString()]));
+          return;
+        }
+      }
+
       if (players.length === 1 && corporateEra === false) {
         const confirm = window.confirm(translateText(
           'We do not recommend playing a solo game without the Corporate Era. Press OK if you want to play without it.'));

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -999,15 +999,16 @@ export default (Vue as WithRefs<Refs>).extend({
 
       // Check custom corp. count
       if (customCorporations.length > 0) {
+        let neededCorpsCount = 0
         if (!this.twoCorpsVariant) {
-          let neededCorpsCount = players.length * startingCorporations;
+          neededCorpsCount = players.length * startingCorporations;
           if (this.prelude && this.promoCardsOption) neededCorpsCount += 4;
         } else {
           // Add an additional 4 for the Merger prelude
           // Everyone-Merger needs an additional 4 corps per player
           //  NB: This will not cover the case when no custom corp list is set!
           //  It _can_ come about if  the number of corps included in all expansions is still not enough.
-          let neededCorpsCount = (players.length * startingCorporations) + (players.length * 4);
+          neededCorpsCount = (players.length * startingCorporations) + (players.length * 4);
         }
 
         if (customCorporations.length < neededCorpsCount) {

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -258,8 +258,24 @@
                         </div>
 
                         <div class="create-game-page-column" v-if="playersCount > 1">
+
                             <h4 v-i18n>Multiplayer Options</h4>
 
+                            <input type="checkbox" v-model="randomFirstPlayer" id="randomFirstPlayer-checkbox">
+                            <label for="randomFirstPlayer-checkbox">
+                                <span v-i18n>Random first player</span>
+                            </label>
+
+                            <input type="checkbox" name="showOtherPlayersVP" v-model="showOtherPlayersVP" id="realTimeVP-checkbox">
+                            <label for="realTimeVP-checkbox">
+                                <span v-i18n>Show real-time VP</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#show-real-time-vp" class="tooltip" target="_blank">&#9432;</a>
+                            </label>
+
+                            <input type="checkbox" v-model="fastModeOption" id="fastMode-checkbox">
+                            <label for="fastMode-checkbox">
+                                <span v-i18n>Fast mode</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#fast-mode" class="tooltip" target="_blank">&#9432;</a>
+                            </label>
+                            <div class="create-game-subsection-label" v-i18n>Drafting</div>
                             <div class="create-game-page-column-row">
                                 <div>
                                 <input type="checkbox" name="draftVariant" v-model="draftVariant" id="draft-checkbox">
@@ -279,11 +295,8 @@
                             <label for="corporationsDraft-checkbox">
                                 <span v-i18n>Corporations Draft</span>
                             </label>
-                            <input type="checkbox" v-model="randomFirstPlayer" id="randomFirstPlayer-checkbox">
-                            <label for="randomFirstPlayer-checkbox">
-                                <span v-i18n>Random first player</span>
-                            </label>
 
+                            <div class="create-game-subsection-label" v-i18n>Milestones/Awards</div>
                             <input type="checkbox" name="randomMAToggle" id="randomMA-checkbox" v-on:change="randomMAToggle()">
                             <label for="randomMA-checkbox">
                                 <span v-i18n>Random Milestones/Awards</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#random-milestones-and-awards" class="tooltip" target="_blank">&#9432;</a>
@@ -323,15 +336,19 @@
                               </label>
                             </template>
 
-                            <input type="checkbox" name="showOtherPlayersVP" v-model="showOtherPlayersVP" id="realTimeVP-checkbox">
-                            <label for="realTimeVP-checkbox">
-                                <span v-i18n>Show real-time VP</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#show-real-time-vp" class="tooltip" target="_blank">&#9432;</a>
-                            </label>
+                            <div class="create-game-subsection-label" v-i18n>Multiplayer Variants</div>
 
-                            <input type="checkbox" v-model="fastModeOption" id="fastMode-checkbox">
-                            <label for="fastMode-checkbox">
-                                <span v-i18n>Fast mode</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#fast-mode" class="tooltip" target="_blank">&#9432;</a>
-                            </label>
+                            <template v-if="prelude">
+                              <input type="checkbox" v-model="twoCorpsVariant" id="twoCorps-checkbox">
+                              <!-- We really need a warning here if there arent enough corps for everyone in the game.
+                                  eg: pCount * (startingCorporations+4) > 'Number of Corps in all activated Expansions' - 'Excluded Corps'
+                              -->
+                              <label for="twoCorps-checkbox" title="Always gain the Merger Prelude card (will be given post-draft)">
+                                    <div class="create-game-expansion-icon expansion-icon-prelude"></div>
+                                    <span v-i18n>Merger</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#Merger" class="tooltip" target="_blank">&#9432;</a>
+                              </label>
+                            </template>
+
                         </div>
 
                         <div class="create-game-players-cont">
@@ -523,6 +540,7 @@ export interface CreateGameModel {
     escapeVelocityThreshold: number;
     escapeVelocityPeriod: number;
     escapeVelocityPenalty: number;
+    twoCorpsVariant: boolean;
 }
 
 type Refs = {
@@ -610,6 +628,7 @@ export default (Vue as WithRefs<Refs>).extend({
       escapeVelocityThreshold: constants.DEFAULT_ESCAPE_VELOCITY_THRESHOLD,
       escapeVelocityPeriod: constants.DEFAULT_ESCAPE_VELOCITY_PERIOD,
       escapeVelocityPenalty: constants.DEFAULT_ESCAPE_VELOCITY_PENALTY,
+      twoCorpsVariant: false,
     };
   },
   components: {
@@ -959,6 +978,7 @@ export default (Vue as WithRefs<Refs>).extend({
       const escapeVelocityThreshold = component.escapeVelocityMode ? component.escapeVelocityThreshold : undefined;
       const escapeVelocityPeriod = component.escapeVelocityMode ? component.escapeVelocityPeriod : undefined;
       const escapeVelocityPenalty = component.escapeVelocityMode ? component.escapeVelocityPenalty : undefined;
+      const twoCorpsVariant = component.twoCorpsVariant;
       let clonedGamedId: undefined | GameId = undefined;
 
       // Check custom colony count
@@ -1109,6 +1129,7 @@ export default (Vue as WithRefs<Refs>).extend({
         escapeVelocityThreshold,
         escapeVelocityPeriod,
         escapeVelocityPenalty,
+        twoCorpsVariant,
       };
       return JSON.stringify(dataToSend, undefined, 4);
     },

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -999,7 +999,7 @@ export default (Vue as WithRefs<Refs>).extend({
 
       // Check custom corp. count
       if (customCorporations.length > 0) {
-        if (!this.twoCorpsVariant)
+        if (!this.twoCorpsVariant) {
           let neededCorpsCount = players.length * startingCorporations;
           if (this.prelude && this.promoCardsOption) neededCorpsCount += 4;
         } else {

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -997,26 +997,6 @@ export default (Vue as WithRefs<Refs>).extend({
         }
       }
 
-      // Check custom corp. count
-      if (customCorporations.length > 0) {
-        let neededCorpsCount = 0
-        if (!this.twoCorpsVariant) {
-          neededCorpsCount = players.length * startingCorporations;
-          if (this.prelude && this.promoCardsOption) neededCorpsCount += 4;
-        } else {
-          // Add an additional 4 for the Merger prelude
-          // Everyone-Merger needs an additional 4 corps per player
-          //  NB: This will not cover the case when no custom corp list is set!
-          //  It _can_ come about if  the number of corps included in all expansions is still not enough.
-          neededCorpsCount = (players.length * startingCorporations) + (players.length * 4);
-        }
-
-        if (customCorporations.length < neededCorpsCount) {
-          window.alert(translateTextWithParams('Must select more corporations (${0}/${0})', [customCorporations.length.toString(), neededCorpsCount.toString()]));
-          return;
-        }
-      }
-
       if (players.length === 1 && corporateEra === false) {
         const confirm = window.confirm(translateText(
           'We do not recommend playing a solo game without the Corporate Era. Press OK if you want to play without it.'));
@@ -1025,7 +1005,18 @@ export default (Vue as WithRefs<Refs>).extend({
 
       // Check custom corp count
       if (component.showCorporationList && customCorporations.length > 0) {
-        const neededCorpsCount = players.length * startingCorporations;
+        let neededCorpsCount = 0
+        if (this.twoCorpsVariant) {
+          // Add an additional 4 for the Merger prelude
+          // Everyone-Merger needs an additional 4 corps per player
+          //  NB: This will not cover the case when no custom corp list is set!
+          //  It _can_ come about if  the number of corps included in all expansions is still not enough.
+          neededCorpsCount = (players.length * startingCorporations) + (players.length * 4);
+        } else {
+          neededCorpsCount = players.length * startingCorporations;
+          // Merger Prelude alone needs 4 additional preludes
+          if (this.prelude && this.promoCardsOption) neededCorpsCount += 4;
+        }
         if (customCorporations.length < neededCorpsCount) {
           window.alert(translateTextWithParams('Must select at least ${0} corporations', [neededCorpsCount.toString()]));
           return;

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -1012,7 +1012,7 @@ export default (Vue as WithRefs<Refs>).extend({
         }
 
         if (customCorporations.length < neededCorpsCount) {
-          window.alert(translateTextWithParams('Must select more corporations (${0}/${0})', [customCorporations.length, neededCorpsCount.toString()]));
+          window.alert(translateTextWithParams('Must select more corporations (${0}/${0})', [customCorporations.length.toString(), neededCorpsCount.toString()]));
           return;
         }
       }

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -208,6 +208,14 @@
                               <span v-i18n>min</span>
                             </label>
 
+                            <template v-if="prelude">
+                              <input type="checkbox" v-model="twoCorpsVariant" id="twoCorps-checkbox">
+                              <label for="twoCorps-checkbox" title="Always gain the Merger Prelude card (will be given post-draft)">
+                                    <div class="create-game-expansion-icon expansion-icon-prelude"></div>
+                                    <span v-i18n>Merger</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#Merger" class="tooltip" target="_blank">&#9432;</a>
+                              </label>
+                            </template>
+
                             <input type="checkbox" v-model="shuffleMapOption" id="shuffleMap-checkbox">
                             <label for="shuffleMap-checkbox">
                                     <span v-i18n>Randomize board tiles</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#randomize-board-tiles" class="tooltip" target="_blank">&#9432;</a>
@@ -332,14 +340,6 @@
                             <label for="fastMode-checkbox">
                                 <span v-i18n>Fast mode</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#fast-mode" class="tooltip" target="_blank">&#9432;</a>
                             </label>
-
-                            <template v-if="prelude">
-                              <input type="checkbox" v-model="twoCorpsVariant" id="twoCorps-checkbox">
-                              <label for="twoCorps-checkbox" title="Always gain the Merger Prelude card (will be given post-draft)">
-                                    <div class="create-game-expansion-icon expansion-icon-prelude"></div>
-                                    <span v-i18n>Merger</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#Merger" class="tooltip" target="_blank">&#9432;</a>
-                              </label>
-                            </template>
                         </div>
 
                         <div class="create-game-players-cont">

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -996,7 +996,7 @@ export default (Vue as WithRefs<Refs>).extend({
 
       // Check custom corp count
       if (component.showCorporationList && customCorporations.length > 0) {
-        let neededCorpsCount = 0
+        let neededCorpsCount = 0;
         if (this.twoCorpsVariant) {
           // Add an additional 4 for the Merger prelude
           // Everyone-Merger needs an additional 4 corps per player

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -258,24 +258,8 @@
                         </div>
 
                         <div class="create-game-page-column" v-if="playersCount > 1">
-
                             <h4 v-i18n>Multiplayer Options</h4>
 
-                            <input type="checkbox" v-model="randomFirstPlayer" id="randomFirstPlayer-checkbox">
-                            <label for="randomFirstPlayer-checkbox">
-                                <span v-i18n>Random first player</span>
-                            </label>
-
-                            <input type="checkbox" name="showOtherPlayersVP" v-model="showOtherPlayersVP" id="realTimeVP-checkbox">
-                            <label for="realTimeVP-checkbox">
-                                <span v-i18n>Show real-time VP</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#show-real-time-vp" class="tooltip" target="_blank">&#9432;</a>
-                            </label>
-
-                            <input type="checkbox" v-model="fastModeOption" id="fastMode-checkbox">
-                            <label for="fastMode-checkbox">
-                                <span v-i18n>Fast mode</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#fast-mode" class="tooltip" target="_blank">&#9432;</a>
-                            </label>
-                            <div class="create-game-subsection-label" v-i18n>Drafting</div>
                             <div class="create-game-page-column-row">
                                 <div>
                                 <input type="checkbox" name="draftVariant" v-model="draftVariant" id="draft-checkbox">
@@ -295,8 +279,11 @@
                             <label for="corporationsDraft-checkbox">
                                 <span v-i18n>Corporations Draft</span>
                             </label>
+                            <input type="checkbox" v-model="randomFirstPlayer" id="randomFirstPlayer-checkbox">
+                            <label for="randomFirstPlayer-checkbox">
+                                <span v-i18n>Random first player</span>
+                            </label>
 
-                            <div class="create-game-subsection-label" v-i18n>Milestones/Awards</div>
                             <input type="checkbox" name="randomMAToggle" id="randomMA-checkbox" v-on:change="randomMAToggle()">
                             <label for="randomMA-checkbox">
                                 <span v-i18n>Random Milestones/Awards</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#random-milestones-and-awards" class="tooltip" target="_blank">&#9432;</a>
@@ -336,19 +323,23 @@
                               </label>
                             </template>
 
-                            <div class="create-game-subsection-label" v-i18n>Multiplayer Variants</div>
+                            <input type="checkbox" name="showOtherPlayersVP" v-model="showOtherPlayersVP" id="realTimeVP-checkbox">
+                            <label for="realTimeVP-checkbox">
+                                <span v-i18n>Show real-time VP</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#show-real-time-vp" class="tooltip" target="_blank">&#9432;</a>
+                            </label>
+
+                            <input type="checkbox" v-model="fastModeOption" id="fastMode-checkbox">
+                            <label for="fastMode-checkbox">
+                                <span v-i18n>Fast mode</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#fast-mode" class="tooltip" target="_blank">&#9432;</a>
+                            </label>
 
                             <template v-if="prelude">
                               <input type="checkbox" v-model="twoCorpsVariant" id="twoCorps-checkbox">
-                              <!-- We really need a warning here if there arent enough corps for everyone in the game.
-                                  eg: pCount * (startingCorporations+4) > 'Number of Corps in all activated Expansions' - 'Excluded Corps'
-                              -->
                               <label for="twoCorps-checkbox" title="Always gain the Merger Prelude card (will be given post-draft)">
                                     <div class="create-game-expansion-icon expansion-icon-prelude"></div>
                                     <span v-i18n>Merger</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#Merger" class="tooltip" target="_blank">&#9432;</a>
                               </label>
                             </template>
-
                         </div>
 
                         <div class="create-game-players-cont">

--- a/src/common/game/NewGameConfig.ts
+++ b/src/common/game/NewGameConfig.ts
@@ -76,4 +76,5 @@ export interface NewGameConfig {
   escapeVelocityThreshold: number | undefined;
   escapeVelocityPeriod: number | undefined;
   escapeVelocityPenalty: number | undefined;
+  twoCorpsVariant: boolean,
 }

--- a/src/common/models/GameOptionsModel.ts
+++ b/src/common/models/GameOptionsModel.ts
@@ -38,4 +38,5 @@ export type GameOptionsModel = {
   turmoilExtension: boolean,
   venusNextExtension: boolean,
   undoOption: boolean,
+  twoCorpsVariant: boolean,
 }

--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -623,7 +623,7 @@ export class Game implements Logger {
 
   private gotoInitialResearchPhase(): void {
     this.phase = Phase.RESEARCH;
-    
+
     // As each player who doesn't have Merger is dealt Merger in SelectInitialCards.ts,
     // remove it from the deck to avoid possible conflicts (e.g. Valley Trust / New Partner)
     if (this.gameOptions.twoCorpsVariant) {

--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -623,7 +623,15 @@ export class Game implements Logger {
 
   private gotoInitialResearchPhase(): void {
     this.phase = Phase.RESEARCH;
+    
+    // As each player who doesn't have Merger is dealt Merger in SelectInitialCards.ts,
+    // remove it from the deck to avoid possible conflicts (e.g. Valley Trust / New Partner)
+    if (this.gameOptions.twoCorpsVariant) {
+      this.preludeDeck.drawPile = this.preludeDeck.drawPile.filter((c) => c.name !== CardName.MERGER);
+    }
+
     this.save();
+
     for (const player of this.players) {
       if (player.pickedCorporationCard === undefined && player.dealtCorporationCards.length > 0) {
         player.setWaitingFor(this.pickCorporationCard(player));

--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -624,12 +624,6 @@ export class Game implements Logger {
   private gotoInitialResearchPhase(): void {
     this.phase = Phase.RESEARCH;
 
-    // As each player who doesn't have Merger is dealt Merger in SelectInitialCards.ts,
-    // remove it from the deck to avoid possible conflicts (e.g. Valley Trust / New Partner)
-    if (this.gameOptions.twoCorpsVariant) {
-      this.preludeDeck.drawPile = this.preludeDeck.drawPile.filter((c) => c.name !== CardName.MERGER);
-    }
-
     this.save();
 
     for (const player of this.players) {

--- a/src/server/GameCards.ts
+++ b/src/server/GameCards.ts
@@ -106,7 +106,7 @@ export class GameCards {
     if (preludes.length === 0) {
       preludes = this.instantiate(PRELUDE_CARD_MANIFEST.preludeCards);
     }
-    preludes = this.addCustomCards(preludes, this.gameOptions.customPreludes);\
+    preludes = this.addCustomCards(preludes, this.gameOptions.customPreludes);
 
     if (this.gameOptions.twoCorpsVariant) {
       // As each player who doesn't have Merger is dealt Merger in SelectInitialCards.ts,

--- a/src/server/GameCards.ts
+++ b/src/server/GameCards.ts
@@ -106,7 +106,15 @@ export class GameCards {
     if (preludes.length === 0) {
       preludes = this.instantiate(PRELUDE_CARD_MANIFEST.preludeCards);
     }
-    return this.addCustomCards(preludes, this.gameOptions.customPreludes);
+    preludes = this.addCustomCards(preludes, this.gameOptions.customPreludes);\
+
+    if (this.gameOptions.twoCorpsVariant) {
+      // As each player who doesn't have Merger is dealt Merger in SelectInitialCards.ts,
+      // remove it from the deck to avoid possible conflicts (e.g. Valley Trust / New Partner)
+      preludes = preludes.filter((c) => c.name !== CardName.MERGER);
+    }
+
+    return preludes
   }
 
   private addCustomCards<T extends ICard>(cards: Array<T>, customList: Array<CardName> = []): Array<T> {

--- a/src/server/GameCards.ts
+++ b/src/server/GameCards.ts
@@ -114,7 +114,7 @@ export class GameCards {
       preludes = preludes.filter((c) => c.name !== CardName.MERGER);
     }
 
-    return preludes
+    return preludes;
   }
 
   private addCustomCards<T extends ICard>(cards: Array<T>, customList: Array<CardName> = []): Array<T> {

--- a/src/server/GameOptions.ts
+++ b/src/server/GameOptions.ts
@@ -54,6 +54,7 @@ export type GameOptions = {
   escapeVelocityThreshold?: number;
   escapeVelocityPeriod?: number;
   escapeVelocityPenalty?: number;
+  twoCorpsVariant: boolean;
 }
 
 export const DEFAULT_GAME_OPTIONS: GameOptions = {
@@ -98,4 +99,5 @@ export const DEFAULT_GAME_OPTIONS: GameOptions = {
   turmoilExtension: false,
   undoOption: false,
   venusNextExtension: false,
+  twoCorpsVariant: false,
 };

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -902,15 +902,9 @@ export class Player {
       cards = passedCards;
     }
 
-    let tmpmsg = cardsToKeep === 1 ?
+    const message = cardsToKeep === 1 ?
       'Select a card to keep and pass the rest to ${0}' :
       'Select two cards to keep and pass the rest to ${0}';
-
-    if (this.game.gameOptions.twoCorpsVariant) {
-      tmpmsg = tmpmsg.concat(' (an additional Merger Prelude will be drawn at the end of all drafting)');
-    }
-
-    const message = tmpmsg;
 
     this.setWaitingFor(
       new SelectCard({

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -902,9 +902,15 @@ export class Player {
       cards = passedCards;
     }
 
-    const message = cardsToKeep === 1 ?
+    let tmpmsg = cardsToKeep === 1 ?
       'Select a card to keep and pass the rest to ${0}' :
       'Select two cards to keep and pass the rest to ${0}';
+    
+    if (this.game.gameOptions.twoCorpsVariant) {
+      tmpmsg = tmpmsg.concat(' (an additional Merger Prelude will be drawn at the end of all drafting)')
+    }
+
+    const message = tmpmsg
 
     this.setWaitingFor(
       new SelectCard({

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -905,12 +905,12 @@ export class Player {
     let tmpmsg = cardsToKeep === 1 ?
       'Select a card to keep and pass the rest to ${0}' :
       'Select two cards to keep and pass the rest to ${0}';
-    
+
     if (this.game.gameOptions.twoCorpsVariant) {
-      tmpmsg = tmpmsg.concat(' (an additional Merger Prelude will be drawn at the end of all drafting)')
+      tmpmsg = tmpmsg.concat(' (an additional Merger Prelude will be drawn at the end of all drafting)');
     }
 
-    const message = tmpmsg
+    const message = tmpmsg;
 
     this.setWaitingFor(
       new SelectCard({

--- a/src/server/inputs/SelectInitialCards.ts
+++ b/src/server/inputs/SelectInitialCards.ts
@@ -34,14 +34,9 @@ export class SelectInitialCards extends AndOptions implements PlayerInput {
       ),
     );
 
-    // Give each player Merger in this variant, or an extra prelude if they already have Merger
+    // Give each player Merger in this variant
     if (player.game.gameOptions.twoCorpsVariant) {
-      if (!player.dealtPreludeCards.some((card) => card.name === CardName.MERGER)) {
-        player.dealtPreludeCards.push(new Merger());
-      } else {
-        // player.dealtPreludeCards.push(player.game.dealer.dealPreludeCard());
-        player.dealtPreludeCards.push(player.game.preludeDeck.draw(player.game));
-      }
+      player.dealtPreludeCards.push(new Merger());
     }
 
     if (player.game.gameOptions.preludeExtension) {

--- a/src/server/inputs/SelectInitialCards.ts
+++ b/src/server/inputs/SelectInitialCards.ts
@@ -7,8 +7,6 @@ import {PlayerInput} from '../PlayerInput';
 import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {SelectCard} from './SelectCard';
 import {Merger} from '../cards/promo/Merger';
-import {CardName} from '../../common/cards/CardName';
-
 
 export class SelectInitialCards extends AndOptions implements PlayerInput {
   public override inputType = PlayerInputType.SELECT_INITIAL_CARDS;

--- a/src/server/inputs/SelectInitialCards.ts
+++ b/src/server/inputs/SelectInitialCards.ts
@@ -6,6 +6,9 @@ import {Player} from '../Player';
 import {PlayerInput} from '../PlayerInput';
 import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {SelectCard} from './SelectCard';
+import {Merger} from '../cards/promo/Merger';
+import {CardName} from '../../common/cards/CardName';
+
 
 export class SelectInitialCards extends AndOptions implements PlayerInput {
   public override inputType = PlayerInputType.SELECT_INITIAL_CARDS;
@@ -30,6 +33,16 @@ export class SelectInitialCards extends AndOptions implements PlayerInput {
         }, {min: 1, max: 1},
       ),
     );
+
+    // Give each player Merger in this variant, or an extra prelude if they already have Merger
+    if (player.game.gameOptions.twoCorpsVariant) {
+      if (!player.dealtPreludeCards.some((card) => card.name === CardName.MERGER)) {
+        player.dealtPreludeCards.push(new Merger());
+      } else {
+        // player.dealtPreludeCards.push(player.game.dealer.dealPreludeCard());
+        player.dealtPreludeCards.push(player.game.preludeDeck.draw(player.game));
+      }
+    }
 
     if (player.game.gameOptions.preludeExtension) {
       this.options.push(

--- a/src/server/models/ServerModel.ts
+++ b/src/server/models/ServerModel.ts
@@ -571,6 +571,7 @@ export class Server {
       turmoilExtension: options.turmoilExtension,
       venusNextExtension: options.venusNextExtension,
       undoOption: options.undoOption,
+      twoCorpsVariant: options.twoCorpsVariant,
     };
   }
 

--- a/src/server/routes/Game.ts
+++ b/src/server/routes/Game.ts
@@ -126,6 +126,7 @@ export class GameHandler extends Handler {
             escapeVelocityThreshold: gameReq.escapeVelocityThreshold,
             escapeVelocityPeriod: gameReq.escapeVelocityPeriod,
             escapeVelocityPenalty: gameReq.escapeVelocityPenalty,
+            twoCorpsVariant: gameReq.twoCorpsVariant,
           };
 
           let game: Game;

--- a/src/server/tools/analyze_ma.ts
+++ b/src/server/tools/analyze_ma.ts
@@ -125,6 +125,7 @@ function simpleGameOptions(): GameOptions {
     escapeVelocityThreshold: undefined,
     escapeVelocityPeriod: undefined,
     escapeVelocityPenalty: undefined,
+    twoCorpsVariant: false,
 
     // The options that can change, should be parameters.
     boardName: BoardName.ORIGINAL,

--- a/tests/GameCards.spec.ts
+++ b/tests/GameCards.spec.ts
@@ -65,5 +65,26 @@ describe('GameCards', function() {
       expect(preludeDeck.includes(preludeCard)).is.not.true;
     });
   });
+
+  it('excludes the Merger prelude if twoCorpVariant is being used ', function() {
+    const gameOptions = testGameOptions({
+      corporateEra: true,
+      preludeExtension: false,
+      venusNextExtension: false,
+      coloniesExtension: false,
+      turmoilExtension: false,
+      promoCardsOption: false,
+      communityCardsOption: true,
+      aresExtension: false,
+    });
+
+    const preludeDeck = new GameCards(gameOptions).getPreludeCards();
+
+    const communityPreludes = CardManifest.keys(COMMUNITY_CARD_MANIFEST.preludeCards);
+    communityPreludes.forEach((preludeName) => {
+      const preludeCard = new CardFinder().getPreludeByName(preludeName)!;
+      expect(preludeDeck.includes(preludeCard)).is.not.true;
+    });
+  });
 });
 

--- a/tests/GameCards.spec.ts
+++ b/tests/GameCards.spec.ts
@@ -66,25 +66,21 @@ describe('GameCards', function() {
     });
   });
 
-  it('excludes the Merger prelude if twoCorpVariant is being used ', function() {
+  it('correctly removes the Merger prelude card if twoCorpsVariant is being used ', function() {
     const gameOptions = testGameOptions({
       corporateEra: true,
-      preludeExtension: false,
+      preludeExtension: true,
       venusNextExtension: false,
       coloniesExtension: false,
       turmoilExtension: false,
       promoCardsOption: false,
-      communityCardsOption: true,
+      communityCardsOption: false,
       aresExtension: false,
+      twoCorpsVariant: true,
     });
 
     const preludeDeck = new GameCards(gameOptions).getPreludeCards();
-
-    const communityPreludes = CardManifest.keys(COMMUNITY_CARD_MANIFEST.preludeCards);
-    communityPreludes.forEach((preludeName) => {
-      const preludeCard = new CardFinder().getPreludeByName(preludeName)!;
-      expect(preludeDeck.includes(preludeCard)).is.not.true;
-    });
+    expect(preludeDeck).to.not.contain(CardName.MERGER);
   });
 });
 

--- a/tests/routes/ApiGame.spec.ts
+++ b/tests/routes/ApiGame.spec.ts
@@ -84,6 +84,7 @@ describe('ApiGame', () => {
           'turmoilExtension': false,
           'undoOption': false,
           'venusNextExtension': false,
+          'twoCorpsVariant': false,
         },
       },
     );


### PR DESCRIPTION
## What does this PR do?
Implements the Merger Variant, which Everyone gets the Merger Prelude.  It's given post-drafting (if enabled).
- A few visual changes to New Game menu were made to make it a little 'easier'.
- Based off the wonderful work in [tfm-community](https://github.com/nwai90/terraforming-mars)

## Notes for code reviewer

- You can very easily run out of corporations if minimal expansions are added.  
  - A check should be done prior to game start to ensure more than enough corporations have been selected.
  - I'm unsure on how to approach doing this just yet

(My apologies for the number of superfluous commits as I try to figure out how this language likes to concat strings.. recommending squashing if PR is accepted.)

---