### PR TITLE
Show All Corporation Names (Merger etc)

### DIFF
--- a/src/client/components/GameEnd.vue
+++ b/src/client/components/GameEnd.vue
@@ -283,7 +283,7 @@ export default Vue.extend({
       const corporationCards = cards
         .filter((card) => getCard(card.name)?.type === CardType.CORPORATION)
         .map((card) => card.name);
-      return corporationCards;
+      return corporationCards.length === 0 ? [''] : corporationCards;
     },
   },
 });

--- a/src/client/components/GameEnd.vue
+++ b/src/client/components/GameEnd.vue
@@ -78,7 +78,9 @@
                       <tr v-for="p in getSortedPlayers()" :key="p.color" :class="getEndGamePlayerRowColorClass(p.color)">
                           <td>
                             <a :href="'player?id='+p.id+'&noredirect'">{{ p.name }}</a>
-                            <div class="column-corporation"><span v-i18n>{{ getCorporationName(p) }}</span></div>
+                            <div class="column-corporation">
+                              <div v-for="(corporationName, index) in getCorporationName(p)" :key="index" v-i18n>{{ corporationName }}</div>
+                            </div>
                           </td>
                           <td>{{ p.victoryPointsBreakdown.terraformRating }}</td>
                           <td>{{ p.victoryPointsBreakdown.milestones }}</td>
@@ -276,9 +278,12 @@ export default Vue.extend({
     isSoloGame(): boolean {
       return this.players.length === 1;
     },
-    getCorporationName(p: PublicPlayerModel): string {
-      const firstCard = p.tableau[0];
-      return getCard(firstCard.name)?.type === CardType.CORPORATION ? firstCard.name : '';
+    getCorporationName(p: PublicPlayerModel): string[] {
+      const cards = p.tableau;
+      const corporationCards = cards
+        .filter((card) => getCard(card.name)?.type === CardType.CORPORATION)
+        .map((card) => card.name);
+      return corporationCards;
     },
   },
 });

--- a/src/client/components/overview/PlayerInfo.vue
+++ b/src/client/components/overview/PlayerInfo.vue
@@ -9,7 +9,6 @@ import {vueRoot} from '@/client/components/vueRoot';
 import {range} from '@/common/utils/utils';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {CardType} from '@/common/cards/CardType';
-import {CardName} from '@/common/cards/CardName';
 import {getCard} from '@/client/cards/ClientCardManifest';
 import {Phase} from '@/common/Phase';
 

--- a/src/client/components/overview/PlayerInfo.vue
+++ b/src/client/components/overview/PlayerInfo.vue
@@ -109,12 +109,12 @@ export default Vue.extend({
     availableBlueActionCount(): number {
       return this.player.availableBlueCardActionCount;
     },
-    getCorporationName(): CardName[] | undefined {
+    getCorporationName(): string[] {
       const cards = this.player.tableau;
       const corporationCards = cards
         .filter((card) => getCard(card.name)?.type === CardType.CORPORATION)
         .map((card) => card.name);
-      return corporationCards;
+      return corporationCards.length === 0 ? [''] : corporationCards;
     },
   },
 });

--- a/src/client/components/overview/PlayerInfo.vue
+++ b/src/client/components/overview/PlayerInfo.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
               </div>
             </span>
           </div>
-          <player-status :timer="player.timer" :showTimers="playerView.game.gameOptions.showTimers" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" />
+          <player-status :timer="player.timer" :showTimer="playerView.game.gameOptions.showTimers" :liveTimer="playerView.game.phase !== Phase.END" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" />
         </div>
           <PlayerResources :player="player" v-trim-whitespace />
           <div class="player-played-cards">

--- a/src/client/components/overview/PlayerInfo.vue
+++ b/src/client/components/overview/PlayerInfo.vue
@@ -125,14 +125,16 @@ export default Vue.extend({
         <div class="player-status">
           <div class="player-info-details">
             <div class="player-info-name" @click="togglePlayerDetails">{{ player.name }}</div>
-            <div class="icon-first-player" v-if="firstForGen && playerView.players.length > 1" v-i18n>1st</div>
             <span @click="togglePlayerDetails" v-for="(corporationName, index) in getCorporationName()" :key="index" v-i18n>
               <div class="player-info-corp" :title="$t(corporationName)">
                 {{ corporationName }}
               </div>
             </span>
           </div>
-          <player-status :timer="player.timer" :showTimer="playerView.game.gameOptions.showTimers" :liveTimer="playerView.game.phase !== Phase.END" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" />
+          <div>
+            <div class="icon-first-player" v-if="firstForGen && playerView.players.length > 1" v-i18n>1st</div>
+            <player-status :timer="player.timer" :showTimer="playerView.game.gameOptions.showTimers" :liveTimer="playerView.game.phase !== Phase.END" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel"/>
+          </div>
         </div>
           <PlayerResources :player="player" v-trim-whitespace />
           <div class="player-played-cards">

--- a/src/client/components/overview/PlayerInfo.vue
+++ b/src/client/components/overview/PlayerInfo.vue
@@ -109,10 +109,12 @@ export default Vue.extend({
     availableBlueActionCount(): number {
       return this.player.availableBlueCardActionCount;
     },
-    corporationCardName(): CardName | undefined {
-      const card = this.player.tableau[0];
-      if (getCard(card.name)?.type !== CardType.CORPORATION) return undefined;
-      return card.name;
+    getCorporationName(): CardName[] | undefined {
+      const cards = this.player.tableau;
+      const corporationCards = cards
+        .filter((card) => getCard(card.name)?.type === CardType.CORPORATION)
+        .map((card) => card.name);
+      return corporationCards;
     },
   },
 });
@@ -125,9 +127,13 @@ export default Vue.extend({
           <div class="player-info-details">
             <div class="player-info-name" @click="togglePlayerDetails">{{ player.name }}</div>
             <div class="icon-first-player" v-if="firstForGen && playerView.players.length > 1" v-i18n>1st</div>
-            <div class="player-info-corp" @click="togglePlayerDetails" v-if="corporationCardName() !== undefined" :title="$t(corporationCardName())"><span v-i18n>{{ corporationCardName() }}</span></div>
+            <span @click="togglePlayerDetails" v-for="(corporationName, index) in getCorporationName()" :key="index" v-i18n>
+              <div class="player-info-corp" :title="$t(corporationName)">
+                {{ corporationName }}
+              </div>
+            </span>
           </div>
-          <player-status :timer="player.timer" :showTimer="playerView.game.gameOptions.showTimers" :liveTimer="playerView.game.phase !== Phase.END" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" />
+          <player-status :timer="player.timer" :showTimers="playerView.game.gameOptions.showTimers" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" />
         </div>
           <PlayerResources :player="player" v-trim-whitespace />
           <div class="player-played-cards">

--- a/src/styles/players_overview.less
+++ b/src/styles/players_overview.less
@@ -10,7 +10,7 @@
     line-height: 24px;
     height: 26px;
     letter-spacing: 0px;
-    margin-top: 34px;
+    margin-top: 8px;
     left: -17px;
     background: linear-gradient(to right, black, #aaa,#aaa, #aaa);
     color: black;


### PR DESCRIPTION
Display all corporation names under the players name on both player screen and endgame.

This kinda breaks the placement of the First Player token, but I think the utility outweighs the issue.

PlayerView:
![image](https://user-images.githubusercontent.com/2050250/225171405-3d4051a3-cf6e-4b65-8c1c-52ab48f6c58f.png)

Endgame:
![image](https://user-images.githubusercontent.com/2050250/225170739-d8982626-b296-4011-bf71-fa844167efd7.png)
