### PR TITLE
CEO PR#4.1 - CardFinder.ts

### DIFF
--- a/src/server/CardFinder.ts
+++ b/src/server/CardFinder.ts
@@ -4,6 +4,7 @@ import {CardManifest, ModuleManifest} from './cards/ModuleManifest';
 import {CardName} from '../common/cards/CardName';
 import {ICorporationCard} from './cards/corporation/ICorporationCard';
 import {IPreludeCard} from './cards/prelude/IPreludeCard';
+import {ILeaderCard} from './cards/leaders/ILeaderCard';
 import {ALL_MODULE_MANIFESTS} from './cards/AllCards';
 
 const CARD_RENAMES = new Map<string, CardName>([
@@ -39,7 +40,7 @@ export class CardFinder {
   }
 
   public getCardByName(cardName: CardName): ICard | undefined {
-    return this.getCard(cardName, ['corporationCards', 'projectCards', 'preludeCards']);
+    return this.getCard(cardName, ['corporationCards', 'projectCards', 'preludeCards', 'leaderCards']);
   }
 
   public getCorporationCardByName(cardName: CardName): ICorporationCard | undefined {
@@ -58,6 +59,10 @@ export class CardFinder {
     return this.getCard(cardName, ['preludeCards']);
   }
 
+  public getLeaderByName(cardName: CardName): ILeaderCard | undefined {
+    return this.getCard(cardName, ['leaderCards']);
+  }
+
   public preludesFromJSON(cards: Array<CardName>): Array<IPreludeCard> {
     if (cards === undefined) {
       console.warn('missing cards calling cardsFromJSON');
@@ -66,6 +71,23 @@ export class CardFinder {
     const result: Array<IPreludeCard> = [];
     cards.forEach((element: CardName) => {
       const card = this.getPreludeByName(element);
+      if (card !== undefined) {
+        result.push(card);
+      } else {
+        console.warn(`card ${element} not found while loading game.`);
+      }
+    });
+    return result;
+  }
+
+  public leadersFromJSON(cards: Array<CardName>): Array<ILeaderCard> {
+    if (cards === undefined) {
+      console.warn('missing cards calling leadersFromJSON');
+      return [];
+    }
+    const result: Array<ILeaderCard> = [];
+    cards.forEach((element: CardName) => {
+      const card = this.getLeaderByName(element);
       if (card !== undefined) {
         result.push(card);
       } else {

--- a/src/server/cards/AllCards.ts
+++ b/src/server/cards/AllCards.ts
@@ -4,6 +4,7 @@ import {COLONIES_CARD_MANIFEST} from './colonies/ColoniesCardManifest';
 import {COMMUNITY_CARD_MANIFEST} from './community/CommunityCardManifest';
 import {PRELUDE_CARD_MANIFEST} from './prelude/PreludeCardManifest';
 import {PROMO_CARD_MANIFEST} from './promo/PromoCardManifest';
+import {LEADER_CARD_MANIFEST} from './leaders/LeaderCardManifest';
 import {
   BASE_CARD_MANIFEST,
   CORP_ERA_CARD_MANIFEST,
@@ -20,6 +21,7 @@ export const ALL_MODULE_MANIFESTS: Array<ModuleManifest> = [
   VENUS_CARD_MANIFEST,
   COLONIES_CARD_MANIFEST,
   PRELUDE_CARD_MANIFEST,
+  LEADER_CARD_MANIFEST,
   TURMOIL_CARD_MANIFEST,
   COMMUNITY_CARD_MANIFEST,
   ARES_CARD_MANIFEST,

--- a/src/server/cards/leaders/LeaderCardManifest.ts
+++ b/src/server/cards/leaders/LeaderCardManifest.ts
@@ -1,4 +1,4 @@
-// import {CardName} from '../../../common/cards/CardName';
+import {CardName} from '../../../common/cards/CardName';
 import {ModuleManifest} from '../ModuleManifest';
 
 // import {Apollo} from './Apollo';
@@ -13,7 +13,7 @@ import {ModuleManifest} from '../ModuleManifest';
 // import {Gaia} from './Gaia';
 // import {Gordon} from './Gordon';
 // import {Greta} from './Greta';
-// import {HAL9000} from './HAL9000';
+import {HAL9000} from './HAL9000';
 // import {Huan} from './Huan';
 // import {Ingrid} from './Ingrid';
 // import {Jansson} from './Jansson';
@@ -53,7 +53,7 @@ export const LEADER_CARD_MANIFEST = new ModuleManifest({
     // [CardName.GAIA]: {Factory: Gaia, compatibility: 'ares'},
     // [CardName.GORDON]: {Factory: Gordon},
     // [CardName.GRETA]: {Factory: Greta},
-    // [CardName.HAL9000]: {Factory: HAL9000},
+    [CardName.HAL9000]: {Factory: HAL9000},
     // [CardName.HUAN]: {Factory: Huan, compatibility: 'colonies'},
     // [CardName.INGRID]: {Factory: Ingrid},
     // [CardName.JANSSON]: {Factory: Jansson},

--- a/tests/CardFinder.spec.ts
+++ b/tests/CardFinder.spec.ts
@@ -3,16 +3,16 @@ import {expect} from 'chai';
 import {CardFinder} from '../src/server/CardFinder';
 
 describe('CardFinder', function() {
-  it('findProjectCardByName: success', function() {
+  it('getProjectCardByName: success', function() {
     expect(new CardFinder().getProjectCardByName(CardName.AI_CENTRAL)?.name).eq(CardName.AI_CENTRAL);
   });
-  it('findProjectCardByName: failure', function() {
+  it('getProjectCardByName: failure', function() {
     expect(new CardFinder().getProjectCardByName(CardName.ECOLINE)).is.undefined;
   });
-  it('findProjectCardByName prelude: success', function() {
+  it('getProjectCardByName prelude: success', function() {
     expect(new CardFinder().getProjectCardByName(CardName.ALLIED_BANK)?.name).eq(CardName.ALLIED_BANK);
   });
-  it('findProjectCardByName leader: success', function() {
+  it('getLeaderByName leader: success', function() {
     expect(new CardFinder().getLeaderByName(CardName.HAL9000)?.name).eq(CardName.HAL9000);
   });
   // Dont' remove this test. It's a placeholder for card renames.

--- a/tests/CardFinder.spec.ts
+++ b/tests/CardFinder.spec.ts
@@ -12,6 +12,9 @@ describe('CardFinder', function() {
   it('findProjectCardByName prelude: success', function() {
     expect(new CardFinder().getProjectCardByName(CardName.ALLIED_BANK)?.name).eq(CardName.ALLIED_BANK);
   });
+  it('findProjectCardByName leader: success', function() {
+    expect(new CardFinder().getLeaderByName(CardName.HAL9000)?.name).eq(CardName.HAL9000);
+  });
   // Dont' remove this test. It's a placeholder for card renames.
   it('finds renamed cards', function() {
     expect(new CardFinder().getProjectCardByName('Designed Micro-organisms'as CardName)?.name).to.equal(CardName.DESIGNED_MICROORGANISMS);


### PR DESCRIPTION
_PR#1 in a set of card+deck related PRs_

### CardFinder.ts

I pretty much just tried to replicate the code as-is for Preludes, however there are a few oddities I'm not 100% sure on.  

For starters, `getLeaderByName`+`getPreludeByName` are only ever referenced in this `CardFinder.ts` in their respective `leadersFromJSON`+`preludesFromJSON` blocks in this same file.  Not sure why they'd need to be split out?

I've also included `leaderCards` in the generic `getCardByName`, but again, not sure this needed

Prior to this I'd just used the generic `cardsFromJSON` and it worked Fine, but would rather get this right if necessary.

(This whole PR for CardFinder.ts may be unnecessary, but will want to get it ironed out before moving on to `Deck.ts`+`Game.ts`
