### PR TITLE
Add 'ares' to list of expansions for card compatibility

### DIFF
--- a/src/server/GameCards.ts
+++ b/src/server/GameCards.ts
@@ -81,7 +81,7 @@ export class GameCards {
       case 'pathfinders':
         return gameOptions.pathfindersExpansion;
       case 'ares':
-        return gameOptions.aresExtension;  
+        return gameOptions.aresExtension;
       case 'ceo':
         return gameOptions.ceoExtension;
       default:

--- a/src/server/GameCards.ts
+++ b/src/server/GameCards.ts
@@ -80,6 +80,8 @@ export class GameCards {
         return gameOptions.moonExpansion;
       case 'pathfinders':
         return gameOptions.pathfindersExpansion;
+      case 'ares':
+        return gameOptions.aresExtension;  
       case 'ceo':
         return gameOptions.ceoExtension;
       default:


### PR DESCRIPTION
This is required for CEOs Caesar and Gaia, and anyone else in the future who needs to add ares compatibility :)

The two CEOs:
```ts
    // [CardName.CAESAR]: {Factory: Caesar, compatibility: 'ares'},
    // [CardName.GAIA]: {Factory: Gaia, compatibility: 'ares'},
```