### PR TITLE
CEO Bugfix :: Increase default drawn CEOs from 2 to 3 to match Community

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -327,7 +327,7 @@ export class Game implements Logger {
         }
         if (gameOptions.ceoExtension) {
           // TODO: Replace this with i < gameOptions.startingCeos constants
-          for (let i = 0; i < 2; i++) {
+          for (let i = 0; i < 3; i++) {
             const ceoCard = ceoDeck.draw(game);
             player.dealtCeoCards.push(ceoCard);
           }


### PR DESCRIPTION
This slipped through because of the way I did my testing using custom CEO draws.

Whoops