### PR TITLE
CEO CreateGameForm :: select starting card count

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -139,6 +139,13 @@
                                 <div class="create-game-expansion-icon expansion-icon-ceo"></div>
                                 <span v-i18n>CEOs (BETA)</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/CEOs" class="tooltip" target="_blank">&#9432;</a>
                             </label>
+                            <template v-if="ceoExtension">
+                              <label for="startingCEONum-checkbox">
+                              <input type="number" class="create-game-ceo-count" value="3" min="1" :max="6" v-model="startingCeos" id="startingCEONum-checkbox">
+                                  <span v-i18n>Starting CEOs</span>
+                              </label>
+                            </template>
+
 
                         </div>
 
@@ -544,6 +551,7 @@ export interface CreateGameModel {
     twoCorpsVariant: boolean;
     ceoExtension: boolean;
     customCeos: Array<CardName>;
+    startingCeos: number;
 }
 
 type Refs = {
@@ -634,6 +642,7 @@ export default (Vue as WithRefs<Refs>).extend({
       twoCorpsVariant: false,
       ceoExtension: false,
       customCeos: [],
+      startingCeos: 3,
     };
   },
   components: {
@@ -983,6 +992,7 @@ export default (Vue as WithRefs<Refs>).extend({
       const twoCorpsVariant = this.twoCorpsVariant;
       const ceoExtension = this.ceoExtension;
       const customCeos = this.customCeos;
+      const startingCeos = this.startingCeos;
       let clonedGamedId: undefined | GameId = undefined;
 
       // Check custom colony count
@@ -1149,6 +1159,7 @@ export default (Vue as WithRefs<Refs>).extend({
         twoCorpsVariant,
         ceoExtension,
         customCeos,
+        startingCeos,
       };
       return JSON.stringify(dataToSend, undefined, 4);
     },

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -139,14 +139,6 @@
                                 <div class="create-game-expansion-icon expansion-icon-ceo"></div>
                                 <span v-i18n>CEOs (BETA)</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/CEOs" class="tooltip" target="_blank">&#9432;</a>
                             </label>
-                            <template v-if="ceoExtension">
-                              <label for="startingCEONum-checkbox">
-                              <input type="number" class="create-game-corporations-count" value="3" min="1" :max="6" v-model="startingCeos" id="startingCEONum-checkbox">
-                                  <span v-i18n>Starting CEOs</span>
-                              </label>
-                            </template>
-
-
                         </div>
 
                         <div class="create-game-page-column">
@@ -174,6 +166,14 @@
                             <input type="number" class="create-game-corporations-count" value="2" min="1" :max="6" v-model="startingCorporations" id="startingCorpNum-checkbox">
                                 <span v-i18n>Starting Corporations</span>
                             </label>
+
+                            <template v-if="ceoExtension">
+                              <label for="startingCEONum-checkbox">
+                              <div class="create-game-expansion-icon expansion-icon-ceo"></div>
+                              <input type="number" class="create-game-corporations-count" value="3" min="1" :max="6" v-model="startingCeos" id="startingCEONum-checkbox">
+                                  <span v-i18n>Starting CEOs</span>
+                              </label>
+                            </template>
 
                             <input type="checkbox" v-model="solarPhaseOption" id="WGT-checkbox">
                             <label for="WGT-checkbox">

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -141,7 +141,7 @@
                             </label>
                             <template v-if="ceoExtension">
                               <label for="startingCEONum-checkbox">
-                              <input type="number" class="create-game-ceo-count" value="3" min="1" :max="6" v-model="startingCeos" id="startingCEONum-checkbox">
+                              <input type="number" class="create-game-corporations-count" value="3" min="1" :max="6" v-model="startingCeos" id="startingCEONum-checkbox">
                                   <span v-i18n>Starting CEOs</span>
                               </label>
                             </template>

--- a/src/common/game/NewGameConfig.ts
+++ b/src/common/game/NewGameConfig.ts
@@ -77,6 +77,7 @@ export interface NewGameConfig {
   escapeVelocityThreshold: number | undefined;
   escapeVelocityPeriod: number | undefined;
   escapeVelocityPenalty: number | undefined;
-  twoCorpsVariant: boolean,
+  twoCorpsVariant: boolean;
   customCeos: Array<CardName>;
+  startingCeos: number;
 }

--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -326,8 +326,7 @@ export class Game implements Logger {
           }
         }
         if (gameOptions.ceoExtension) {
-          // TODO: Replace this with i < gameOptions.startingCeos constants
-          for (let i = 0; i < 3; i++) {
+          for (let i = 0; i < gameOptions.startingCeos; i++) {
             const ceoCard = ceoDeck.draw(game);
             player.dealtCeoCards.push(ceoCard);
           }

--- a/src/server/GameOptions.ts
+++ b/src/server/GameOptions.ts
@@ -48,6 +48,7 @@ export type GameOptions = {
   customColoniesList: Array<ColonyName>;
   customPreludes: Array<CardName>;
   customCeos: Array<CardName>;
+  startingCeos: number;
   requiresMoonTrackCompletion: boolean; // Moon must be completed to end the game
   requiresVenusTrackCompletion: boolean; // Venus must be completed to end the game
   moonStandardProjectVariant: boolean;
@@ -99,6 +100,7 @@ export const DEFAULT_GAME_OPTIONS: GameOptions = {
   shuffleMapOption: false,
   solarPhaseOption: false,
   soloTR: false,
+  startingCeos: 3,
   startingCorporations: 2,
   turmoilExtension: false,
   undoOption: false,

--- a/src/server/routes/Game.ts
+++ b/src/server/routes/Game.ts
@@ -125,6 +125,7 @@ export class GameHandler extends Handler {
             twoCorpsVariant: gameReq.twoCorpsVariant,
             ceoExtension: gameReq.ceoExtension,
             customCeos: gameReq.customCeos,
+            startingCeos: gameReq.startingCeos,
           };
 
           let game: Game;

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -73,6 +73,13 @@
     padding-left: 30px;
 }
 
+.create-game-ceo-count {
+    width: 80px;
+    margin-right: 10px;
+    height: 40px;
+    padding-left: 30px;
+}
+
 .player-handicap {
     width: 80px;
     margin-right: 10px;

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -73,13 +73,6 @@
     padding-left: 30px;
 }
 
-.create-game-ceo-count {
-    width: 80px;
-    margin-right: 10px;
-    height: 40px;
-    padding-left: 30px;
-}
-
 .player-handicap {
     width: 80px;
     margin-right: 10px;


### PR DESCRIPTION
Allow players to choose how many CEOs they'd like to be dealt.

`startingCeos` has been added to all the GameOption locations where `startingCorporations` lives

My playgroup has been using 4 instead of the default 3, sometimes its more interesting.

Output display:

![image](https://user-images.githubusercontent.com/2050250/219842975-9d213b17-4ed2-430f-bad1-514a7f10c680.png)

![image](https://user-images.githubusercontent.com/2050250/219842971-3fe79931-ffd2-4fd9-98b5-22e656a441d1.png)
