### PR TITLE
CEO Gordon

### DIFF
--- a/src/server/boards/Board.ts
+++ b/src/server/boards/Board.ts
@@ -125,7 +125,7 @@ export abstract class Board {
     return this.getOceanSpaces(include).length;
   }
 
-  public getAvailableSpacesForType(player: Player, type: PlacementType) {
+  public getAvailableSpacesForType(player: Player, type: PlacementType): Array<ISpace> {
     switch (type) {
     case 'land': return this.getAvailableSpacesOnLand(player);
     case 'ocean': return this.getAvailableSpacesForOcean(player);

--- a/src/server/boards/Board.ts
+++ b/src/server/boards/Board.ts
@@ -169,14 +169,19 @@ export abstract class Board {
   }
 
   public getAvailableSpacesForCity(player: Player): Array<ISpace> {
+    const spacesOnLand = this.getAvailableSpacesOnLand(player);
+    // Gordon CEO can ignore placement restrictions for Cities+Greenery
+    if (player.cardIsInEffect(CardName.GORDON)) return spacesOnLand;
     // A city cannot be adjacent to another city
-    return this.getAvailableSpacesOnLand(player).filter(
+    return spacesOnLand.filter(
       (space) => this.getAdjacentSpaces(space).some((adjacentSpace) => Board.isCitySpace(adjacentSpace)) === false,
     );
   }
 
   public getAvailableSpacesForGreenery(player: Player): Array<ISpace> {
     let spacesOnLand = this.getAvailableSpacesOnLand(player);
+    // Gordon CEO can ignore placement restrictions for Cities+Greenery
+    if (player.cardIsInEffect(CardName.GORDON)) return spacesOnLand;
     // Spaces next to Red City are always unavialable.
     if (player.game.gameOptions.pathfindersExpansion === true) {
       spacesOnLand = spacesOnLand.filter((space) => {

--- a/src/server/cards/ceos/CeoCardManifest.ts
+++ b/src/server/cards/ceos/CeoCardManifest.ts
@@ -11,7 +11,7 @@ import {Ender} from './Ender';
 import {Faraday} from './Faraday';
 import {Floyd} from './Floyd';
 // import {Gaia} from './Gaia';
-// import {Gordon} from './Gordon';
+import {Gordon} from './Gordon';
 // import {Greta} from './Greta';
 import {HAL9000} from './HAL9000';
 // import {Huan} from './Huan';
@@ -51,7 +51,7 @@ export const CEO_CARD_MANIFEST = new ModuleManifest({
     [CardName.FARADAY]: {Factory: Faraday},
     [CardName.FLOYD]: {Factory: Floyd},
     // [CardName.GAIA]: {Factory: Gaia, compatibility: 'ares'},
-    // [CardName.GORDON]: {Factory: Gordon},
+    [CardName.GORDON]: {Factory: Gordon},
     // [CardName.GRETA]: {Factory: Greta},
     [CardName.HAL9000]: {Factory: HAL9000},
     // [CardName.HUAN]: {Factory: Huan, compatibility: 'colonies'},

--- a/src/server/cards/ceos/Gordon.ts
+++ b/src/server/cards/ceos/Gordon.ts
@@ -1,0 +1,43 @@
+import {CardName} from '../../../common/cards/CardName';
+import {Player} from '../../Player';
+import {CardRenderer} from '../render/CardRenderer';
+import {CeoCard} from './CeoCard';
+
+import {Board} from '../../boards/Board';
+import {ISpace} from '../../boards/ISpace';
+import {GainResources} from '../../deferredActions/GainResources';
+import {Resources} from '../../../common/Resources';
+import {SpaceType} from '../../../common/boards/SpaceType';
+import {BoardType} from '../../boards/BoardType';
+import {Phase} from '../../../common/Phase';
+
+export class Gordon extends CeoCard {
+  constructor() {
+    super({
+      name: CardName.GORDON,
+      metadata: {
+        cardNumber: 'L07',
+        renderData: CardRenderer.builder((b) => {
+          b.greenery().city().colon().megacredits(2).asterix();
+          b.br.br;
+        }),
+        description: 'Ignore placement restrictions for greenery and city tiles on Mars. Gain 2 M€ when you place a greenery or city tile on Mars.',
+      },
+    });
+  }
+
+  public override canAct(): boolean {
+    return false;
+  }
+
+  public onTilePlaced(cardOwner: Player, activePlayer: Player, space: ISpace, boardType: BoardType) {
+    if (cardOwner.id !== activePlayer.id) return;
+    if (boardType !== BoardType.MARS || space.spaceType !== SpaceType.LAND) return;
+    if (cardOwner.game.phase === Phase.SOLAR) return;
+
+    if (Board.isCitySpace(space) || Board.isGreenerySpace(space)) {
+      cardOwner.game.defer(new GainResources(cardOwner, Resources.MEGACREDITS, {count: 2}));
+    }
+    return;
+  }
+}

--- a/src/server/cards/ceos/Gordon.ts
+++ b/src/server/cards/ceos/Gordon.ts
@@ -36,7 +36,7 @@ export class Gordon extends CeoCard {
     if (cardOwner.game.phase === Phase.SOLAR) return;
 
     if (Board.isCitySpace(space) || Board.isGreenerySpace(space)) {
-      cardOwner.game.defer(new GainResources(cardOwner, Resources.MEGACREDITS, {count: 2}));
+      cardOwner.game.defer(new GainResources(cardOwner, Resources.MEGACREDITS, {count: 2, log: true}));
     }
     return;
   }

--- a/tests/cards/ceo/Gordon.spec.ts
+++ b/tests/cards/ceo/Gordon.spec.ts
@@ -1,0 +1,62 @@
+import {expect} from 'chai';
+import {TestPlayer} from '../../TestPlayer';
+import {Game} from '../../../src/server/Game';
+import {SpaceType} from '../../../src/common/boards/SpaceType';
+import {TileType} from '../../../src/common/TileType';
+import {getTestPlayer, newTestGame} from '../../TestGame';
+
+import {Gordon} from '../../../src/server/cards/ceos/Gordon';
+
+import {addGreenery, addCityTile, runAllActions} from '../../TestingUtils';
+
+
+describe('Gordon', function() {
+  let card: Gordon;
+  let player: TestPlayer;
+  let player2: TestPlayer;
+  let game: Game;
+
+  beforeEach(() => {
+    card = new Gordon();
+    game = newTestGame(2);
+    player = getTestPlayer(game, 0);
+    player2 = getTestPlayer(game, 1);
+
+    player.playedCards.push(card);
+  });
+
+  it('Can place greenery tile on any available land space, not just adjacent to exising greenery', function() {
+    addGreenery(player, '35');
+    expect(game.board.getAvailableSpacesForGreenery(player).length).greaterThan(6);
+  });
+
+  it('Can place cities next to other cities', function() {
+    const initialAvailableSpaces = game.board.getAvailableSpacesForCity(player).length;
+    addCityTile(player, '35');
+    expect(game.board.getAvailableSpacesForCity(player).length).eq(initialAvailableSpaces - 1);
+  });
+
+  it('Gains 2 MC when placing city or greenery tile', function() {
+    player.megaCredits = 0;
+    addGreenery(player, '35');
+    game.deferredActions.runNext();
+    expect(player.megaCredits).eq(2);
+    addCityTile(player, '37');
+    game.deferredActions.runNext();
+    expect(player.megaCredits).eq(4);
+  });
+
+  it('Does not give MC production for city off Mars', function() {
+    game.addTile(player, game.board.spaces.find((space) => space.spaceType === SpaceType.COLONY)!, {
+      tileType: TileType.CITY,
+    });
+    runAllActions(game);
+    expect(player.megaCredits).to.eq(0);
+  });
+
+  it('Does not gain MC when opponent places city or greenery tile', function() {
+    player.megaCredits = 0;
+    addGreenery(player2, '35');
+    expect(player.megaCredits).eq(0);
+  });
+});

--- a/tests/cards/ceo/Gordon.spec.ts
+++ b/tests/cards/ceo/Gordon.spec.ts
@@ -21,7 +21,6 @@ describe('Gordon', function() {
     game = newTestGame(2);
     player = getTestPlayer(game, 0);
     player2 = getTestPlayer(game, 1);
-
     player.playedCards.push(card);
   });
 
@@ -36,8 +35,7 @@ describe('Gordon', function() {
     addCityTile(player, space.id);
     const availableSpacesForCity = board.getAvailableSpacesForCity(player);
     const spacesNextToCity = board.getAdjacentSpaces(space);
-    // intersect preserves order of first element.
-    expect(intersection(spacesNextToCity, availableSpacesForCity)).deep.eq(spacesNextToCity);
+    expect(availableSpacesForCity).includes(spacesNextToCity[0]);
   });
 
   it('Gains 2 MC when placing city or greenery tile', function() {

--- a/tests/cards/ceo/Gordon.spec.ts
+++ b/tests/cards/ceo/Gordon.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
+import {intersection} from '../../../src/common/utils/utils';
 import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/server/Game';
 import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {TileType} from '../../../src/common/TileType';
 import {getTestPlayer, newTestGame} from '../../TestGame';
+import {addGreenery, addCityTile, runAllActions} from '../../TestingUtils';
 
 import {Gordon} from '../../../src/server/cards/ceos/Gordon';
-
-import {addGreenery, addCityTile, runAllActions} from '../../TestingUtils';
 
 
 describe('Gordon', function() {
@@ -31,9 +31,13 @@ describe('Gordon', function() {
   });
 
   it('Can place cities next to other cities', function() {
-    const initialAvailableSpaces = game.board.getAvailableSpacesForCity(player).length;
-    addCityTile(player, '35');
-    expect(game.board.getAvailableSpacesForCity(player).length).eq(initialAvailableSpaces - 1);
+    const board = game.board;
+    const space = board.getSpace('35');
+    addCityTile(player, space.id);
+    const availableSpacesForCity = board.getAvailableSpacesForCity(player);
+    const spacesNextToCity = board.getAdjacentSpaces(space);
+    // intersect preserves order of first element.
+    expect(intersection(spacesNextToCity, availableSpacesForCity)).deep.eq(spacesNextToCity);
   });
 
   it('Gains 2 MC when placing city or greenery tile', function() {
@@ -57,6 +61,7 @@ describe('Gordon', function() {
   it('Does not gain MC when opponent places city or greenery tile', function() {
     player.megaCredits = 0;
     addGreenery(player2, '35');
+    runAllActions(game);
     expect(player.megaCredits).eq(0);
   });
 });

--- a/tests/cards/ceo/Gordon.spec.ts
+++ b/tests/cards/ceo/Gordon.spec.ts
@@ -1,5 +1,4 @@
 import {expect} from 'chai';
-import {intersection} from '../../../src/common/utils/utils';
 import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/server/Game';
 import {SpaceType} from '../../../src/common/boards/SpaceType';


### PR DESCRIPTION
### Gordon

![image](https://user-images.githubusercontent.com/2050250/219844508-e9246b99-ef73-4351-81e3-e97cfca948b6.png)

There probably needs to be discussions around how this plays with Ares and other special tiles.

Either we need to be strict in the definition, or work through special tiles.

If we rework Gordon from:
* 'Ignore placement restrictions for greenery and city tiles on Mars. Gain 2 M€ when you place a greenery or city tile on Mars.'
To:
* 'Ignore **normal** placement restrictions for greenery and city tiles on Mars. Gain 2 M€ when you place a greenery or city tile on Mars.',

We can say that special tile placement restrictions override even Gordon. If so, does Gordon override placement rules/get 2MC for:

|Tile|Placement Rules|2MC Bonus if the player places it?|
--|--|--
**Red City**|Gordon _can_ place next to Red City|Player **does** gain 2MC|
**Martian Natural Wonders**| Gordon can **not** place a City/Greenery on the cube'd space|N/A|
**Ocean Cities**|Gordon does not override placement behaviour; Ocean Cities are _not_ City Tiles.|Player **does** gain 2MC|
**Wetlands**|Gordon does not override placement behaviour; Wetlands is _not_ a Greenery Tile.|Player **does** gain 2MC|

(I'm sure there are more I'm missing)