### PR TITLE
CEO Balance Update

### DIFF
--- a/src/server/CeoExtension.ts
+++ b/src/server/CeoExtension.ts
@@ -7,7 +7,7 @@ export class CeoExtension {
   public static calculateVictoryPoints(player: Player, vpb: VictoryPointsBreakdown): void {
     const duncan = player.getCeo(CardName.DUNCAN);
     if (duncan?.isDisabled === true && duncan.generationUsed !== undefined) {
-      vpb.setVictoryPoints('victoryPoints', 6 - duncan.generationUsed, 'CEO VP');
+      vpb.setVictoryPoints('victoryPoints', 7 - duncan.generationUsed, 'CEO VP');
     }
   }
 

--- a/src/server/cards/ceos/Clarke.ts
+++ b/src/server/cards/ceos/Clarke.ts
@@ -13,15 +13,19 @@ export class Clarke extends CeoCard {
       metadata: {
         cardNumber: 'L03',
         renderData: CardRenderer.builder((b) => {
-          b.opgArrow().text('X+4').plants(1).heat(1).asterix();
+          b.opgArrow().text('ACTIVATE THE BELOW ABILITY').br;
+          b.production((pb) => pb.plants(1).heat(1));
+          b.text('X+4').plants(1).heat(1).asterix();
         }),
-        description: 'Once per game, gain plants and heat equal to your production +4.',
+        description: 'Once per game, increase your plant and heat production 1 step each. Gain plants and heat equal to your production +4.',
       },
     });
   }
 
   public action(player: Player): PlayerInput | undefined {
     this.isDisabled = true;
+    player.production.add(Resources.PLANTS, 1, {log: true});
+    player.production.add(Resources.HEAT, 1, {log: true});
     player.addResource(Resources.PLANTS, player.production.plants + 4, {log: true});
     player.addResource(Resources.HEAT, player.production.heat + 4, {log: true});
     return undefined;

--- a/src/server/cards/ceos/Duncan.ts
+++ b/src/server/cards/ceos/Duncan.ts
@@ -8,7 +8,6 @@ import {Resources} from '../../../common/Resources';
 import {multiplier} from '../Options';
 
 
-// TODO(dl): Does Duncan trigger Vitor?
 export class Duncan extends CeoCard {
   constructor() {
     super({
@@ -19,7 +18,7 @@ export class Duncan extends CeoCard {
           b.opgArrow().vpIcon().asterix().megacredits(4, {multiplier});
           b.br;
         }),
-        description: 'Once per game, gain 6-X VP and 4X M€, where X is the current generation number.',
+        description: 'Once per game, gain 7-X VP and 4X M€, where X is the current generation number.',
       },
     });
   }

--- a/src/server/cards/ceos/Faraday.ts
+++ b/src/server/cards/ceos/Faraday.ts
@@ -18,6 +18,8 @@ const INVALID_TAGS = [
   Tag.WILD,
 ];
 
