### PR TITLE
CEO PR#4.4 - Deck

### DIFF
--- a/src/server/cards/Deck.ts
+++ b/src/server/cards/Deck.ts
@@ -9,6 +9,7 @@ import {IProjectCard} from './IProjectCard';
 import {inplaceShuffle} from '../utils/shuffle';
 import {Logger} from '../logs/Logger';
 import {IPreludeCard} from './prelude/IPreludeCard';
+import {ILeaderCard} from './leaders/ILeaderCard';
 
 /**
  * A deck of cards to draw from, and also its discard pile.
@@ -180,5 +181,19 @@ export class PreludeDeck extends Deck<IPreludeCard> {
     const deck = <Array<IPreludeCard>>cardFinder.preludesFromJSON(d.drawPile);
     const discarded = cardFinder.preludesFromJSON(d.discardPile);
     return new PreludeDeck(deck, discarded, random);
+  }
+}
+
+export class LeaderDeck extends Deck<ILeaderCard> {
+  public constructor(deck: Array<ILeaderCard>, discarded: Array<ILeaderCard>, random: Random) {
+    super('leader', deck, discarded, random);
+  }
+
+  public static deserialize(d: SerializedDeck, random: Random): Deck<ILeaderCard> {
+    const cardFinder = new CardFinder();
+
+    const deck = cardFinder.leadersFromJSON(d.drawPile);
+    const discarded = cardFinder.leadersFromJSON(d.discardPile);
+    return new LeaderDeck(deck, discarded, random);
   }
 }


### PR DESCRIPTION
_PR#4 in a set of card+deck related PRs_

### [src/server/cards/Deck.ts](https://github.com/terraforming-mars/terraforming-mars/compare/main...d-little:leaders-Deck?expand=1#diff-954dcd314b4559b0fed3b2df781925caee54ea9853546a1ac95cbb591020810e)

Another easy one.  Just a clone of Preludes really


### [tests/cards/Deck.spec.ts](https://github.com/terraforming-mars/terraforming-mars/compare/main...d-little:leaders-Deck?expand=1#diff-20d0e550025dab8dee2ba255f5d9542ec3a33059956384e57db92112164f4a50)

This one is trickier.  I'm not 100% sure why the Preludes test is hard coded, but.. it is.  I don't really want to update this test every single time we push in a new CEO during deployment so I'm leaving it dynamic.  We are testing to see if the drawing works as expected, and the serialisation works after that. So maybe the hard coded length isn't ever necessary.

I _could_ add a test that we draw a custom list of Leaders, and work with that.  A deck size of 5 leaders maybe?  But I _think_ the test intentions are met as-is

I'm also not sure what the `customCorporationsList: [CardName.MERGER]` on the Prelude test is doing? I didn't replicate it in any case