### PR TITLE
Remove Errant Backtick

### DIFF
--- a/src/client/components/turmoil/Agendas.vue
+++ b/src/client/components/turmoil/Agendas.vue
@@ -110,7 +110,8 @@
       <span class="red-arrow-3x"></span>
       <div class="resource card card-with-border policy-card-with-tag"><div class="card-icon tag-space"></div></div>
     </template>
-    <template v-else-if="id === 'up04'"> `<div class="policy-top-margin"><div class="resource-tag tag-space"></div> : <div class="money resource">-2</div></div>
+    <template v-else-if="id === 'up04'">
+      <div class="policy-top-margin"><div class="resource-tag tag-space"></div> : <div class="money resource">-2</div></div>
     </template>
     <template v-else-if="id === 'kp01'">
       <span class="money resource">10</span>


### PR DESCRIPTION
This one's been bugging me for so long.  It's like finally removing a piece of food stuck in your teeth.

This backtick:
![image](https://user-images.githubusercontent.com/2050250/230279582-53884182-d811-42d4-9299-e21492937617.png)


Gone.


```vue
    <template v-else-if="id === 'up04'"> `<div class="policy-top-margin"><div class="resource-tag tag-space"></div> : <div class="money resource">-2</div></div>
```

to:
```vue
    <template v-else-if="id === 'up04'"><div class="policy-top-margin"><div class="resource-tag tag-space"></div> : <div class="money resource">-2</div></div>
```