### PR TITLE
CEOs: Add checkbox to CreateGameForm.ts for CEOs (BETA)

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -133,6 +133,13 @@
                                     <span v-i18n>Alt. Venus Board</span> &nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Alternative-Venus-Board" class="tooltip" target="_blank">&#9432;</a>
                                 </label>
                             </template>
+
+                            <input type="checkbox" name="ceo" id="ceo-checkbox" v-model="ceoExtension">
+                            <label for="ceo-checkbox" class="expansion-button">
+                                <div class="create-game-expansion-icon expansion-icon-ceo"></div>
+                                <span v-i18n>CEOs (BETA)</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/CEOs" class="tooltip" target="_blank">&#9432;</a>
+                            </label>
+
                         </div>
 
                         <div class="create-game-page-column">


### PR DESCRIPTION
Allow players to enable CEOs via CreateGameForm, with a simple (BETA) warning:
![image](https://user-images.githubusercontent.com/2050250/219278572-46fadfda-60fd-402c-add7-d4f933dfbb20.png)


The wiki page linked is heavily under construction.  I'll do a quick edit there to explain what BETA in this context means

Wiki: https://github.com/terraforming-mars/terraforming-mars/wiki/CEOs