### PR TITLE
Make "Pass" option more visually distinct

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1461,7 +1461,7 @@ export class Player {
   }
 
   private passOption(): PlayerInput {
-    return new SelectOption('Pass for this generation', 'Pass', () => {
+    return new SelectOption('~~!! Pass for this generation !!~~', 'Pass', () => {
       this.pass();
       this.game.log('${0} passed', (b) => b.player(this));
       return undefined;


### PR DESCRIPTION
Make "Pass for this generation" option more visually distinct to reduce chance of confusion with "End turn" option.