### PR TITLE
 CEO#4.8.1 - SelectInitialCards.vue - Add missing this.hasCeo to saveData

### DIFF
--- a/src/client/components/SelectInitialCards.vue
+++ b/src/client/components/SelectInitialCards.vue
@@ -227,6 +227,12 @@ export default (Vue as WithRefs<Refs>).extend({
           cards: this.selectedPreludes,
         });
       }
+      if (this.hasCeo) {
+        result.responses.push({
+          type: 'card',
+          cards: this.selectedCeos,
+        });
+      }
       result.responses.push({
         type: 'card',
         cards: this.selectedCards,


### PR DESCRIPTION
###

As it says on the box.  Required when turn on CEOs