### PR TITLE
Step 1 of renaming cardType to type.

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -1484,7 +1484,7 @@ export class Game implements Logger {
   }
 
   public getCardsInHandByType(player: Player, cardType: CardType) {
-    return player.cardsInHand.filter((card) => card.cardType === cardType);
+    return player.cardsInHand.filter((card) => card.type === cardType);
   }
 
   public log(message: string, f?: (builder: LogBuilder) => void, options?: {reservedFor?: Player}) {

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -609,8 +609,8 @@ export class Player {
   public getNoTagsCount() {
     let noTagsCount = 0;
 
-    noTagsCount += this.corporations.filter((card) => card.cardType !== CardType.EVENT && card.tags.every((tag) => tag === Tag.WILD)).length;
-    noTagsCount += this.playedCards.filter((card) => card.cardType !== CardType.EVENT && card.tags.every((tag) => tag === Tag.WILD)).length;
+    noTagsCount += this.corporations.filter((card) => card.type !== CardType.EVENT && card.tags.every((tag) => tag === Tag.WILD)).length;
+    noTagsCount += this.playedCards.filter((card) => card.type !== CardType.EVENT && card.tags.every((tag) => tag === Tag.WILD)).length;
 
     return noTagsCount;
   }
@@ -669,7 +669,7 @@ export class Player {
    * Legend Milestone, Media Archives, and NOT Media Group.
    */
   public getPlayedEventsCount(): number {
-    let count = this.playedCards.filter((card) => card.cardType === CardType.EVENT).length;
+    let count = this.playedCards.filter((card) => card.type === CardType.EVENT).length;
     if (this.getCorporation(CardName.PHARMACY_UNION)?.isDisabled) count++;
 
     return count;
@@ -766,7 +766,7 @@ export class Player {
   }
 
   public getCardsByCardType(cardType: CardType) {
-    return this.playedCards.filter((card) => card.cardType === cardType);
+    return this.playedCards.filter((card) => card.type === cardType);
   }
 
   public deferInputCb(result: PlayerInput | undefined): void {
@@ -1056,7 +1056,7 @@ export class Player {
       microbes: card.tags.includes(Tag.PLANT),
       science: card.tags.includes(Tag.MOON),
       // TODO(kberg): add this.corporation.name === CardName.AURORAI
-      data: card.cardType === CardType.STANDARD_PROJECT,
+      data: card.type === CardType.STANDARD_PROJECT,
     };
   }
 
@@ -1155,7 +1155,7 @@ export class Player {
 
     ColoniesHandler.onCardPlayed(this.game, selectedCard);
 
-    if (selectedCard.cardType !== CardType.PROXY) {
+    if (selectedCard.type !== CardType.PROXY) {
       this.lastCardPlayed = selectedCard.name;
       this.game.log('${0} played ${1}', (b) => b.player(this).card(selectedCard));
     }
@@ -1225,7 +1225,7 @@ export class Player {
   }
 
   public onCardPlayed(card: IProjectCard) {
-    if (card.cardType === CardType.PROXY) {
+    if (card.type === CardType.PROXY) {
       return;
     }
     for (const playedCard of this.playedCards) {

--- a/src/server/awards/Adapter.ts
+++ b/src/server/awards/Adapter.ts
@@ -8,7 +8,7 @@ export class Adapter implements IAward {
 
   public getScore(player: Player): number {
     const validCards = player.playedCards.filter((card) => {
-      const isValidCardType = card.cardType !== CardType.EVENT;
+      const isValidCardType = card.type !== CardType.EVENT;
       const hasRequirements = card.requirements !== undefined;
 
       return isValidCardType && hasRequirements;

--- a/src/server/awards/Celebrity.ts
+++ b/src/server/awards/Celebrity.ts
@@ -7,6 +7,6 @@ export class Celebrity implements IAward {
   public readonly description = 'Most cards in play (not events) with a cost of at least 20 megacredits';
   public getScore(player: Player): number {
     return player.playedCards
-      .filter((card) => (card.cost >= 20) && (card.cardType === CardType.ACTIVE || card.cardType === CardType.AUTOMATED)).length;
+      .filter((card) => (card.cost >= 20) && (card.type === CardType.ACTIVE || card.type === CardType.AUTOMATED)).length;
   }
 }

--- a/src/server/awards/Magnate.ts
+++ b/src/server/awards/Magnate.ts
@@ -8,6 +8,6 @@ export class Magnate implements IAward {
   public readonly description = 'Most automated cards in play (green cards)';
   public getScore(player: Player): number {
     return player.playedCards
-      .filter((card) => card.cardType === CardType.AUTOMATED).length;
+      .filter((card) => card.type === CardType.AUTOMATED).length;
   }
 }

--- a/src/server/awards/Manufacturer.ts
+++ b/src/server/awards/Manufacturer.ts
@@ -6,6 +6,6 @@ export class Manufacturer implements IAward {
   public readonly name = 'Manufacturer';
   public readonly description = 'Having the most active (blue) cards in play';
   public getScore(player: Player): number {
-    return player.playedCards.filter((card) => card.cardType === CardType.ACTIVE).length;
+    return player.playedCards.filter((card) => card.type === CardType.ACTIVE).length;
   }
 }

--- a/src/server/awards/terraCimmeria/Economizer2.ts
+++ b/src/server/awards/terraCimmeria/Economizer2.ts
@@ -9,6 +9,6 @@ export class Economizer2 implements IAward {
   public getScore(player: Player): number {
     const validCardTypes = [CardType.ACTIVE, CardType.AUTOMATED];
     return player.playedCards
-      .filter((card) => (card.cost <= 10) && validCardTypes.includes(card.cardType)).length;
+      .filter((card) => (card.cost <= 10) && validCardTypes.includes(card.type)).length;
   }
 }

--- a/src/server/cards/Card.ts
+++ b/src/server/cards/Card.ts
@@ -24,21 +24,22 @@ import {getBehaviorExecutor} from '../behavior/BehaviorExecutor';
 type ReserveUnits = Units & {deduct: boolean};
 type FirstActionBehavior = Behavior & {text: string};
 
-/* External representation of card properties. */
-export interface StaticCardProperties {
+type TemporaryCardType = {type: CardType} | {cardType: CardType};
+
+type ProperitesMinusType = {
   /** @deprecated use behavior */
   adjacencyBonus?: AdjacencyBonus;
   behavior?: Behavior | undefined;
   cardCost?: number;
   cardDiscount?: CardDiscount | Array<CardDiscount>;
-  cardType: CardType;
+  // cardType: CardType;
   cost?: number;
   initialActionText?: string;
   firstAction?: FirstActionBehavior;
   metadata: ICardMetadata;
   requirements?: CardRequirements;
   name: CardName;
-  reserveUnits?: Partial<ReserveUnits>,
+  reserveUnits?: ReserveUnits,
   resourceType?: CardResource;
   startingMegaCredits?: number;
   tags?: Array<Tag>;
@@ -47,12 +48,18 @@ export interface StaticCardProperties {
   victoryPoints?: number | 'special' | IVictoryPoints,
 }
 
+// TODO(kberg): move this out.
+// Makes fields in T Partial.
+type PartialField<T, K extends keyof T> = Omit<T, K> & {[k in K]: Partial<T[K]>};
+
+/* External representation of card properties. */
+// type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+export type StaticCardProperties = PartialField<ProperitesMinusType, 'reserveUnits'> & TemporaryCardType;
+
 /*
  * Internal representation of card properties.
  */
-type Properties = Omit<StaticCardProperties, 'reserveUnits'> & {
-  reserveUnits?: ReserveUnits,
-};
+type Properties = ProperitesMinusType & {type: CardType};
 
 export const staticCardProperties = new Map<CardName, Properties>();
 
@@ -80,7 +87,8 @@ export abstract class Card {
   constructor(properties: StaticCardProperties) {
     let staticInstance = staticCardProperties.get(properties.name);
     if (staticInstance === undefined) {
-      if (properties.cardType === CardType.CORPORATION && properties.startingMegaCredits === undefined) {
+      const type = ('type' in properties) ? properties.type : properties.cardType;
+      if (type === CardType.CORPORATION && properties.startingMegaCredits === undefined) {
         throw new Error('must define startingMegaCredits for corporation cards');
       }
       if (properties.cost === undefined) {
@@ -90,7 +98,7 @@ export abstract class Card {
           CardType.CEO,
           CardType.STANDARD_ACTION,
         ];
-        if (noCostCardTypes.includes(properties.cardType) === false) {
+        if (noCostCardTypes.includes(type) === false) {
           throw new Error(`${properties.name} must have a cost property`);
         }
       }
@@ -99,6 +107,7 @@ export abstract class Card {
 
       const p: Properties = {
         ...properties,
+        type: type,
         reserveUnits: properties.reserveUnits === undefined ? undefined : {...Units.of(properties.reserveUnits), deduct: properties.reserveUnits.deduct ?? true},
       };
       staticCardProperties.set(properties.name, p);
@@ -116,8 +125,8 @@ export abstract class Card {
   public get cardCost() {
     return this.properties.cardCost;
   }
-  public get cardType() {
-    return this.properties.cardType;
+  public get type() {
+    return this.properties.type;
   }
   public get cost() {
     return this.properties.cost === undefined ? 0 : this.properties.cost;

--- a/src/server/cards/ICard.ts
+++ b/src/server/cards/ICard.ts
@@ -77,9 +77,8 @@ export interface ICard {
      */
     onResourceAdded?: (player: Player, playedCard: ICard, count: number) => void;
 
-    /** Used with IProjectCard only, I think. */
-    cost?: number;
-    cardType: CardType;
+    cost?: number; /** Used with IProjectCard and PreludeCard. */
+    type: CardType;
     requirements?: CardRequirements;
     metadata: ICardMetadata;
     warning?: string | Message;

--- a/src/server/cards/IProjectCard.ts
+++ b/src/server/cards/IProjectCard.ts
@@ -23,7 +23,7 @@ export interface IProjectCard extends ICard {
 }
 
 export function isIProjectCard(card: ICard): card is IProjectCard {
-  return card.cardType === CardType.AUTOMATED ||
-    card.cardType === CardType.ACTIVE ||
-    card.cardType === CardType.EVENT;
+  return card.type === CardType.AUTOMATED ||
+    card.type === CardType.ACTIVE ||
+    card.type === CardType.EVENT;
 }

--- a/src/server/cards/IStandardActionCard.ts
+++ b/src/server/cards/IStandardActionCard.ts
@@ -2,5 +2,5 @@ import {IActionCard, ICard} from './ICard';
 import {CardType} from '../../common/cards/CardType';
 
 export interface IStandardActionCard extends ICard, IActionCard {
-  cardType: CardType.STANDARD_ACTION;
+  type: CardType.STANDARD_ACTION;
 }

--- a/src/server/cards/IStandardProjectCard.ts
+++ b/src/server/cards/IStandardProjectCard.ts
@@ -2,6 +2,6 @@ import {IActionCard, ICard} from './ICard';
 import {CardType} from '../../common/cards/CardType';
 
 export interface IStandardProjectCard extends ICard, IActionCard {
-  cardType: CardType.STANDARD_PROJECT;
+  type: CardType.STANDARD_PROJECT;
   cost: number;
 }

--- a/src/server/cards/StandardActionCard.ts
+++ b/src/server/cards/StandardActionCard.ts
@@ -14,12 +14,12 @@ interface StaticStandardActionCardProperties {
 export abstract class StandardActionCard extends Card implements IActionCard, ICard {
   constructor(properties: StaticStandardActionCardProperties) {
     super({
-      cardType: CardType.STANDARD_ACTION,
+      type: CardType.STANDARD_ACTION,
       ...properties,
     });
   }
 
-  public override get cardType(): CardType.STANDARD_ACTION {
+  public override get type(): CardType.STANDARD_ACTION {
     return CardType.STANDARD_ACTION;
   }
 

--- a/src/server/cards/StandardProjectCard.ts
+++ b/src/server/cards/StandardProjectCard.ts
@@ -21,12 +21,12 @@ interface StaticStandardProjectCardProperties {
 export abstract class StandardProjectCard extends Card implements IActionCard, ICard {
   constructor(properties: StaticStandardProjectCardProperties) {
     super({
-      cardType: CardType.STANDARD_PROJECT,
+      type: CardType.STANDARD_PROJECT,
       ...properties,
     });
   }
 
-  public override get cardType(): CardType.STANDARD_PROJECT {
+  public override get type(): CardType.STANDARD_PROJECT {
     return CardType.STANDARD_PROJECT;
   }
 

--- a/src/server/cards/base/MediaGroup.ts
+++ b/src/server/cards/base/MediaGroup.ts
@@ -29,7 +29,7 @@ export class MediaGroup extends Card implements IProjectCard {
   }
 
   public onCardPlayed(player: Player, card: IProjectCard) {
-    if (card.cardType === CardType.EVENT) {
+    if (card.type === CardType.EVENT) {
       player.game.defer(new GainResources(player, Resources.MEGACREDITS, {count: 3}));
     }
   }

--- a/src/server/cards/base/MicroMills.ts
+++ b/src/server/cards/base/MicroMills.ts
@@ -7,7 +7,7 @@ import {CardRenderer} from '../render/CardRenderer';
 export class MicroMills extends Card implements IProjectCard {
   constructor() {
     super({
-      cardType: CardType.AUTOMATED,
+      type: CardType.AUTOMATED,
       name: CardName.MICRO_MILLS,
       cost: 3,
 

--- a/src/server/cards/base/OptimalAerobraking.ts
+++ b/src/server/cards/base/OptimalAerobraking.ts
@@ -25,7 +25,7 @@ export class OptimalAerobraking extends Card implements IProjectCard {
   }
 
   public onCardPlayed(player: Player, card: IProjectCard) {
-    if (card.cardType === CardType.EVENT && card.tags.includes(Tag.SPACE)) {
+    if (card.type === CardType.EVENT && card.tags.includes(Tag.SPACE)) {
       player.megaCredits += 3;
       player.heat += 3;
     }

--- a/src/server/cards/ceos/CeoCard.ts
+++ b/src/server/cards/ceos/CeoCard.ts
@@ -32,7 +32,7 @@ export abstract class CeoCard extends Card implements ICeoCard {
     return undefined;
   }
 
-  public override get cardType(): CardType.CEO {
+  public override get type(): CardType.CEO {
     return CardType.CEO;
   }
 }

--- a/src/server/cards/ceos/Faraday.ts
+++ b/src/server/cards/ceos/Faraday.ts
@@ -56,7 +56,7 @@ export class Faraday extends CeoCard {
   }
 
   public onCardPlayed(player: Player, card: IProjectCard) {
-    if (card.tags.length === 0 || card.cardType === CardType.EVENT || !player.canAfford(2)) return;
+    if (card.tags.length === 0 || card.type === CardType.EVENT || !player.canAfford(2)) return;
 
     const counts = this.countTags(player);
 

--- a/src/server/cards/ceos/ICeoCard.ts
+++ b/src/server/cards/ceos/ICeoCard.ts
@@ -18,5 +18,5 @@ export interface ICeoCard extends IProjectCard, Partial<IActionCard> {
 }
 
 export function isCeoCard(card: ICard): card is ICeoCard {
-  return card.cardType === CardType.CEO;
+  return card.type === CardType.CEO;
 }

--- a/src/server/cards/colonies/Aridor.ts
+++ b/src/server/cards/colonies/Aridor.ts
@@ -74,7 +74,7 @@ export class Aridor extends Card implements ICorporationCard {
 
   public onCardPlayed(player: Player, card: ICard) {
     if (
-      card.cardType === CardType.EVENT ||
+      card.type === CardType.EVENT ||
       card.tags.filter((tag) => tag !== Tag.WILD).length === 0 ||
       !player.isCorporation(this.name)) {
       return undefined;

--- a/src/server/cards/community/Playwrights.ts
+++ b/src/server/cards/community/Playwrights.ts
@@ -114,7 +114,7 @@ export class Playwrights extends Card implements ICorporationCard {
     try {
       player.game.getPlayers().forEach((p) => {
         playedEvents.push(...p.playedCards.filter((card) => {
-          return card.cardType === CardType.EVENT &&
+          return card.type === CardType.EVENT &&
           // Can player.canPlay(card) replace this?
           player.canAfford(player.getCardCost(card), {
             reserveUnits: MoonExpansion.adjustedReserveCosts(player, card),

--- a/src/server/cards/community/ScienceTagCard.ts
+++ b/src/server/cards/community/ScienceTagCard.ts
@@ -17,6 +17,9 @@ export class ScienceTagCard implements IProjectCard {
   public get cardType() {
     return CardType.PROXY;
   }
+  public get type() {
+    return CardType.PROXY;
+  }
   public canPlay() {
     return false;
   }

--- a/src/server/cards/corporation/ICorporationCard.ts
+++ b/src/server/cards/corporation/ICorporationCard.ts
@@ -20,5 +20,5 @@ export interface ICorporationCard extends ICard {
 }
 
 export function isICorporationCard(card: ICard): card is ICorporationCard {
-  return card.cardType === CardType.CORPORATION;
+  return card.type === CardType.CORPORATION;
 }

--- a/src/server/cards/corporation/InterplanetaryCinematics.ts
+++ b/src/server/cards/corporation/InterplanetaryCinematics.ts
@@ -36,7 +36,7 @@ export class InterplanetaryCinematics extends Card implements ICorporationCard {
     });
   }
   public onCardPlayed(player: Player, card: IProjectCard) {
-    if (player.isCorporation(this.name) && card.cardType === CardType.EVENT) {
+    if (player.isCorporation(this.name) && card.type === CardType.EVENT) {
       player.megaCredits += 2;
     }
   }

--- a/src/server/cards/pathfinders/MartianInsuranceGroup.ts
+++ b/src/server/cards/pathfinders/MartianInsuranceGroup.ts
@@ -38,7 +38,7 @@ export class MartianInsuranceGroup extends Card implements ICorporationCard {
   }
 
   public onCardPlayed(player: Player, card: IProjectCard): void {
-    if (player.isCorporation(this.name) && card.cardType === CardType.EVENT) {
+    if (player.isCorporation(this.name) && card.type === CardType.EVENT) {
       player.production.add(Resources.MEGACREDITS, 1, {log: true});
     }
   }

--- a/src/server/cards/pathfinders/Odyssey.ts
+++ b/src/server/cards/pathfinders/Odyssey.ts
@@ -45,7 +45,7 @@ export class Odyssey extends Card implements ICorporationCard, IActionCard {
     this.checkLoops++;
     try {
       return player.playedCards.filter((card) => {
-        return card.cardType === CardType.EVENT &&
+        return card.type === CardType.EVENT &&
         card.cost <= 16 &&
         player.canPlay(card);
       });

--- a/src/server/cards/pathfinders/PersonalAgenda.ts
+++ b/src/server/cards/pathfinders/PersonalAgenda.ts
@@ -28,7 +28,7 @@ export class PersonalAgenda extends PreludeCard {
   public override bespokePlay(player: Player) {
     player.drawCard(3, {
       include: (card) => {
-        return card.cardType === CardType.EVENT &&
+        return card.type === CardType.EVENT &&
           (card.tags.includes(Tag.SPACE) === false);
       }});
     return undefined;

--- a/src/server/cards/pathfinders/ValuableGases.ts
+++ b/src/server/cards/pathfinders/ValuableGases.ts
@@ -44,7 +44,7 @@ export class ValuableGases extends PreludeCard implements IProjectCard {
 
     const playableCards = player.cardsInHand.filter((card) => {
       return card.resourceType === CardResource.FLOATER &&
-        card.cardType === CardType.ACTIVE &&
+        card.type === CardType.ACTIVE &&
         player.canPlay(card);
     });
     if (playableCards.length !== 0) {

--- a/src/server/cards/prelude/IPreludeCard.ts
+++ b/src/server/cards/prelude/IPreludeCard.ts
@@ -4,9 +4,9 @@ import {CardType} from '../../../common/cards/CardType';
 
 export interface IPreludeCard extends IProjectCard {
   startingMegaCredits: number;
-  cardType: CardType.PRELUDE;
+  type: CardType.PRELUDE;
 }
 
 export function isPreludeCard(card: ICard): card is IPreludeCard {
-  return card.cardType === CardType.PRELUDE;
+  return card.type === CardType.PRELUDE;
 }

--- a/src/server/cards/prelude/PreludeCard.ts
+++ b/src/server/cards/prelude/PreludeCard.ts
@@ -27,7 +27,7 @@ export abstract class PreludeCard extends Card implements IPreludeCard {
       startingMegaCredits: properties.startingMegacredits,
     });
   }
-  public override get cardType(): CardType.PRELUDE {
+  public override get type(): CardType.PRELUDE {
     return CardType.PRELUDE;
   }
 }

--- a/src/server/cards/promo/DoubleDown.ts
+++ b/src/server/cards/promo/DoubleDown.ts
@@ -22,7 +22,7 @@ export class DoubleDown extends PreludeCard {
   }
 
   private cloneablePreludes(player: Player) {
-    return player.playedCards.filter((card) => card.cardType === CardType.PRELUDE)
+    return player.playedCards.filter((card) => card.type === CardType.PRELUDE)
       .filter((card) => card.name !== this.name)
       .filter((card) => card.canPlay(player));
   }

--- a/src/server/deferredActions/DrawCards.ts
+++ b/src/server/deferredActions/DrawCards.ts
@@ -31,7 +31,7 @@ export class DrawCards<T extends undefined | SelectCard<IProjectCard>> extends D
       if (this.options.resource !== undefined && this.options.resource !== card.resourceType) {
         return false;
       }
-      if (this.options.cardType !== undefined && this.options.cardType !== card.cardType) {
+      if (this.options.cardType !== undefined && this.options.cardType !== card.type) {
         return false;
       }
       if (this.options.tag !== undefined && !this.player.tags.cardHasTag(card, this.options.tag)) {

--- a/src/server/milestones/Tactician.ts
+++ b/src/server/milestones/Tactician.ts
@@ -9,7 +9,7 @@ export class Tactician implements IMilestone {
 
   public getScore(player: Player): number {
     const validCards = player.playedCards.filter((card) => {
-      const isValidCardType = !this.excludedCardTypes.includes(card.cardType);
+      const isValidCardType = !this.excludedCardTypes.includes(card.type);
       const hasRequirements = card.requirements !== undefined;
 
       return isValidCardType && hasRequirements;

--- a/src/server/milestones/Tycoon.ts
+++ b/src/server/milestones/Tycoon.ts
@@ -7,7 +7,7 @@ export class Tycoon implements IMilestone {
   public readonly description = 'Requires that you have 15 project cards in play (blue and green cards)';
   public getScore(player: Player): number {
     return player.playedCards
-      .filter((card) => card.cardType === CardType.ACTIVE || card.cardType === CardType.AUTOMATED).length;
+      .filter((card) => card.type === CardType.ACTIVE || card.type === CardType.AUTOMATED).length;
   }
   public canClaim(player: Player): boolean {
     return this.getScore(player) > 14;

--- a/src/server/milestones/terraCimmeria/Collector.ts
+++ b/src/server/milestones/terraCimmeria/Collector.ts
@@ -7,8 +7,8 @@ export class Collector implements IMilestone {
   public readonly description = 'Have 3 sets of automated, active and event cards';
 
   public getScore(player: Player): number {
-    const numAutomatedCards = player.playedCards.filter((card) => card.cardType === CardType.AUTOMATED).length;
-    const numActiveCards = player.playedCards.filter((card) => card.cardType === CardType.ACTIVE).length;
+    const numAutomatedCards = player.playedCards.filter((card) => card.type === CardType.AUTOMATED).length;
+    const numActiveCards = player.playedCards.filter((card) => card.type === CardType.ACTIVE).length;
     const numEventCards = player.getPlayedEventsCount();
 
     return Math.min(numAutomatedCards, numActiveCards, numEventCards);

--- a/src/server/models/ServerModel.ts
+++ b/src/server/models/ServerModel.ts
@@ -382,7 +382,7 @@ export class Server {
         resources: options.showResources ? card.resourceCount : undefined,
         name: card.name,
         calculatedCost: options.showCalculatedCost ? (isIProjectCard(card) && card.cost !== undefined ? player.getCardCost(card) : undefined) : card.cost,
-        cardType: card.cardType,
+        cardType: card.type,
         isDisabled: isDisabled,
         warning: card.warning,
         reserveUnits: options.reserveUnits ? options.reserveUnits[index] : Units.EMPTY,

--- a/src/server/pathfinders/PathfindersExpansion.ts
+++ b/src/server/pathfinders/PathfindersExpansion.ts
@@ -63,7 +63,7 @@ export class PathfindersExpansion {
     });
 
     // Communication Center hook
-    if (card.cardType === CardType.EVENT) {
+    if (card.type === CardType.EVENT) {
       for (const p of player.game.getPlayers()) {
         for (const c of p.playedCards) {
           if (c.name === CardName.COMMUNICATION_CENTER) {

--- a/src/server/player/Tags.ts
+++ b/src/server/player/Tags.ts
@@ -136,7 +136,7 @@ export class Tags {
     let tagCount = 0;
 
     this.player.tableau.forEach((card: IProjectCard | ICorporationCard) => {
-      if (!includeEventsTags && card.cardType === CardType.EVENT) return;
+      if (!includeEventsTags && card.type === CardType.EVENT) return;
       if (isICorporationCard(card) && card.isDisabled) return;
       tagCount += card.tags.filter((cardTag) => cardTag === tag).length;
     });
@@ -195,7 +195,7 @@ export class Tags {
       }
     }
     for (const card of this.player.playedCards) {
-      if (card.cardType !== CardType.EVENT) {
+      if (card.type !== CardType.EVENT) {
         card.tags.forEach(addTag);
       }
     }

--- a/src/server/tools/export_card_rendering.ts
+++ b/src/server/tools/export_card_rendering.ts
@@ -57,7 +57,7 @@ class ProjectCardProcessor {
       cardDiscount: card.cardDiscount,
       victoryPoints: card.victoryPoints,
       cost: card.cost,
-      cardType: card.cardType,
+      cardType: card.type,
       requirements: card.requirements,
       metadata: card.metadata,
       warning: card.warning,

--- a/src/server/turmoil/globalEvents/CelebrityLeaders.ts
+++ b/src/server/turmoil/globalEvents/CelebrityLeaders.ts
@@ -27,7 +27,7 @@ export class CelebrityLeaders extends GlobalEvent implements IGlobalEvent {
 
   public resolve(game: Game, turmoil: Turmoil) {
     game.getPlayersInGenerationOrder().forEach((player) => {
-      const eventsCards = player.playedCards.filter((card) => card.cardType === CardType.EVENT).length;
+      const eventsCards = player.playedCards.filter((card) => card.type === CardType.EVENT).length;
       player.addResource(Resources.MEGACREDITS, 2 * (Math.min(5, eventsCards) + turmoil.getPlayerInfluence(player)), {log: true, from: this.name});
     });
   }

--- a/src/server/turmoil/globalEvents/SolarnetShutdown.ts
+++ b/src/server/turmoil/globalEvents/SolarnetShutdown.ts
@@ -26,7 +26,7 @@ export class SolarnetShutdown extends GlobalEvent implements IGlobalEvent {
   }
   public resolve(game: Game, turmoil: Turmoil) {
     game.getPlayersInGenerationOrder().forEach((player) => {
-      const amount = Math.min(5, player.playedCards.filter((card) => card.cardType === CardType.ACTIVE).length) - turmoil.getPlayerInfluence(player);
+      const amount = Math.min(5, player.playedCards.filter((card) => card.type === CardType.ACTIVE).length) - turmoil.getPlayerInfluence(player);
       if (amount > 0) {
         player.deductResource(Resources.MEGACREDITS, amount * 3, {log: true, from: this.name});
       }

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -126,7 +126,7 @@ const FAKE_CARD_TEMPLATE: IProjectCard = {
   canPlay: () => true,
   play: () => undefined,
   getVictoryPoints: () => 0,
-  cardType: CardType.ACTIVE,
+  type: CardType.ACTIVE,
   metadata: {},
   resourceCount: 0,
 };

--- a/tests/awards/amazonisPlanitia/Curator.spec.ts
+++ b/tests/awards/amazonisPlanitia/Curator.spec.ts
@@ -42,7 +42,7 @@ describe('Curator', () => {
     player.playedCards.push(fakeCard({tags: [Tag.SPACE, Tag.BUILDING]}));
     expect(award.getScore(player)).to.eq(1);
 
-    player.playedCards.push(fakeCard({tags: [Tag.SPACE, Tag.BUILDING], cardType: CardType.EVENT}));
+    player.playedCards.push(fakeCard({tags: [Tag.SPACE, Tag.BUILDING], type: CardType.EVENT}));
     expect(award.getScore(player)).to.eq(1);
   });
 });

--- a/tests/behavior/Executor.spec.ts
+++ b/tests/behavior/Executor.spec.ts
@@ -161,9 +161,9 @@ describe('Executor', () => {
     expect(player.cardsInHand[0].tags).contains(Tag.SPACE);
     expect(player.cardsInHand[1].tags).contains(Tag.SPACE);
     expect(player.cardsInHand[2].tags).contains(Tag.SPACE);
-    expect(player.cardsInHand[0].cardType).eq(CardType.EVENT);
-    expect(player.cardsInHand[1].cardType).eq(CardType.EVENT);
-    expect(player.cardsInHand[2].cardType).eq(CardType.EVENT);
+    expect(player.cardsInHand[0].type).eq(CardType.EVENT);
+    expect(player.cardsInHand[1].type).eq(CardType.EVENT);
+    expect(player.cardsInHand[2].type).eq(CardType.EVENT);
     expect(player.megaCredits).eq(5);
   });
 

--- a/tests/cards/Card.spec.ts
+++ b/tests/cards/Card.spec.ts
@@ -9,7 +9,7 @@ import {Tag} from '../../src/common/cards/Tag';
 describe('Card', function() {
   it('pulls values for typical corporation', function() {
     const card = new Helion();
-    expect(card.cardType).to.eq(CardType.CORPORATION);
+    expect(card.type).to.eq(CardType.CORPORATION);
     expect(card.initialActionText).is.undefined;
     expect(card.startingMegaCredits).to.eq(42);
     expect(card.metadata).not.is.undefined;

--- a/tests/cards/ceo/Faraday.spec.ts
+++ b/tests/cards/ceo/Faraday.spec.ts
@@ -147,7 +147,7 @@ describe('Faraday', function() {
 
   it('Does not trigger on event cards', function() {
     player.playedCards.push(fakeCard({tags: [Tag.SCIENCE, Tag.SCIENCE, Tag.SCIENCE, Tag.SCIENCE]}));
-    player.playCard(fakeCard({tags: [Tag.SCIENCE], cardType: CardType.EVENT}));
+    player.playCard(fakeCard({tags: [Tag.SCIENCE], type: CardType.EVENT}));
     expect(game.deferredActions).has.length(0);
     expect(player.cardsInHand).has.length(0);
   });

--- a/tests/cards/ceo/Karen.spec.ts
+++ b/tests/cards/ceo/Karen.spec.ts
@@ -32,7 +32,7 @@ describe('Karen', function() {
     expect(selectCard.cards).has.length(1);
 
     selectCard.cb([selectCard.cards[0]]);
-    expect(player.playedCards.filter((card) => card.cardType === CardType.PRELUDE)).has.length(1);
+    expect(player.playedCards.filter((card) => card.type === CardType.PRELUDE)).has.length(1);
   });
 
   it('Takes action in Generation 4', function() {
@@ -45,7 +45,7 @@ describe('Karen', function() {
     expect(selectCard.cards).has.length(4);
 
     selectCard.cb([selectCard.cards[0]]);
-    expect(player.playedCards.filter((card) => card.cardType === CardType.PRELUDE)).has.length(1);
+    expect(player.playedCards.filter((card) => card.type === CardType.PRELUDE)).has.length(1);
   });
 
   it('Discards unplayable prelude cards', function() {
@@ -54,7 +54,7 @@ describe('Karen', function() {
 
     const action = card.action(player);
     expect(action).is.undefined;
-    expect(player.playedCards.filter((card) => card.cardType === CardType.PRELUDE)).has.length(0);
+    expect(player.playedCards.filter((card) => card.type === CardType.PRELUDE)).has.length(0);
   });
 
   it('Can only act once per game', function() {

--- a/tests/cards/ceo/Lowell.spec.ts
+++ b/tests/cards/ceo/Lowell.spec.ts
@@ -46,7 +46,7 @@ describe('Lowell', function() {
     game.deferredActions.runNext();
 
     selectCard.cb([selectCard.cards[0]]);
-    expect(player.playedCards.filter((card) => card.cardType === CardType.CEO).length).eq(1);
+    expect(player.playedCards.filter((card) => card.type === CardType.CEO).length).eq(1);
     expect(player.playedCards.includes(card)).is.false;
     expect(player.megaCredits).eq(0);
   });

--- a/tests/cards/community/ProjectWorkshop.spec.ts
+++ b/tests/cards/community/ProjectWorkshop.spec.ts
@@ -45,7 +45,7 @@ describe('ProjectWorkshop', function() {
     player.runInitialAction(card);
     runAllActions(game);
     expect(player.cardsInHand).has.lengthOf(1);
-    expect(player.cardsInHand[0].cardType).to.eq(CardType.ACTIVE);
+    expect(player.cardsInHand[0].type).to.eq(CardType.ACTIVE);
   });
 
   it('Can not act', function() {
@@ -60,7 +60,7 @@ describe('ProjectWorkshop', function() {
     card.action(player).cb();
     runAllActions(game);
     expect(player.cardsInHand).has.lengthOf(1);
-    expect(player.cardsInHand[0].cardType).to.eq(CardType.ACTIVE);
+    expect(player.cardsInHand[0].type).to.eq(CardType.ACTIVE);
   });
 
   it('Can flip a played blue card and remove its ongoing effects', function() {
@@ -197,6 +197,6 @@ describe('ProjectWorkshop', function() {
     expect(player.megaCredits).to.eq(1);
     expect(player.heat).to.eq(3);
     expect(player.cardsInHand).has.lengthOf(1);
-    expect(player.cardsInHand[0].cardType).to.eq(CardType.ACTIVE);
+    expect(player.cardsInHand[0].type).to.eq(CardType.ACTIVE);
   });
 });

--- a/tests/cards/pathfinders/CommunicationCenter.spec.ts
+++ b/tests/cards/pathfinders/CommunicationCenter.spec.ts
@@ -45,25 +45,25 @@ describe('CommunicationCenter', function() {
     player.playedCards = [card];
     expect(card.resourceCount).eq(0);
 
-    player.onCardPlayed(fakeCard({cardType: CardType.ACTIVE}));
+    player.onCardPlayed(fakeCard({type: CardType.ACTIVE}));
     expect(card.resourceCount).eq(0);
-    player.onCardPlayed(fakeCard({cardType: CardType.AUTOMATED}));
+    player.onCardPlayed(fakeCard({type: CardType.AUTOMATED}));
     expect(card.resourceCount).eq(0);
-    player.onCardPlayed(fakeCard({cardType: CardType.CORPORATION}));
+    player.onCardPlayed(fakeCard({type: CardType.CORPORATION}));
     expect(card.resourceCount).eq(0);
-    player.onCardPlayed(fakeCard({cardType: CardType.PRELUDE}));
+    player.onCardPlayed(fakeCard({type: CardType.PRELUDE}));
     expect(card.resourceCount).eq(0);
 
-    player.onCardPlayed(fakeCard({cardType: CardType.EVENT}));
+    player.onCardPlayed(fakeCard({type: CardType.EVENT}));
     expect(card.resourceCount).eq(1);
 
-    otherPlayer.onCardPlayed(fakeCard({cardType: CardType.EVENT}));
+    otherPlayer.onCardPlayed(fakeCard({type: CardType.EVENT}));
     expect(card.resourceCount).eq(2);
 
     expect(player.cardsInHand).is.length(0);
     expect(otherPlayer.cardsInHand).is.length(0);
 
-    otherPlayer.onCardPlayed(fakeCard({cardType: CardType.EVENT}));
+    otherPlayer.onCardPlayed(fakeCard({type: CardType.EVENT}));
 
     expect(card.resourceCount).eq(0);
     expect(player.cardsInHand).is.length(1);

--- a/tests/cards/pathfinders/MartianInsuranceGroup.spec.ts
+++ b/tests/cards/pathfinders/MartianInsuranceGroup.spec.ts
@@ -22,7 +22,7 @@ describe('MartianInsuranceGroup', function() {
   });
 
   it('when you play an event', function() {
-    const event = fakeCard({name: 'A' as CardName, cardType: CardType.EVENT});
+    const event = fakeCard({name: 'A' as CardName, type: CardType.EVENT});
     expect(player.production.megacredits).eq(0);
     expect(player2.production.megacredits).eq(0);
     player.playCard(event);
@@ -31,7 +31,7 @@ describe('MartianInsuranceGroup', function() {
   });
 
   it('when opponent plays an event', function() {
-    const event = fakeCard({name: 'A' as CardName, cardType: CardType.EVENT});
+    const event = fakeCard({name: 'A' as CardName, type: CardType.EVENT});
     expect(player.production.megacredits).eq(0);
     expect(player2.production.megacredits).eq(0);
     player2.playCard(event);

--- a/tests/cards/pathfinders/Odyssey.spec.ts
+++ b/tests/cards/pathfinders/Odyssey.spec.ts
@@ -32,7 +32,7 @@ describe('Odyssey', () => {
   });
 
   it('events count for tags', () => {
-    const event = fakeCard({cardType: CardType.EVENT, tags: [Tag.JOVIAN]});
+    const event = fakeCard({type: CardType.EVENT, tags: [Tag.JOVIAN]});
     player.playedCards.push(event);
     expect(player.tags.count(Tag.JOVIAN)).eq(1);
     player.setCorporationForTest(undefined);
@@ -40,7 +40,7 @@ describe('Odyssey', () => {
   });
 
   it('cannot act - cannot afford', () => {
-    const expensiveEvent = fakeCard({cardType: CardType.EVENT, cost: 8});
+    const expensiveEvent = fakeCard({type: CardType.EVENT, cost: 8});
     player.playedCards = [expensiveEvent];
     expect(card.canAct(player)).is.false;
     player.megaCredits = 7;
@@ -64,8 +64,8 @@ describe('Odyssey', () => {
   it('can act', () => {
     player.megaCredits = 50;
     expect(card.canAct(player)).is.false;
-    const expensiveEvent = fakeCard({cardType: CardType.EVENT, cost: 17});
-    const nonEvent = fakeCard({cardType: CardType.ACTIVE, cost: 2});
+    const expensiveEvent = fakeCard({type: CardType.EVENT, cost: 17});
+    const nonEvent = fakeCard({type: CardType.ACTIVE, cost: 2});
     player.playedCards = [expensiveEvent, nonEvent];
     expect(card.canAct(player)).is.false;
     expensiveEvent.cost = 16;

--- a/tests/cards/pathfinders/PersonalAgenda.spec.ts
+++ b/tests/cards/pathfinders/PersonalAgenda.spec.ts
@@ -25,7 +25,7 @@ describe('PersonalAgenda', function() {
 
     expect(player.cardsInHand).has.lengthOf(3);
     player.cardsInHand.forEach((card) => {
-      expect(card.cardType).eq(CardType.EVENT);
+      expect(card.type).eq(CardType.EVENT);
       expect(card.tags.indexOf(Tag.SPACE)).to.eq(-1);
     });
   });

--- a/tests/cards/prelude/ValleyTrust.spec.ts
+++ b/tests/cards/prelude/ValleyTrust.spec.ts
@@ -36,7 +36,7 @@ describe('ValleyTrust', function() {
   it('initial action', () => {
     const selectCard = cast(card.initialAction(player), SelectCard);
     expect(selectCard.cards).has.length(3);
-    expect(selectCard.cards.filter((c) => c.cardType === CardType.PRELUDE)).has.length(3);
+    expect(selectCard.cards.filter((c) => c.type === CardType.PRELUDE)).has.length(3);
   });
 
   it('Card works even without prelude expansion enabled', () => {
@@ -44,6 +44,6 @@ describe('ValleyTrust', function() {
     const player = getTestPlayer(game, 0);
     const selectCard = cast(card.initialAction(player), SelectCard);
     expect(selectCard.cards).has.length(3);
-    expect(selectCard.cards.filter((c) => c.cardType === CardType.PRELUDE)).has.length(3);
+    expect(selectCard.cards.filter((c) => c.type === CardType.PRELUDE)).has.length(3);
   });
 });

--- a/tests/cards/promo/NewPartner.spec.ts
+++ b/tests/cards/promo/NewPartner.spec.ts
@@ -31,7 +31,7 @@ describe('NewPartner', function() {
     expect(selectCard.cards).has.length(2);
     selectCard.cb([selectCard.cards[0]]);
     expect(player.production.megacredits).to.eq(1);
-    expect(player.playedCards.every((card) => card.cardType === CardType.PRELUDE)).is.true;
+    expect(player.playedCards.every((card) => card.type === CardType.PRELUDE)).is.true;
   });
 
   it('Should play with only 1 playable prelude', function() {

--- a/tests/cards/venusNext/MaxwellBase.spec.ts
+++ b/tests/cards/venusNext/MaxwellBase.spec.ts
@@ -85,7 +85,7 @@ describe('MaxwellBase', function() {
       canPlay: () => true,
       play: () => undefined,
       getVictoryPoints: () => 0,
-      cardType: CardType.ACTIVE,
+      type: CardType.ACTIVE,
       metadata: {
         cardNumber: '1',
       },

--- a/tests/deferredActions/DrawCards.spec.ts
+++ b/tests/deferredActions/DrawCards.spec.ts
@@ -45,7 +45,7 @@ describe('DrawCards', function() {
   it('draws 3 special', function() {
     DrawCards.keepAll(player, 3, {cardType: CardType.ACTIVE, tag: Tag.SPACE}).execute();
     expect(player.cardsInHand).has.length(3);
-    expect(player.cardsInHand.filter((card) => card.tags.includes(Tag.SPACE) && card.cardType === CardType.ACTIVE))
+    expect(player.cardsInHand.filter((card) => card.tags.includes(Tag.SPACE) && card.type === CardType.ACTIVE))
       .has.length(3);
   });
 

--- a/tests/player/Tags.spec.ts
+++ b/tests/player/Tags.spec.ts
@@ -27,7 +27,7 @@ describe('Tags', function() {
   });
 
   function playFakeCorporation(...tags: Array<Tag>) {
-    const card = fakeCard({cardType: CardType.CORPORATION, tags: tags});
+    const card = fakeCard({type: CardType.CORPORATION, tags: tags});
     if (isICorporationCard(card)) {
       player.corporations.push(card);
     } else {
@@ -36,12 +36,12 @@ describe('Tags', function() {
   }
 
   function playFakeEvent(...tags: Array<Tag>) {
-    const card = fakeCard({cardType: CardType.EVENT, tags: tags});
+    const card = fakeCard({type: CardType.EVENT, tags: tags});
     player.playedCards.push(card);
   }
 
   function playFakeProject(...tags: Array<Tag>) {
-    const card = fakeCard({cardType: CardType.AUTOMATED, tags: tags});
+    const card = fakeCard({type: CardType.AUTOMATED, tags: tags});
     player.playedCards.push(card);
   }
 


### PR DESCRIPTION
This is just a readability renaming. The trick is that this PR limits the blast radius by not requiring cards to change from cardType to type. This is done for the most part in all the StaticCardProperties mumbo jumbo.

The remaining steps include
1. Changing CardModel (and UI.)
2. Changing ClientCard
3. Changing the fields in cards. (Which is ~600 cards, so can also be done in pieces.)