### PR TITLE
Turmoil Bugfixes

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -30,7 +30,7 @@ export const TITANIUM_TRADE_COST = 3;
 
 // Turmoil
 export const DELEGATES_PER_PLAYER = 7;
-export const DELEGATES_FOR_NEUTRAL_PLAYER = 13;
+export const DELEGATES_FOR_NEUTRAL_PLAYER = 14;
 export const REDS_RULING_POLICY_COST = 3;
 export const POLITICAL_AGENDAS_MAX_ACTION_USES = 3;
 

--- a/src/server/turmoil/Turmoil.ts
+++ b/src/server/turmoil/Turmoil.ts
@@ -82,7 +82,8 @@ export class Turmoil {
     game.getPlayersInGenerationOrder().forEach((player) => {
       turmoil.delegateReserve.add(player.id, DELEGATES_PER_PLAYER);
     });
-    turmoil.delegateReserve.add('NEUTRAL', DELEGATES_FOR_NEUTRAL_PLAYER);
+    // One Neutral delegate is already Chairman
+    turmoil.delegateReserve.add('NEUTRAL', DELEGATES_FOR_NEUTRAL_PLAYER - 1);
 
     turmoil.politicalAgendasData = PoliticalAgendas.newInstance(agendaStyle, turmoil.parties);
     // Note: this call relies on an instance of Game that will not be fully formed.

--- a/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
+++ b/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
@@ -26,4 +26,18 @@ describe('VoteOfNoConfidence', function() {
     runAllActions(game);
     expect(player.getTerraformRating()).to.eq(15);
   });
+
+  it('Neutral Delegate returns to Reserve', function() {
+    const card = new VoteOfNoConfidence();
+    const game = newTestGame(1, testGameOptions({turmoilExtension: true}));
+    const player = getTestPlayer(game, 0);
+    const turmoil = game.turmoil!;
+    const neutralReserve = turmoil.getAvailableDelegateCount('NEUTRAL');
+    turmoil.chairman = 'NEUTRAL';
+    const greens = game.turmoil!.getPartyByName(PartyName.GREENS);
+    greens.partyLeader = player.id;
+    card.play(player);
+    runAllActions(game);
+    expect(turmoil.getAvailableDelegateCount('NEUTRAL')).to.eq(neutralReserve+1);
+  });
 });


### PR DESCRIPTION
### 14 Neutrals

Per official rulebook.  

### Exiting Chairman Return to Reserve

Moved out of `setRulingParty()` and into `setNewChairman()`, so that Vote of No Confidence returns Neutral Chairman to Reserve. (and Oscar will too)

### Additional tests for Vote Of No Confidence

Just making sure Neutrals get their Chairman Delegate back to reserve