### PR TITLE
 CEO PR#4.2 - GameOptions.ts

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -534,6 +534,8 @@ export interface CreateGameModel {
     escapeVelocityPeriod: number;
     escapeVelocityPenalty: number;
     twoCorpsVariant: boolean;
+    leadersExtension: boolean;
+    customLeaders: Array<CardName>;
 }
 
 type Refs = {
@@ -622,6 +624,8 @@ export default (Vue as WithRefs<Refs>).extend({
       escapeVelocityPeriod: constants.DEFAULT_ESCAPE_VELOCITY_PERIOD,
       escapeVelocityPenalty: constants.DEFAULT_ESCAPE_VELOCITY_PENALTY,
       twoCorpsVariant: false,
+      leadersExtension: false,
+      customLeaders: [],
     };
   },
   components: {
@@ -972,6 +976,8 @@ export default (Vue as WithRefs<Refs>).extend({
       const escapeVelocityPeriod = component.escapeVelocityMode ? component.escapeVelocityPeriod : undefined;
       const escapeVelocityPenalty = component.escapeVelocityMode ? component.escapeVelocityPenalty : undefined;
       const twoCorpsVariant = component.twoCorpsVariant;
+      const leadersExtension = component.leadersExtension;
+      const customLeaders = component.customLeaders;
       let clonedGamedId: undefined | GameId = undefined;
 
       // Check custom colony count
@@ -1136,6 +1142,8 @@ export default (Vue as WithRefs<Refs>).extend({
         escapeVelocityPeriod,
         escapeVelocityPenalty,
         twoCorpsVariant,
+        leadersExtension,
+        customLeaders,
       };
       return JSON.stringify(dataToSend, undefined, 4);
     },

--- a/src/common/game/NewGameConfig.ts
+++ b/src/common/game/NewGameConfig.ts
@@ -55,6 +55,7 @@ export interface NewGameConfig {
   includeVenusMA: boolean;
   moonExpansion: boolean;
   pathfindersExpansion: boolean;
+  leadersExtension: boolean;
 
   // Variants
   draftVariant: boolean;
@@ -77,4 +78,5 @@ export interface NewGameConfig {
   escapeVelocityPeriod: number | undefined;
   escapeVelocityPenalty: number | undefined;
   twoCorpsVariant: boolean,
+  customLeaders: Array<CardName>;
 }

--- a/src/server/GameOptions.ts
+++ b/src/server/GameOptions.ts
@@ -32,7 +32,7 @@ export type GameOptions = {
   includeVenusMA: boolean;
   moonExpansion: boolean;
   pathfindersExpansion: boolean;
-  leadersExpansion: boolean;
+  leadersExtension: boolean;
 
   // Variants
   draftVariant: boolean;
@@ -86,7 +86,7 @@ export const DEFAULT_GAME_OPTIONS: GameOptions = {
   moonExpansion: false,
   moonStandardProjectVariant: false,
   pathfindersExpansion: false,
-  leadersExpansion: false,
+  leadersExtension: false,
   politicalAgendasExtension: AgendaStyle.STANDARD,
   preludeExtension: false,
   promoCardsOption: false,

--- a/src/server/GameOptions.ts
+++ b/src/server/GameOptions.ts
@@ -32,6 +32,7 @@ export type GameOptions = {
   includeVenusMA: boolean;
   moonExpansion: boolean;
   pathfindersExpansion: boolean;
+  leadersExpansion: boolean;
 
   // Variants
   draftVariant: boolean;
@@ -46,6 +47,7 @@ export type GameOptions = {
   bannedCards: Array<CardName>;
   customColoniesList: Array<ColonyName>;
   customPreludes: Array<CardName>;
+  customLeaders: Array<CardName>;
   requiresMoonTrackCompletion: boolean; // Moon must be completed to end the game
   requiresVenusTrackCompletion: boolean; // Venus must be completed to end the game
   moonStandardProjectVariant: boolean;
@@ -71,6 +73,7 @@ export const DEFAULT_GAME_OPTIONS: GameOptions = {
   customColoniesList: [],
   customCorporationsList: [],
   customPreludes: [],
+  customLeaders: [],
   draftVariant: false,
   escapeVelocityMode: false, // When true, escape velocity is enabled.
   escapeVelocityThreshold: constants.DEFAULT_ESCAPE_VELOCITY_THRESHOLD, // Time in minutes a player has to complete a game.
@@ -83,6 +86,7 @@ export const DEFAULT_GAME_OPTIONS: GameOptions = {
   moonExpansion: false,
   moonStandardProjectVariant: false,
   pathfindersExpansion: false,
+  leadersExpansion: false,
   politicalAgendasExtension: AgendaStyle.STANDARD,
   preludeExtension: false,
   promoCardsOption: false,

--- a/src/server/cards/leaders/LeaderCardManifest.ts
+++ b/src/server/cards/leaders/LeaderCardManifest.ts
@@ -5,11 +5,11 @@ import {ModuleManifest} from '../ModuleManifest';
 // import {Asimov} from './Asimov';
 // import {Bjorn} from './Bjorn';
 // import {Caesar} from './Caesar';
-// import {Clarke} from './Clarke';
+import {Clarke} from './Clarke';
 // import {Duncan} from './Duncan';
-// import {Ender} from './Ender';
+import {Ender} from './Ender';
 // import {Faraday} from './Faraday';
-// import {Floyd} from './Floyd';
+import {Floyd} from './Floyd';
 // import {Gaia} from './Gaia';
 // import {Gordon} from './Gordon';
 // import {Greta} from './Greta';
@@ -17,7 +17,7 @@ import {HAL9000} from './HAL9000';
 // import {Huan} from './Huan';
 // import {Ingrid} from './Ingrid';
 // import {Jansson} from './Jansson';
-// import {Karen} from './Karen';
+import {Karen} from './Karen';
 // import {Lowell} from './Lowell';
 // import {Maria} from './Maria';
 // import {Naomi} from './Naomi';
@@ -45,11 +45,11 @@ export const LEADER_CARD_MANIFEST = new ModuleManifest({
     // [CardName.ASIMOV]: {Factory: Asimov},
     // [CardName.BJORN]: {Factory: Bjorn},
     // [CardName.CAESAR]: {Factory: Caesar, compatibility: 'ares'},
-    // [CardName.CLARKE]: {Factory: Clarke},
+    [CardName.CLARKE]: {Factory: Clarke},
     // [CardName.DUNCAN]: {Factory: Duncan},
-    // [CardName.ENDER]: {Factory: Ender},
+    [CardName.ENDER]: {Factory: Ender},
     // [CardName.FARADAY]: {Factory: Faraday},
-    // [CardName.FLOYD]: {Factory: Floyd},
+    [CardName.FLOYD]: {Factory: Floyd},
     // [CardName.GAIA]: {Factory: Gaia, compatibility: 'ares'},
     // [CardName.GORDON]: {Factory: Gordon},
     // [CardName.GRETA]: {Factory: Greta},
@@ -57,7 +57,7 @@ export const LEADER_CARD_MANIFEST = new ModuleManifest({
     // [CardName.HUAN]: {Factory: Huan, compatibility: 'colonies'},
     // [CardName.INGRID]: {Factory: Ingrid},
     // [CardName.JANSSON]: {Factory: Jansson},
-    // [CardName.KAREN]: {Factory: Karen, compatibility: 'prelude'},
+    [CardName.KAREN]: {Factory: Karen, compatibility: 'prelude'},
     // [CardName.LOWELL]: {Factory: Lowell, compatibility: 'prelude'},
     // [CardName.MARIA]: {Factory: Maria, compatibility: 'colonies'},
     // [CardName.NAOMI]: {Factory: Naomi, compatibility: 'colonies'},

--- a/src/server/routes/Game.ts
+++ b/src/server/routes/Game.ts
@@ -123,6 +123,8 @@ export class GameHandler extends Handler {
             escapeVelocityPeriod: gameReq.escapeVelocityPeriod,
             escapeVelocityPenalty: gameReq.escapeVelocityPenalty,
             twoCorpsVariant: gameReq.twoCorpsVariant,
+            leadersExtension: gameReq.leadersExtension,
+            customLeaders: gameReq.customLeaders,
           };
 
           let game: Game;


### PR DESCRIPTION
_PR#2 in a set of card+deck related PRs_

### `GameOptions.ts` and all of the sundry changes it brings along with it

These options are required for tests that will be coming in `Deck.ts` and `Game.ts`.

No tests for this work _yet_, it needs Deck and Game set up before we can test it properly.  I can include some basics if desired.


### [LeaderCardManifest.ts](https://github.com/terraforming-mars/terraforming-mars/compare/main...d-little:terraforming-mars:leadersVariant-PR2?expand=1#diff-08969a2d3b395a22ca05055a18a40a37892cde4ab617e9e3c66a04512b9703a0)

I'm filling out the manifest for all of the Leaders we've added so far.  These will be used for future tests of Deck and Game.ts