### PR TITLE
WIP: disallow loading and saving purged games.

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -376,7 +376,7 @@ export class Game implements Logger {
   }
 
   public save(): void {
-    Database.getInstance().saveGame(this);
+    GameLoader.getInstance().saveGame(this);
   }
 
   public toJSON(): string {
@@ -985,12 +985,7 @@ export class Game implements Logger {
 
     Database.getInstance().saveGameResults(this.id, this.players.length, this.generation, this.gameOptions, scores);
     this.phase = Phase.END;
-    Database.getInstance().saveGame(this).then(() => {
-      GameLoader.getInstance().mark(this.id);
-      return Database.getInstance().cleanGame(this.id);
-    }).catch((err) => {
-      console.error(err);
-    });
+    GameLoader.getInstance().completeGame(this);
   }
 
   // Part of final greenery placement.

--- a/src/server/database/GameLoader.ts
+++ b/src/server/database/GameLoader.ts
@@ -34,11 +34,13 @@ export class GameLoader implements IGameLoader {
   private cache: Cache;
   private readonly config: CacheConfig;
   private readonly clock: Clock;
+  private purgedGames: Array<GameId>;
 
   private constructor(config: CacheConfig, clock: Clock) {
     this.config = config;
     this.clock = clock;
     this.cache = new Cache(config, clock);
+    this.purgedGames = [];
     timeAsync(this.cache.load())
       .then((v) => {
         metrics.initialize.set(v.duration);
@@ -140,6 +142,27 @@ export class GameLoader implements IGameLoader {
 
   public sweep() {
     this.cache.sweep();
+  }
+
+  public async completeGame(game: Game) {
+    const database = Database.getInstance();
+    await database.saveGame(game);
+    try {
+      this.mark(game.id);
+      const cleanPromise = database.cleanGame(game.id);
+      const purgedGames = await database.purgeUnfinishedGames();
+      await Promise.all([cleanPromise, purgedGames]);
+      this.purgedGames.push(...purgedGames);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  public saveGame(game: Game): Promise<void> {
+    if (this.purgedGames.includes(game.id)) {
+      throw new Error('This game no longer exists');
+    }
+    return Database.getInstance().saveGame(game);
   }
 }
 

--- a/src/server/database/IDatabase.ts
+++ b/src/server/database/IDatabase.ts
@@ -69,6 +69,8 @@ export interface IDatabase {
     /**
      * Saves the current state of the game. at a supplied save point. Used for
      * interim game updates.
+     *
+     * Do not call directly.
      */
     saveGame(game: Game): Promise<void>;
 
@@ -102,11 +104,7 @@ export interface IDatabase {
      *
      * * Purge all saves between `(0, last save]`.
      * * Mark the game as finished.
-     * * It also participates in purging abandoned solo games older
-     *   than a given date range, regardless of the supplied `gameId`.
-     *   Constraints for this purge vary by database.
      */
-    // TODO(kberg): Make the extra maintenance behavior a first-class method.
     cleanGame(gameId: GameId): Promise<void>;
 
     /**
@@ -119,8 +117,10 @@ export interface IDatabase {
      * * In PostgreSQL, it uses a default of 10 days
      * * In Sqlite, it doesn't purge
      * * This whole method is ignored in LocalFilesystem.
+     *
+     * Returns a list of purged Game IDs.
      */
-    purgeUnfinishedGames(maxGameDays?: string): Promise<void>;
+    purgeUnfinishedGames(maxGameDays?: string): Promise<Array<GameId>>;
 
     /**
      * Generate database statistics for admin purposes.

--- a/src/server/database/IGameLoader.ts
+++ b/src/server/database/IGameLoader.ts
@@ -28,4 +28,6 @@ export interface IGameLoader {
    * @param {GameId} gameId the game to be removed from the cache. Only call this for completed games.
    */
   mark(gameId: GameId): void;
+  saveGame(game: Game): Promise<void>
+  completeGame(game: Game): Promise<void>;
 }

--- a/src/server/database/LocalFilesystem.ts
+++ b/src/server/database/LocalFilesystem.ts
@@ -150,9 +150,9 @@ export class LocalFilesystem implements IDatabase {
     return Promise.resolve();
   }
 
-  purgeUnfinishedGames(): Promise<void> {
+  purgeUnfinishedGames(): Promise<Array<GameId>> {
     // Not implemented.
-    return Promise.resolve();
+    return Promise.resolve([]);
   }
 
   deleteGameNbrSaves(gameId: GameId, rollbackCount: number): Promise<void> {

--- a/tests/routes/FakeGameLoader.ts
+++ b/tests/routes/FakeGameLoader.ts
@@ -29,4 +29,10 @@ export class FakeGameLoader implements IGameLoader {
   }
   public mark() {
   }
+  public completeGame(_game: Game): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+  public saveGame(_game: Game) {
+    return Promise.resolve(undefined);
+  }
 }

--- a/tests/testing/InMemoryDatabase.ts
+++ b/tests/testing/InMemoryDatabase.ts
@@ -77,7 +77,7 @@ export class InMemoryDatabase implements IDatabase {
   cleanGame(_gameId: GameId): Promise<void> {
     throw new Error('Method not implemented.');
   }
-  purgeUnfinishedGames(): Promise<void> {
+  purgeUnfinishedGames(): Promise<Array<GameId>> {
     throw new Error('Method not implemented.');
   }
   stats(): Promise<{[ key: string ]: string | number;}> {

--- a/tests/utils/setup.ts
+++ b/tests/utils/setup.ts
@@ -21,7 +21,7 @@ const FAKE_DATABASE: IDatabase = {
   loadCloneableGame: () => Promise.resolve({} as SerializedGame),
   saveGameResults: () => {},
   saveGame: () => Promise.resolve(),
-  purgeUnfinishedGames: () => Promise.resolve(),
+  purgeUnfinishedGames: () => Promise.resolve([]),
   stats: () => Promise.resolve({}),
 
   storeParticipants: () => Promise.resolve(),


### PR DESCRIPTION
This change removes a case where games can continue to exist after their base records are purged. This is done by starting to add a layer that hides the database and the GameLoader together.

Tests needed.