### PR TITLE
Luna Project Office not keeping 5 cards

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1004,7 +1004,6 @@ export class Player {
 
   public runResearchPhase(draftVariant: boolean): void {
     let dealtCards: Array<IProjectCard> = [];
-    let cardsToKeep = 4;
     if (draftVariant) {
       dealtCards = this.draftedCards;
       this.draftedCards = [];
@@ -1014,10 +1013,15 @@ export class Player {
         cardsToDraw = 5;
       }
       if (LunaProjectOffice.isActive(this)) {
-        cardsToKeep = 5;
         cardsToDraw = 5;
       }
       this.dealForDraft(cardsToDraw, dealtCards);
+    }
+
+    let cardsToKeep = 4;
+    if (LunaProjectOffice.isActive(this)) {
+      // If Luna Project is active, they get to keep the 5 cards they drafted
+      cardsToKeep = 5;
     }
 
     const action = DrawCards.choose(this, dealtCards, {paying: true, keepMax: cardsToKeep});


### PR DESCRIPTION
Bug reported from Discord: https://discord.com/channels/737945098695999559/742721510376210583/1093460776561410048

```test
19:02]tappi: Am I mistaken in that you should be able to buy all five cards with Luna Project Office?
Image
[19:04]tappi: https://terraforming-mars.herokuapp.com/spectator?id=s4950bd1b0176 I'm playing a game against Mars Maths where I played this card but I am unable to buy all five cards
```

I am _pretty sure_ that this should fix it, in drafting variant it looks like the player wouldnt ever get to keep all 5 cards.

Testing could be updated to ensure that the actual keepMax is 5 for LPO? I'm unsure how to do that