+const CARD_DRAW_COST = 3;
+
 export class Faraday extends CeoCard {
   constructor() {
     super({
@@ -26,10 +28,10 @@ export class Faraday extends CeoCard {
         cardNumber: 'L27',
         renderData: CardRenderer.builder((b) => {
           b.br;
-          b.text('5', Size.LARGE).diverseTag(1).colon().megacredits(-2).cards(1, {secondaryTag: AltSecondaryTag.DIVERSE}).asterix();
+          b.text('5', Size.LARGE).diverseTag(1).colon().megacredits(-CARD_DRAW_COST).cards(1, {secondaryTag: AltSecondaryTag.DIVERSE}).asterix();
           b.br.br;
         }),
-        description: 'When you gain a multiple of 5 for any tag type IN PLAY, you may pay 2 M€ to draw a card with that tag. Wild tags do not count for this effect.',
+        description: 'When you gain a multiple of 5 for any tag type IN PLAY, you may pay ${CARD_DRAW_COST} M€ to draw a card with that tag. Wild tags do not count for this effect.',
       },
     });
   }
@@ -71,12 +73,13 @@ export class Faraday extends CeoCard {
   }
 
   public effectOptions(player: Player, tag: Tag) {
+    if (!player.canAfford(CARD_DRAW_COST)) return;
     return new OrOptions(
-      new SelectOption(newMessage('Pay 2 M€ to draw a ${0} card', (b) => b.string(tag)), 'Confirm', () => {
+      new SelectOption(newMessage('Pay ${CARD_DRAW_COST} M€ to draw a ${0} card', (b) => b.string(tag)), 'Confirm', () => {
         player.game.defer(
           new SelectPaymentDeferred(
             player,
-            2,
+            CARD_DRAW_COST,
             {
               title: 'Select how to pay for action',
               afterPay: () => {

--- a/src/server/cards/ceos/Faraday.ts
+++ b/src/server/cards/ceos/Faraday.ts
@@ -18,8 +18,6 @@ const INVALID_TAGS = [
   Tag.WILD,
 ];
 
-const CARD_DRAW_COST = 3;
-
 export class Faraday extends CeoCard {
   constructor() {
     super({
@@ -28,10 +26,10 @@ export class Faraday extends CeoCard {
         cardNumber: 'L27',
         renderData: CardRenderer.builder((b) => {
           b.br;
-          b.text('5', Size.LARGE).diverseTag(1).colon().megacredits(-CARD_DRAW_COST).cards(1, {secondaryTag: AltSecondaryTag.DIVERSE}).asterix();
+          b.text('5', Size.LARGE).diverseTag(1).colon().megacredits(-3).cards(1, {secondaryTag: AltSecondaryTag.DIVERSE}).asterix();
           b.br.br;
         }),
-        description: 'When you gain a multiple of 5 for any tag type IN PLAY, you may pay ${CARD_DRAW_COST} M€ to draw a card with that tag. Wild tags do not count for this effect.',
+        description: 'When you gain a multiple of 5 for any tag type IN PLAY, you may pay 3 M€ to draw a card with that tag. Wild tags do not count for this effect.',
       },
     });
   }
@@ -73,13 +71,13 @@ export class Faraday extends CeoCard {
   }
 
   public effectOptions(player: Player, tag: Tag) {
-    if (!player.canAfford(CARD_DRAW_COST)) return;
+    if (!player.canAfford(3)) return;
     return new OrOptions(
-      new SelectOption(newMessage('Pay ${CARD_DRAW_COST} M€ to draw a ${0} card', (b) => b.string(tag)), 'Confirm', () => {
+      new SelectOption(newMessage('Pay 3 MC to draw a ${1} card', (b) => b.string(tag)), 'Confirm', () => {
         player.game.defer(
           new SelectPaymentDeferred(
             player,
-            CARD_DRAW_COST,
+            3,
             {
               title: 'Select how to pay for action',
               afterPay: () => {

--- a/src/server/cards/ceos/Greta.ts
+++ b/src/server/cards/ceos/Greta.ts
@@ -13,9 +13,9 @@ export class Greta extends CeoCard {
       metadata: {
         cardNumber: 'L31',
         renderData: CardRenderer.builder((b) => {
-          b.opgArrow().text('ACTIVATE THE BELOW ABILITY').asterix();
+          b.opgArrow().text('ACTIVATE THE BELOW ABILITY');
           b.br.br;
-          b.tr(1).colon().megacredits(4);
+          b.tr(1).colon().megacredits(4).asterix();
           b.br;
         }),
         description: 'When you take an action or play a card that increases your TR THIS GENERATION (max 10 times), gain 4 M€.',

--- a/src/server/cards/ceos/Greta.ts
+++ b/src/server/cards/ceos/Greta.ts
@@ -13,17 +13,18 @@ export class Greta extends CeoCard {
       metadata: {
         cardNumber: 'L31',
         renderData: CardRenderer.builder((b) => {
-          b.opgArrow().text('ACTIVATE THE BELOW ABILITY');
+          b.opgArrow().text('ACTIVATE THE BELOW ABILITY').asterix();
           b.br.br;
           b.tr(1).colon().megacredits(4);
           b.br;
         }),
-        description: 'When you take an action or play a card that increases your TR THIS GENERATION, gain 4 M€ for each step.',
+        description: 'When you take an action or play a card that increases your TR THIS GENERATION (max 10 times), gain 4 M€.',
       },
     });
   }
 
   public opgActionIsActive = false;
+  public effectTriggerCount = 0;
 
   public action(): PlayerInput | undefined {
     this.opgActionIsActive = true;
@@ -31,11 +32,12 @@ export class Greta extends CeoCard {
     return undefined;
   }
 
-  public onIncreaseTerraformRating(player: Player, cardOwner: Player, steps: number) {
+  public onIncreaseTerraformRating(player: Player, cardOwner: Player) {
     const game = player.game;
-    if (this.opgActionIsActive === true) {
+    if (this.opgActionIsActive === true && this.effectTriggerCount < 10) {
       if (player === cardOwner && game.phase === Phase.ACTION) {
-        player.addResource(Resources.MEGACREDITS, 4*steps, {log: true});
+        player.addResource(Resources.MEGACREDITS, 4, {log: true});
+        this.effectTriggerCount++;
       }
     }
     return undefined;

--- a/src/server/cards/ceos/Naomi.ts
+++ b/src/server/cards/ceos/Naomi.ts
@@ -16,11 +16,11 @@ export class Naomi extends CeoCard {
         cardNumber: 'L14',
         renderData: CardRenderer.builder((b) => {
           b.br;
-          b.colonies(1).colon().energy(2).megacredits(2);
+          b.colonies(1).colon().energy(2).megacredits(3);
           b.br.br.br;
           b.opgArrow().text('SET ALL').colonies(1).asterix();
         }),
-        description: 'When you build a colony, gain 2 energy and 2 M€. Once per game, move each colony tile track marker to its highest or lowest value.',
+        description: 'When you build a colony, gain 2 energy and 3 M€. Once per game, move each colony tile track marker to its highest or lowest value.',
       },
     });
   }

--- a/src/server/cards/ceos/Quill.ts
+++ b/src/server/cards/ceos/Quill.ts
@@ -18,7 +18,7 @@ export class Quill extends CeoCard {
         cardNumber: 'L17',
         renderData: CardRenderer.builder((b) => {
           b.opgArrow().text('ACTIVATE THE BELOW ABILITY').br;
-          b.opgArrow().cards(1, {secondaryTag: AltSecondaryTag.FLOATER}).colon().floaters(2).megacredits(1).asterix();
+          b.cards(1, {secondaryTag: AltSecondaryTag.FLOATER}).colon().floaters(2).megacredits(1).asterix();
         }),
         description: 'Once per game, add 2 floaters to each of your cards that collect floaters, then add 2 floaters to ANY card. Gain 1 M€ for every 2 floaters added this way.',
       },

--- a/src/server/cards/ceos/Quill.ts
+++ b/src/server/cards/ceos/Quill.ts
@@ -3,10 +3,11 @@ import {Player} from '../../Player';
 import {PlayerInput} from '../../PlayerInput';
 import {CardRenderer} from '../render/CardRenderer';
 import {CeoCard} from './CeoCard';
-
 import {CardResource} from '../../../common/CardResource';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
 import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
+import {Resources} from '../../../common/Resources';
+import {GainResources} from '../../deferredActions/GainResources';
 
 
 export class Quill extends CeoCard {
@@ -16,21 +17,27 @@ export class Quill extends CeoCard {
       metadata: {
         cardNumber: 'L17',
         renderData: CardRenderer.builder((b) => {
-          b.opgArrow().cards(1, {secondaryTag: AltSecondaryTag.FLOATER}).colon().nbsp;
-          b.plus().floaters(2).asterix();
+          b.opgArrow().text('ACTIVATE THE BELOW ABILITY').br;
+          b.opgArrow().cards(1, {secondaryTag: AltSecondaryTag.FLOATER}).colon().floaters(2).megacredits(1).asterix();
         }),
-        description: 'Once per game, add 2 floaters to each of your cards that collect floaters, then add 2 floaters to ANY card.',
+        description: 'Once per game, add 2 floaters to each of your cards that collect floaters, then add 2 floaters to ANY card. Gain 1 M€ for every 2 floaters added this way.',
       },
     });
+  }
+
+  public override canAct(player: Player): boolean {
+    if (!super.canAct(player)) {
+      return false;
+    }
+    return player.getResourceCards(CardResource.FLOATER).length > 0;
   }
 
   public action(player: Player): PlayerInput | undefined {
     this.isDisabled = true;
     const resourceCards = player.getResourceCards(CardResource.FLOATER);
     resourceCards.forEach((card) => player.addResourceTo(card, {qty: 2, log: true}));
-
     player.game.defer(new AddResourcesToCard(player, CardResource.FLOATER, {count: 2}));
-
+    player.game.defer(new GainResources(player, Resources.MEGACREDITS, {count: resourceCards.length + 1, log: true}));
     return undefined;
   }
 }

--- a/src/server/cards/ceos/Will.ts
+++ b/src/server/cards/ceos/Will.ts
@@ -16,10 +16,10 @@ export class Will extends CeoCard {
         renderData: CardRenderer.builder((b) => {
           b.opgArrow().text('GAIN THESE RESOURCES').br;
           b.animals(1).animals(1).microbes(1).microbes(1).br;
-          b.science().floaters(1).asteroids(1).wild(1);
+          b.floaters(1).floaters(1).wild(1).wild(1);
           b.br;
         }),
-        description: 'Once per game, add the following resources to your cards: 2 animals, 2 microbes, 1 science, 1 floater, 1 asteroid, 1 wild.',
+        description: 'Once per game, add the following resources to your cards: 2 animals, 2 microbes, 2 floaters, 2 wild.',
       },
     });
   }
@@ -28,10 +28,8 @@ export class Will extends CeoCard {
     this.isDisabled = true;
     player.game.defer(new AddResourcesToCard(player, CardResource.ANIMAL, {count: 2}));
     player.game.defer(new AddResourcesToCard(player, CardResource.MICROBE, {count: 2}));
-    player.game.defer(new AddResourcesToCard(player, CardResource.SCIENCE, {count: 1}));
-    player.game.defer(new AddResourcesToCard(player, CardResource.FLOATER, {count: 1}));
-    player.game.defer(new AddResourcesToCard(player, CardResource.ASTEROID, {count: 1}));
-    player.game.defer(new AddResourcesToCard(player, undefined, {count: 1}));
+    player.game.defer(new AddResourcesToCard(player, CardResource.FLOATER, {count: 2}));
+    player.game.defer(new AddResourcesToCard(player, undefined, {count: 2}));
 
     return undefined;
   }

--- a/src/server/cards/ceos/Zan.ts
+++ b/src/server/cards/ceos/Zan.ts
@@ -5,6 +5,8 @@ import {CardRenderer} from '../render/CardRenderer';
 import {CeoCard} from './CeoCard';
 import {PartyName} from '../../../common/turmoil/PartyName';
 import {Turmoil} from '../../turmoil/Turmoil';
+import {Size} from '../../../common/cards/render/Size';
+import {Resources} from '../../../common/Resources';
 
 export class Zan extends CeoCard {
   constructor() {
@@ -16,9 +18,9 @@ export class Zan extends CeoCard {
           b.br.br;
           b.redsInactive().asterix();
           b.br.br;
-          b.opgArrow().text('ALL').delegates(1).colon().reds();
+          b.opgArrow().text('ALL', Size.SMALL).delegates(1).colon().reds().megacredits(1);
         }),
-        description: 'You are immune to Reds\' ruling policy. Once per game, place all of your available delegates in Reds.',
+        description: 'You are immune to Reds\' ruling policy. Once per game, place all of your available delegates in Reds. Gain 1 M€ for each delegate placed this way.',
       },
     });
   }
@@ -27,9 +29,11 @@ export class Zan extends CeoCard {
     this.isDisabled = true;
     const game = player.game;
     const turmoil = Turmoil.getTurmoil(game);
+    const totalDelegatesPlaced = turmoil.getAvailableDelegateCount(player.id);
     while (turmoil.getAvailableDelegateCount(player.id) > 0) {
       turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
     }
+    player.addResource(Resources.MEGACREDITS, totalDelegatesPlaced, {log: true});
     return undefined;
   }
 }

--- a/src/server/colonies/Colony.ts
+++ b/src/server/colonies/Colony.ts
@@ -96,7 +96,7 @@ export abstract class Colony implements IColony {
       // CEO Naomi hook
       if (player.cardIsInEffect(CardName.NAOMI)) {
         player.addResource(Resources.ENERGY, 2, {log: true});
-        player.addResource(Resources.MEGACREDITS, 2, {log: true});
+        player.addResource(Resources.MEGACREDITS, 3, {log: true});
       }
     }
 

--- a/tests/cards/ceo/Clarke.spec.ts
+++ b/tests/cards/ceo/Clarke.spec.ts
@@ -2,8 +2,8 @@ import {expect} from 'chai';
 import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
 import {runAllActions, forceGenerationEnd, churnAction} from '../../TestingUtils';
-import {Clarke} from '../../../src/server/cards/ceos/Clarke';
 import {testGame} from '../../TestGame';
+import {Clarke} from '../../../src/server/cards/ceos/Clarke';
 
 describe('Clarke', function() {
   let card: Clarke;
@@ -28,7 +28,9 @@ describe('Clarke', function() {
 
   it('Takes action', function() {
     expect(churnAction(card, player)).is.undefined;
-    expect(player.plants).eq(4);
-    expect(player.heat).eq(4);
+    expect(player.production.plants).eq(1);
+    expect(player.production.heat).eq(1);
+    expect(player.plants).eq(5);
+    expect(player.heat).eq(5);
   });
 });

--- a/tests/cards/ceo/Duncan.spec.ts
+++ b/tests/cards/ceo/Duncan.spec.ts
@@ -26,7 +26,7 @@ describe('Duncan', function() {
 
   it('Has 5 VP and 4 MC in gen 1', function() {
     card.action(player);
-    expect(player.getVictoryPoints().total).eq(25);
+    expect(player.getVictoryPoints().total).eq(26);
     expect(player.megaCredits).eq(4);
   });
 
@@ -37,13 +37,13 @@ describe('Duncan', function() {
 
     player.megaCredits = 0;
     card.action(player);
-    expect(player.getVictoryPoints().total).eq(18);
+    expect(player.getVictoryPoints().total).eq(19);
     expect(player.megaCredits).eq(32);
 
     // Run for a few more generations, leader VP should not change
     forceGenerationEnd(player.game);
     forceGenerationEnd(player.game);
-    expect(player.getVictoryPoints().total).eq(18);
+    expect(player.getVictoryPoints().total).eq(19);
   });
 
   it('Does not affect VP if OPG action not used yet', function() {

--- a/tests/cards/ceo/Faraday.spec.ts
+++ b/tests/cards/ceo/Faraday.spec.ts
@@ -15,13 +15,14 @@ describe('Faraday', function() {
   let card: Faraday;
   let player: TestPlayer;
   let game: Game;
-
+  const CARD_DRAW_COST = 3;
+  const PLAYER_INITIALMC = 10;
   beforeEach(() => {
     card = new Faraday();
     [game, player] = testGame(1);
 
     player.popWaitingFor();
-    player.megaCredits = 10;
+    player.megaCredits = PLAYER_INITIALMC;
     player.playedCards.push(card);
   });
 
@@ -33,7 +34,7 @@ describe('Faraday', function() {
     runAllActions(player.game);
     expect(player.getWaitingFor()).is.undefined;
     expect(player.cardsInHand).has.length(0);
-    expect(player.megaCredits).to.eq(10);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC);
   });
 
   it('Can draw a card when reaching a multiple of 5 for a tag', function() {
@@ -50,7 +51,7 @@ describe('Faraday', function() {
     const orOptions = cast(player.popWaitingFor(), OrOptions);
     orOptions.options[0].cb();
     runAllActions(game);
-    expect(player.megaCredits).to.eq(8);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC - CARD_DRAW_COST);
     expect(player.cardsInHand).has.length(1);
     expect(player.cardsInHand[0].tags.includes(Tag.SCIENCE)).is.true;
   });
@@ -64,7 +65,7 @@ describe('Faraday', function() {
     orOptions.options[1].cb();
     runAllActions(game);
     expect(player.cardsInHand).has.length(0);
-    expect(player.megaCredits).to.eq(10);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC);
   });
 
   it('No prompt if player cannot afford to pay for card', function() {
@@ -86,7 +87,7 @@ describe('Faraday', function() {
     const orOptions = cast(player.popWaitingFor(), OrOptions);
     orOptions.options[0].cb();
     runAllActions(game);
-    expect(player.megaCredits).to.eq(8);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC - CARD_DRAW_COST);
     expect(player.cardsInHand).has.length(1);
     expect(player.cardsInHand[0].tags.includes(Tag.SCIENCE)).is.true;
   });
@@ -104,7 +105,7 @@ describe('Faraday', function() {
     runAllActions(game);
 
     expect(player.cardsInHand).has.length(2);
-    expect(player.megaCredits).to.eq(6);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC - CARD_DRAW_COST - CARD_DRAW_COST);
   });
 
   it('Play a card that puts two tags at 5 count, buy one', function() {
@@ -120,7 +121,7 @@ describe('Faraday', function() {
     runAllActions(game);
 
     expect(player.cardsInHand).has.length(1);
-    expect(player.megaCredits).to.eq(8);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC - CARD_DRAW_COST);
   });
 
   it('Play a card that puts two tags at 5 count, buy none', function() {
@@ -133,7 +134,7 @@ describe('Faraday', function() {
     orOptions.options[1].cb();
     runAllActions(game);
     expect(player.cardsInHand).has.length(0);
-    expect(player.megaCredits).to.eq(10);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC);
   });
 
   it('Wild tags dont count', function() {
@@ -162,7 +163,7 @@ describe('Faraday', function() {
     runAllActions(player.game);
     expect(player.getWaitingFor()).is.undefined;
     expect(player.cardsInHand).has.length(0);
-    expect(player.megaCredits).to.eq(10);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC);
   });
 
   it('Does trigger when activating Clone Tags (via CrewTraining)', function() {
@@ -182,7 +183,7 @@ describe('Faraday', function() {
     const orOptions = cast(player.popWaitingFor(), OrOptions);
     orOptions.options[0].cb();
     runAllActions(game);
-    expect(player.megaCredits).to.eq(8);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC - CARD_DRAW_COST);
     expect(player.cardsInHand).has.length(1);
     expect(player.cardsInHand[0].tags.includes(Tag.EARTH)).is.true;
   });

--- a/tests/cards/ceo/Greta.spec.ts
+++ b/tests/cards/ceo/Greta.spec.ts
@@ -43,12 +43,35 @@ describe('Greta', function() {
     player.game.increaseVenusScaleLevel(player, 1);
     expect(player.megaCredits).to.eq(12);
 
-    player.playCard(new BigAsteroid()); // 2 Temp Steps
-    expect(player.megaCredits).to.eq(20);
+    player.playCard(new BigAsteroid()); // 2 Temp Steps in ONE ACTION
+    expect(player.megaCredits).to.eq(16);
 
-    player.playCard(new Omnicourt()); // 2 Steps
-    expect(player.megaCredits).to.eq(28);
+    player.playCard(new Omnicourt()); // 2 Steps in ONE ACTION
+    expect(player.megaCredits).to.eq(20);
   });
+
+  it('Does not gain MC after 10 increases', function() {
+    // doesnt gain before card action
+    runAllActions(game);
+    game.phase = Phase.ACTION;
+    card.action();
+    expect(player.megaCredits).to.eq(0);
+    player.game.increaseOxygenLevel(player, 2); // One action, two steps, only 4MC
+    player.game.increaseOxygenLevel(player, 1);
+    player.game.increaseOxygenLevel(player, 1);
+    player.game.increaseOxygenLevel(player, 1);
+    player.game.increaseOxygenLevel(player, 1);
+    expect(player.megaCredits).to.eq(20);
+    player.game.increaseTemperature(player, 2); // One action, two steps, only 4MC
+    player.game.increaseTemperature(player, 1);
+    player.game.increaseTemperature(player, 1);
+    player.game.increaseTemperature(player, 1);
+    player.game.increaseTemperature(player, 1);
+    expect(player.megaCredits).to.eq(40);
+    player.game.increaseTemperature(player, 2); // 10 increases already, no more bonuses
+    expect(player.megaCredits).to.eq(40);
+  });
+
 
   it('Can only act once per game, no income when not active', function() {
     card.action();

--- a/tests/cards/ceo/Naomi.spec.ts
+++ b/tests/cards/ceo/Naomi.spec.ts
@@ -30,10 +30,10 @@ describe('Naomi', function() {
     expect(player.megaCredits).to.eq(0);
     game.colonies[0].addColony(player);
     expect(player.energy).to.eq(2);
-    expect(player.megaCredits).to.eq(2);
+    expect(player.megaCredits).to.eq(3);
     game.colonies[1].addColony(player);
     expect(player.energy).to.eq(4);
-    expect(player.megaCredits).to.eq(4);
+    expect(player.megaCredits).to.eq(6);
 
     // Player2 here is just a sanity check, _and_ is necessary for the colony count
     game.colonies[0].addColony(player2);

--- a/tests/cards/ceo/Quill.spec.ts
+++ b/tests/cards/ceo/Quill.spec.ts
@@ -29,24 +29,31 @@ describe('Quill', function() {
     expect(card.canAct(player)).is.false;
   });
 
+  it('Cannot act if no Floaters are in play', function() {
+    expect(card.canAct(player)).is.false;
+  });
+
   it('Takes action', function() {
     const dirigibles = new Dirigibles();
     const localShading = new LocalShading();
     player.playedCards.push(dirigibles, localShading);
+    player.megaCredits = 0;
 
     // Sanity
     expect(dirigibles.resourceCount).eq(0);
     expect(localShading.resourceCount).eq(0);
-    expect(dirigibles.resourceCount).eq(0);
 
     card.action(player);
     expect(dirigibles.resourceCount).eq(2);
     expect(localShading.resourceCount).eq(2);
-    expect(game.deferredActions).has.length(1);
+    expect(game.deferredActions).has.length(2);
 
     runAllActions(game);
     const addFloaters = cast(player.popWaitingFor(), SelectCard<ICard>);
     addFloaters.cb([dirigibles]);
     expect(dirigibles.resourceCount).eq(4);
+    runAllActions(game);
+
+    expect(player.megaCredits).eq(3);
   });
 });

--- a/tests/cards/ceo/Will.spec.ts
+++ b/tests/cards/ceo/Will.spec.ts
@@ -8,7 +8,6 @@ import {TestPlayer} from '../../TestPlayer';
 
 import {Ants} from '../../../src/server/cards/base/Ants';
 import {Birds} from '../../../src/server/cards/base/Birds';
-import {AsteroidRights} from '../../../src/server/cards/promo/AsteroidRights';
 import {CommunicationCenter} from '../../../src/server/cards/pathfinders/CommunicationCenter';
 
 import {Will} from '../../../src/server/cards/ceos/Will';
@@ -35,11 +34,10 @@ describe('Will', function() {
   it('Takes OPG action', function() {
     const birds = new Birds();
     const ants = new Ants();
-    const asteroidRights = new AsteroidRights();
-    player.playedCards.push(birds, ants, asteroidRights);
+    player.playedCards.push(birds, ants);
 
     card.action(player);
-    expect(game.deferredActions).has.length(6);
+    expect(game.deferredActions).has.length(4);
 
     // Add animals
     game.deferredActions.runNext();
@@ -49,17 +47,12 @@ describe('Will', function() {
     game.deferredActions.runNext();
     expect(ants.resourceCount).eq(2);
 
-    game.deferredActions.runNext(); // No Science resource cards, skip
     game.deferredActions.runNext(); // No Floater resource cards, skip
-
-    // Add asteroid
-    game.deferredActions.runNext();
-    expect(asteroidRights.resourceCount).eq(1);
 
     // Add resource to any card
     const selectCard = game.deferredActions.pop()!.execute() as SelectCard<ICard>;
     selectCard.cb([selectCard.cards[1]]);
-    expect(ants.resourceCount).eq(3);
+    expect(ants.resourceCount).eq(4);
   });
 
   it('Takes OPG w/ Communication Center', function() {
@@ -73,16 +66,14 @@ describe('Will', function() {
 
     // Action
     card.action(player);
-    expect(game.deferredActions).has.length(6);
+    expect(game.deferredActions).has.length(4);
     game.deferredActions.runNext(); // No animals
     game.deferredActions.runNext(); // No bugs
-    game.deferredActions.runNext(); // No Science
     game.deferredActions.runNext(); // No Floaters
-    game.deferredActions.runNext(); // No Asteroid
-    game.deferredActions.runNext(); // One Wild on comms
+    game.deferredActions.runNext(); // Two Wild on comms
 
-    // We should have drawn a card here
-    expect(comms.resourceCount).eq(0);
+    // We should have drawn a card here AND added another science to Comms
+    expect(comms.resourceCount).eq(1);
     expect(player.cardsInHand.length).to.eq(1);
   });
 });

--- a/tests/cards/ceo/Zan.spec.ts
+++ b/tests/cards/ceo/Zan.spec.ts
@@ -39,13 +39,16 @@ describe('Zan', function() {
 
   it('Takes OPG action', function() {
     const turmoil = game.turmoil!;
+    player.megaCredits = 0;
+    const expectedMegagredits = turmoil.getAvailableDelegateCount(player.id);
     card.action(player);
-
     while (game.deferredActions.length) {
       game.deferredActions.pop()!.execute();
     }
 
     expect(turmoil.getAvailableDelegateCount(player.id)).eq(0);
+    expect(player.megaCredits).eq(expectedMegagredits);
+
     expect(turmoil.dominantParty.name).eq(PartyName.REDS);
     expect(turmoil.dominantParty.partyLeader).eq(player.id);
     expect(card.isDisabled).is.true;


### PR DESCRIPTION
I know, I know, a lot of changes in one PR.. I'm hoping it will be allowed, but I wont defend it any further than this and can submit a PR per CEO if required :)

## ⚖️ Balance Changes ⚖️
* **Clarke**: 💚 Buff 
    * Gain 1 Heat and Plant _production_ before gaining bonuses.
* **Duncan**: 💚 Buff
    * Increased initial VP gain from 6 to 7
* **Faraday**: 💀 Nerf
    * Increase cost of drawing card from 2 to 3MC
* **Greta**: 💀 Nerf
    * TR gain is now per ACTION, not per steps increased
    * MC gain is limited to 10x (40MC total gain)
* **Naomi**: 💚 Buff
    * Increase MC gain from 2 to 3 per colony built
* **Quill**: 💚 Buff
    * Gains an additional 1MC for every 2 floaters added.
    * Can no longer act if player has no floater cards in play
* **Will**: 🔁 Rebalance
    * Rebalance bonus resources:
         * old: 2 animals, 2 microbes, 1 science, 1 floater, 1 asteroid, 1 wild.
         * new: 2 animals, 2 microbes, 2 floaters, 2 wild
* **Zan**: 💚 Buff
    * Gain an additional 1MC per delegate placed