### PR TITLE
Add unplayed corporation cards to the discard pile.

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -561,23 +561,10 @@ export class Game implements Logger {
     }
   }
 
-  private pickCorporationCard(player: Player): PlayerInput {
+  private selectInitialCards(player: Player): PlayerInput {
     return new SelectInitialCards(player, (corporation: ICorporationCard) => {
-      // Check for negative M€
-      const cardCost = corporation.cardCost !== undefined ? corporation.cardCost : player.cardCost;
-      if (corporation.name !== CardName.BEGINNER_CORPORATION && player.cardsInHand.length * cardCost > corporation.startingMegaCredits) {
-        player.cardsInHand = [];
-        player.preludeCardsInHand = [];
-        throw new Error('Too many cards selected');
-      }
-      // discard all unpurchased cards
-      player.dealtProjectCards.forEach((card) => {
-        if (player.cardsInHand.includes(card) === false) {
-          this.projectDeck.discard(card);
-        }
-      });
-
-      this.playerHasPickedCorporationCard(player, corporation); return undefined;
+      this.playerHasPickedCorporationCard(player, corporation);
+      return undefined;
     });
   }
 
@@ -628,7 +615,7 @@ export class Game implements Logger {
 
     for (const player of this.players) {
       if (player.pickedCorporationCard === undefined && player.dealtCorporationCards.length > 0) {
-        player.setWaitingFor(this.pickCorporationCard(player));
+        player.setWaitingFor(this.selectInitialCards(player));
       }
     }
     if (this.players.length === 1 && this.gameOptions.coloniesExtension) {

--- a/src/server/inputs/SelectInitialCards.ts
+++ b/src/server/inputs/SelectInitialCards.ts
@@ -6,11 +6,13 @@ import {Player} from '../Player';
 import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {SelectCard} from './SelectCard';
 import {Merger} from '../cards/promo/Merger';
+import {CardName} from '../../common/cards/CardName';
 
 export class SelectInitialCards extends AndOptions {
   public override readonly inputType = PlayerInputType.SELECT_INITIAL_CARDS;
-  constructor(player: Player, cb: (corporation: ICorporationCard) => undefined) {
+  constructor(private player: Player, cb: (corporation: ICorporationCard) => undefined) {
     super(() => {
+      this.completed(corporation);
       cb(corporation);
       return undefined;
     });
@@ -60,5 +62,28 @@ export class SelectInitialCards extends AndOptions {
         }, {min: 0, max: 10},
       ),
     );
+  }
+
+  private completed(corporation: ICorporationCard) {
+    const player = this.player;
+    // Check for negative M€
+    const cardCost = corporation.cardCost !== undefined ? corporation.cardCost : player.cardCost;
+    if (corporation.name !== CardName.BEGINNER_CORPORATION && player.cardsInHand.length * cardCost > corporation.startingMegaCredits) {
+      player.cardsInHand = [];
+      player.preludeCardsInHand = [];
+      throw new Error('Too many cards selected');
+    }
+    // discard all unpurchased cards
+    player.dealtProjectCards.forEach((card) => {
+      if (player.cardsInHand.includes(card) === false) {
+        player.game.projectDeck.discard(card);
+      }
+    });
+
+    player.dealtCorporationCards.forEach((card) => {
+      if (card.name !== corporation.name) {
+        player.game.corporationDeck.discard(card);
+      }
+    });
   }
 }

--- a/tests/inputs/SelectInitialCards.spec.ts
+++ b/tests/inputs/SelectInitialCards.spec.ts
@@ -58,14 +58,20 @@ describe('SelectInitialCards', () => {
   });
 
   it('Simple', () => {
+    player.game.projectDeck.discardPile.length = 0; // Emptying the discard pile, which has 4 cards setting up the solo opponent.
+    expect(player.game.corporationDeck.discardPile).is.empty;
+
     selectInitialCards.process({type: 'and', responses: [
       {type: 'card', cards: [CardName.INVENTRIX]},
       {type: 'card', cards: [CardName.ANTS]},
     ]}, player);
 
-    expect(player.corporations).has.length(0); // This input object doesn't set the player's corporationc ard
+    expect(player.corporations).has.length(0); // This input object doesn't set the player's corporation card
     expect(corp!.name).eq(CardName.INVENTRIX);
     expect(player.cardsInHand).has.length(1); // But it does set their cards in hand.
     expect(player.cardsInHand[0].name).eq(CardName.ANTS);
+
+    expect(player.game.projectDeck.discardPile.map((c) => c.name)).has.members([CardName.BACTOVIRAL_RESEARCH, CardName.COMET_AIMING, CardName.DIRIGIBLES]);
+    expect(player.game.corporationDeck.discardPile.map((c) => c.name)).has.members([CardName.HELION]);
   });
 });


### PR DESCRIPTION
This makes them available for Merger.

Also, this is moved to SelectInitialCards as it puts most of the initial card setup in one place. There's probably a cleaner way to do this by moving _all_ the selection out of SIC, but this is an easy way to test.

Partially fixes #5277