### PR TITLE
Fix: CEO Floyd OPG Discounts

### DIFF
--- a/src/server/cards/ceos/Floyd.ts
+++ b/src/server/cards/ceos/Floyd.ts
@@ -4,7 +4,6 @@ import {PlayerInput} from '../../PlayerInput';
 import {CardRenderer} from '../render/CardRenderer';
 import {CeoCard} from './CeoCard';
 import {PlayProjectCard} from '../../deferredActions/PlayProjectCard';
-import {SimpleDeferredAction} from '../../deferredActions/DeferredAction';
 import {multiplier} from '../Options';
 
 export class Floyd extends CeoCard {
@@ -36,17 +35,16 @@ export class Floyd extends CeoCard {
   public action(player: Player): PlayerInput | undefined {
     this.isDisabled = true;
     this.opgActionIsActive = true;
-    player.game.defer(new PlayProjectCard(player));
-    player.game.defer(new SimpleDeferredAction(player, () => {
+    player.game.defer(new PlayProjectCard(player, () => {
+      this.opgActionIsActive = false;
       return undefined;
     }));
     return undefined;
   }
 
   public override getCardDiscount(player: Player) {
-    if (player.getActionsThisGeneration().has(this.name) && this.opgActionIsActive === true) {
-      this.opgActionIsActive = false;
-      return 13 + 2 * player.game.generation;
+    if (this.opgActionIsActive === true) {
+      return 13 + (2 * player.game.generation);
     }
     return 0;
   }

--- a/src/server/deferredActions/PlayProjectCard.ts
+++ b/src/server/deferredActions/PlayProjectCard.ts
@@ -1,9 +1,10 @@
+import {IProjectCard} from '../cards/IProjectCard';
 import {SelectProjectCardToPlay} from '../inputs/SelectProjectCardToPlay';
 import {Player} from '../Player';
 import {DeferredAction, Priority} from './DeferredAction';
 
 export class PlayProjectCard extends DeferredAction {
-  constructor(player: Player) {
+  constructor(player: Player, private cb?: (card: IProjectCard) => void) {
     super(player, Priority.DEFAULT);
   }
 
@@ -12,6 +13,6 @@ export class PlayProjectCard extends DeferredAction {
     if (playableCards.length === 0) {
       return undefined;
     }
-    return new SelectProjectCardToPlay(this.player, playableCards);
+    return new SelectProjectCardToPlay(this.player, playableCards, {cb: this.cb});
   }
 }


### PR DESCRIPTION
May need to update tests too

Should resolve:

> Floyd CEO bug - would not allow me to use the discount against a card that cost more than the discount to be given.  Generation 3, should be a discount of 13 + 6, would not let me play Phobos Space Haven when I had 9 MC in hand and 3 titanium
