### PR TITLE
Add CEO icon to game details

### DIFF
--- a/src/client/components/GameSetupDetail.vue
+++ b/src/client/components/GameSetupDetail.vue
@@ -12,6 +12,7 @@
               <div v-if="gameOptions.pathfindersExpansion" class="create-game-expansion-icon expansion-icon-pathfinders"></div>
               <div v-if="gameOptions.communityCardsOption" class="create-game-expansion-icon expansion-icon-community"></div>
               <div v-if="isPoliticalAgendasOn" class="create-game-expansion-icon expansion-icon-agendas"></div>
+              <div v-if="gameOptions.ceoExtension" class="create-game-expansion-icon expansion-icon-ceo"></div>
             </li>
 
             <li><div class="setup-item" v-i18n>Board:</div>


### PR DESCRIPTION
This was missing for ages and I finally remembered to fix it:

![image](https://user-images.githubusercontent.com/2050250/233822361-bdba3a53-1e93-4dcd-b6ff-8402fc4becd6.png)
