### PR TITLE
Put this.isDisabled in the same place on every CEO

### DIFF
--- a/src/server/cards/ceos/Apollo.ts
+++ b/src/server/cards/ceos/Apollo.ts
@@ -27,9 +27,9 @@ export class Apollo extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const moonSpacesCount = MoonExpansion.spaces(player.game, undefined, {surfaceOnly: true}).length;
     player.addResource(Resources.MEGACREDITS, moonSpacesCount * 3, {log: true});
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Asimov.ts
+++ b/src/server/cards/ceos/Asimov.ts
@@ -37,10 +37,11 @@ export class Asimov extends CeoCard {
       return false;
     }
     if (player.game.isSoloMode()) return false; // Awards are disabled in solo mode
-    return !player.game.allAwardsFunded() && this.isDisabled === false;
+    return !player.game.allAwardsFunded();
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     const awardCount = Math.max(1, 10 - game.generation);
     const validAwards = this.getValidAwards(player);
@@ -54,7 +55,6 @@ export class Asimov extends CeoCard {
     freeAward.options.push(
       new SelectOption('Do nothing', 'Confirm', () => {
         game.log('${0} chose not to fund any award', (b) => b.player(player));
-        this.isDisabled = true;
         return undefined;
       }),
     );
@@ -78,7 +78,6 @@ export class Asimov extends CeoCard {
     return new SelectOption(title, 'Confirm', () => {
       player.game.awards.push(award);
       player.game.fundAward(player, award);
-      this.isDisabled = true;
       return undefined;
     });
   }

--- a/src/server/cards/ceos/Bjorn.ts
+++ b/src/server/cards/ceos/Bjorn.ts
@@ -23,6 +23,7 @@ export class Bjorn extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     const targetPlayers = game.getPlayers().filter((p) => p.id !== player.id && p.megaCredits > player.megaCredits);
 
@@ -30,7 +31,6 @@ export class Bjorn extends CeoCard {
       target.stealResource(Resources.MEGACREDITS, game.generation, player);
     });
 
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Caesar.ts
+++ b/src/server/cards/ceos/Caesar.ts
@@ -35,6 +35,7 @@ export class Caesar extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     for (let i = 0; i < game.generation; i++) {
       game.defer(new PlaceHazardTile(player, TileType.EROSION_MILD));
@@ -51,7 +52,6 @@ export class Caesar extends CeoCard {
       return undefined;
     }));
 
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Clarke.ts
+++ b/src/server/cards/ceos/Clarke.ts
@@ -21,9 +21,9 @@ export class Clarke extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     player.addResource(Resources.PLANTS, player.production.plants + 4, {log: true});
     player.addResource(Resources.HEAT, player.production.heat + 4, {log: true});
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Duncan.ts
+++ b/src/server/cards/ceos/Duncan.ts
@@ -27,8 +27,8 @@ export class Duncan extends CeoCard {
   public generationUsed = -1;
 
   public action(player: Player): PlayerInput | undefined {
-    player.addResource(Resources.MEGACREDITS, 4 * player.game.generation, {log: true});
     this.isDisabled = true;
+    player.addResource(Resources.MEGACREDITS, 4 * player.game.generation, {log: true});
     this.generationUsed = player.game.generation;
     return undefined;
   }

--- a/src/server/cards/ceos/Ender.ts
+++ b/src/server/cards/ceos/Ender.ts
@@ -30,6 +30,7 @@ export class Ender extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const max = Math.min(player.cardsInHand.length, player.game.generation * 2);
     // TODO(d-little): Replace with SelectCard.
     return new SelectAmount(
@@ -38,7 +39,6 @@ export class Ender extends CeoCard {
       (amount: number) => {
         player.game.defer(new DiscardCards(player, amount), Priority.DISCARD_AND_DRAW);
         player.game.defer(DrawCards.keepAll(player, amount));
-        this.isDisabled = true;
         return undefined;
       },
       1,

--- a/src/server/cards/ceos/Floyd.ts
+++ b/src/server/cards/ceos/Floyd.ts
@@ -24,6 +24,8 @@ export class Floyd extends CeoCard {
     });
   }
 
+  public opgActionIsActive = false;
+
   public override canAct(player: Player): boolean {
     if (!super.canAct(player)) {
       return false;
@@ -32,16 +34,18 @@ export class Floyd extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
+    this.opgActionIsActive = true;
     player.game.defer(new PlayProjectCard(player));
     player.game.defer(new SimpleDeferredAction(player, () => {
-      this.isDisabled = true;
       return undefined;
     }));
     return undefined;
   }
 
   public override getCardDiscount(player: Player) {
-    if (player.getActionsThisGeneration().has(this.name) && this.isDisabled === false) {
+    if (player.getActionsThisGeneration().has(this.name) && this.opgActionIsActive === true) {
+      this.opgActionIsActive = false;
       return 13 + 2 * player.game.generation;
     }
     return 0;

--- a/src/server/cards/ceos/HAL9000.ts
+++ b/src/server/cards/ceos/HAL9000.ts
@@ -24,6 +24,7 @@ export class HAL9000 extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     // For every Unit type, if it can be reduced one unit, do so, and give the player
     // 4 of that resource.
     for (const type of Units.keys) {
@@ -35,8 +36,6 @@ export class HAL9000 extends CeoCard {
         player.addUnits(adjustment, {log: true});
       }
     }
-
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Ingrid.ts
+++ b/src/server/cards/ceos/Ingrid.ts
@@ -29,8 +29,8 @@ export class Ingrid extends CeoCard {
   public opgActionIsActive = false;
 
   public action(): PlayerInput | undefined {
-    this.opgActionIsActive = true;
     this.isDisabled = true;
+    this.opgActionIsActive = true;
     return undefined;
   }
 

--- a/src/server/cards/ceos/Jansson.ts
+++ b/src/server/cards/ceos/Jansson.ts
@@ -19,13 +19,11 @@ export class Jansson extends CeoCard {
   }
 
   public action(player: Player): undefined {
+    this.isDisabled = true;
     const spaces = player.game.board.spaces.filter((space) => space.tile !== undefined && space.player === player);
     spaces.forEach((space) => {
       player.game.grantSpaceBonuses(player, space);
     });
-
-    this.isDisabled = true;
-
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Karen.ts
+++ b/src/server/cards/ceos/Karen.ts
@@ -21,6 +21,7 @@ export class Karen extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const cardsDrawn: Array<IProjectCard> = [];
     const game = player.game;
     for (let i = 0; i < game.generation; i++) {
@@ -41,7 +42,6 @@ export class Karen extends CeoCard {
 
     return new SelectCard('Choose prelude card to play', 'Play', cardsDrawn, ([card]) => {
       if (card.canPlay === undefined || card.canPlay(player)) {
-        this.isDisabled = true;
         return player.playCard(card);
       } else {
         throw new Error('You cannot play this card');

--- a/src/server/cards/ceos/Lowell.ts
+++ b/src/server/cards/ceos/Lowell.ts
@@ -33,6 +33,7 @@ export class Lowell extends CeoCard {
 
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     const cardsDrawn: Array<ICeoCard> = [
       game.ceoDeck.draw(game),
@@ -48,7 +49,6 @@ export class Lowell extends CeoCard {
     });
 
     player.game.defer(new SelectPaymentDeferred(player, 8, {title: 'Select how to pay for action'}));
-    this.isDisabled = true;
 
     return new SelectCard('Choose CEO card to play', 'Play', cardsDrawn, (([card]) => {
       const cardIndex = player.playedCards.findIndex((c) => c.name === this.name);

--- a/src/server/cards/ceos/Musk.ts
+++ b/src/server/cards/ceos/Musk.ts
@@ -29,9 +29,9 @@ export class Musk extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     const eligibleCards = player.cardsInHand.filter((card) => card.tags.includes(Tag.EARTH));
-    this.isDisabled = true;
 
     if (eligibleCards.length === 0) {
       game.log('${0} has no Earth cards', (b) => b.player(player), {reservedFor: player});

--- a/src/server/cards/ceos/Naomi.ts
+++ b/src/server/cards/ceos/Naomi.ts
@@ -34,6 +34,7 @@ export class Naomi extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     const activeColonies = game.colonies.filter((colony) => colony.isActive);
 
@@ -49,7 +50,6 @@ export class Naomi extends CeoCard {
         }),
       )));
     });
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Neil.ts
+++ b/src/server/cards/ceos/Neil.ts
@@ -36,6 +36,7 @@ export class Neil extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     MoonExpansion.ifMoon(game, (moonData) => {
       const lowestRate = Math.min(moonData.colonyRate, moonData.logisticRate, moonData.miningRate);
@@ -45,7 +46,6 @@ export class Neil extends CeoCard {
       }
     });
 
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Quill.ts
+++ b/src/server/cards/ceos/Quill.ts
@@ -25,12 +25,12 @@ export class Quill extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const resourceCards = player.getResourceCards(CardResource.FLOATER);
     resourceCards.forEach((card) => player.addResourceTo(card, {qty: 2, log: true}));
 
     player.game.defer(new AddResourcesToCard(player, CardResource.FLOATER, {count: 2}));
 
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Rogers.ts
+++ b/src/server/cards/ceos/Rogers.ts
@@ -30,8 +30,8 @@ export class Rogers extends CeoCard {
   public opgActionIsActive = false;
 
   public action(): PlayerInput | undefined {
-    this.opgActionIsActive = true;
     this.isDisabled = true;
+    this.opgActionIsActive = true;
     return undefined;
   }
 

--- a/src/server/cards/ceos/Ryu.ts
+++ b/src/server/cards/ceos/Ryu.ts
@@ -40,6 +40,7 @@ export class Ryu extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const choices = new OrOptions();
 
     ALL_RESOURCES.filter((r) => this.productionIsDecreasable(player, r)).forEach((resourceToDecrease) => {
@@ -73,7 +74,6 @@ export class Ryu extends CeoCard {
       choices.options.push(selectOption);
     });
 
-    this.isDisabled = true;
     return choices;
   }
 

--- a/src/server/cards/ceos/Stefan.ts
+++ b/src/server/cards/ceos/Stefan.ts
@@ -30,6 +30,7 @@ export class Stefan extends CeoCard {
 
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     return new SelectCard(
       'Sell patents',
       'Sell',
@@ -48,7 +49,6 @@ export class Stefan extends CeoCard {
         });
 
         player.game.log('${0} sold ${1} patents', (b) => b.player(player).number(foundCards.length));
-        this.isDisabled = true;
         return undefined;
       }, {min: 0, max: player.cardsInHand.length},
     );

--- a/src/server/cards/ceos/Tate.ts
+++ b/src/server/cards/ceos/Tate.ts
@@ -26,6 +26,7 @@ export class Tate extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     const tags = [...game.tags];
     inplaceRemove(tags, Tag.WILD);
@@ -39,7 +40,6 @@ export class Tate extends CeoCard {
       });
     });
 
-    this.isDisabled = true;
     return new OrOptions(...options);
   }
 }

--- a/src/server/cards/ceos/Ulrich.ts
+++ b/src/server/cards/ceos/Ulrich.ts
@@ -22,11 +22,11 @@ export class Ulrich extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     const oceansPlaced = game.board.getOceanCount();
     const bonusCredits = oceansPlaced < MAX_OCEAN_TILES ? (oceansPlaced * 4) : 15;
     player.addResource(Resources.MEGACREDITS, bonusCredits, {log: true});
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Will.ts
+++ b/src/server/cards/ceos/Will.ts
@@ -25,6 +25,7 @@ export class Will extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     player.game.defer(new AddResourcesToCard(player, CardResource.ANIMAL, {count: 2}));
     player.game.defer(new AddResourcesToCard(player, CardResource.MICROBE, {count: 2}));
     player.game.defer(new AddResourcesToCard(player, CardResource.SCIENCE, {count: 1}));
@@ -32,7 +33,6 @@ export class Will extends CeoCard {
     player.game.defer(new AddResourcesToCard(player, CardResource.ASTEROID, {count: 1}));
     player.game.defer(new AddResourcesToCard(player, undefined, {count: 1}));
 
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Xavier.ts
+++ b/src/server/cards/ceos/Xavier.ts
@@ -24,8 +24,8 @@ export class Xavier extends CeoCard {
   public opgActionIsActive = false;
 
   public action(): PlayerInput | undefined {
-    this.opgActionIsActive = true;
     this.isDisabled = true;
+    this.opgActionIsActive = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Yvonne.ts
+++ b/src/server/cards/ceos/Yvonne.ts
@@ -30,13 +30,13 @@ export class Yvonne extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     player.game.colonies.forEach((colony) => {
       colony.colonies.filter((owner) => owner === player.id).forEach((owner) => {
         player.game.defer(new SimpleDeferredAction(player, () => colony.giveColonyBonus(player.game.getPlayerById(owner))));
         player.game.defer(new SimpleDeferredAction(player, () => colony.giveColonyBonus(player.game.getPlayerById(owner))));
       });
     });
-    this.isDisabled = true;
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Zan.ts
+++ b/src/server/cards/ceos/Zan.ts
@@ -24,12 +24,12 @@ export class Zan extends CeoCard {
   }
 
   public action(player: Player): PlayerInput | undefined {
+    this.isDisabled = true;
     const game = player.game;
     const turmoil = Turmoil.getTurmoil(game);
     while (turmoil.getAvailableDelegateCount(player.id) > 0) {
       turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
     }
-    this.isDisabled = true;
     return undefined;
   }
 }


### PR DESCRIPTION
### Moving every `this.isDisabled = true;` to the same place on every CEO

There are reported issues with **Karen** and **Floyd** that both are able to reuse their OPG actions.  I'm not able to replicate this in either usage or testing, but I think it _may_ be be cause the `this.isDisabled = true;` on those two happen to appear in deferred actions.

If the first thing that `action()` does for every CEO is prevent it from being used again, seems like a fine approach


### [Floyd.ts](https://github.com/terraforming-mars/terraforming-mars/compare/main...d-little:ceoStandardiseDisable?expand=1#diff-6d4226312c17ab01783fb183dcf6adc1c83a57146c9eb990d528befa46b69a5d)

Minor rework in the way this behaves to ensure that we're disabling the CEO while still providing reward