### PR TITLE
Update AncientShipyards.ts

### DIFF
--- a/src/server/cards/moon/AncientShipyards.ts
+++ b/src/server/cards/moon/AncientShipyards.ts
@@ -45,7 +45,7 @@ export class AncientShipyards extends Card {
       p.stealResource(Resources.MEGACREDITS, 2, player);
     }
     if (game.isSoloMode()) {
-      player.addResource(Resources.MEGACREDITS, 2);
+      player.addResource(Resources.MEGACREDITS, 8);
     }
     player.addResourceTo(this, 1);
     return undefined;


### PR DESCRIPTION
Adjustment for ancient shipyards for solo mode only. The orginal effect is back and it is now a multiple "Indentured Workers" card, thus balanced as +8M€ for -1VP multiple times if you wish. So its fair for solo,

This would be the way how it should be copied over to the Darkside of the Moon Syndicate corp for solo mode only.