### PR TITLE
Change hide cards in hand functionality to be similar to card filters

### DIFF
--- a/src/client/components/PlayerHome.vue
+++ b/src/client/components/PlayerHome.vue
@@ -91,6 +91,7 @@
             <div class="played-cards-count">{{cardsInHandCount.toString()}}</div>
             <div class="played-cards-selection" v-i18n>{{ getToggleLabel('HAND')}}</div>
           </div>
+          <div class="text-overview" v-i18n>[ toggle cards in hand ]</div>
         </div>
         <sortable-cards v-show="isVisible('HAND')" :playerId="playerView.id"
                         :cards="playerView.preludeCardsInHand

--- a/src/client/components/PlayerHome.vue
+++ b/src/client/components/PlayerHome.vue
@@ -85,8 +85,17 @@
 
       <a name="cards" class="player_home_anchor"></a>
       <div class="player_home_block player_home_block--hand" v-if="cardsInHandCount > 0" id="shortkey-hand">
-        <dynamic-title title="Cards In Hand" :color="thisPlayer.color" :withAdditional="true" :additional="cardsInHandCount.toString()" />
-        <sortable-cards :playerId="playerView.id" :cards="playerView.preludeCardsInHand.concat(playerView.ceoCardsInHand).concat(playerView.cardsInHand)" />
+        <div class="hiding-card-button-row">
+          <dynamic-title title="Cards In Hand" :color="thisPlayer.color"/>
+          <div :class="getHideButtonClass('HAND')" v-on:click.prevent="toggle('HAND')">
+            <div class="played-cards-count">{{cardsInHandCount.toString()}}</div>
+            <div class="played-cards-selection" v-i18n>{{ getToggleLabel('HAND')}}</div>
+          </div>
+        </div>
+        <sortable-cards v-show="isVisible('HAND')" :playerId="playerView.id"
+                        :cards="playerView.preludeCardsInHand
+                                .concat(playerView.ceoCardsInHand)
+                                .concat(playerView.cardsInHand)"/>
       </div>
 
       <div class="player_home_block player_home_block--cards">
@@ -315,6 +324,7 @@ import {sortActiveCards} from '@/client/utils/ActiveCardsSortingOrder';
 import * as raw_settings from '@/genfiles/settings.json';
 
 export interface PlayerHomeModel {
+  showHand: boolean;
   showActiveCards: boolean;
   showAutomatedCards: boolean;
   showEventCards: boolean;
@@ -330,6 +340,7 @@ export default Vue.extend({
   data(): PlayerHomeModel {
     const preferences = getPreferences();
     return {
+      showHand: !preferences.hide_hand,
       showActiveCards: !preferences.hide_active_cards,
       showAutomatedCards: !preferences.hide_automated_cards,
       showEventCards: !preferences.hide_event_cards,
@@ -337,6 +348,9 @@ export default Vue.extend({
     };
   },
   watch: {
+    showHand: function hide_hand() {
+      PreferencesManager.INSTANCE.set('hide_hand', !this.showHand);
+    },
     showActiveCards: function toggle_active_cards() {
       PreferencesManager.INSTANCE.set('hide_active_cards', !this.showActiveCards);
     },
@@ -452,6 +466,9 @@ export default Vue.extend({
     },
     toggle(type: string): void {
       switch (type) {
+      case 'HAND':
+        this.showHand = !this.showHand;
+        break;
       case 'ACTIVE':
         this.showActiveCards = !this.showActiveCards;
         break;
@@ -468,6 +485,8 @@ export default Vue.extend({
     },
     isVisible(type: string): boolean {
       switch (type) {
+      case 'HAND':
+        return this.showHand;
       case 'ACTIVE':
         return this.showActiveCards;
       case 'AUTOMATED':
@@ -484,7 +503,9 @@ export default Vue.extend({
       return (this.game.phase === Phase.CORPORATIONDRAFTING) && this.game.gameOptions.corporationsDraft;
     },
     getToggleLabel(hideType: string): string {
-      if (hideType === 'ACTIVE') {
+      if (hideType === 'HAND') {
+        return (this.showHand ? '✔' : '');
+      } else if (hideType === 'ACTIVE') {
         return (this.showActiveCards? '✔' : '');
       } else if (hideType === 'AUTOMATED') {
         return (this.showAutomatedCards ? '✔' : '');
@@ -496,7 +517,9 @@ export default Vue.extend({
     },
     getHideButtonClass(hideType: string): string {
       const prefix = 'hiding-card-button ';
-      if (hideType === 'ACTIVE') {
+      if (hideType === 'HAND') {
+        return prefix + (this.showHand ? 'hand-toggle' : 'hand-toggle-transparent');
+      } else if (hideType === 'ACTIVE') {
         return prefix + (this.showActiveCards ? 'active' : 'active-transparent');
       } else if (hideType === 'AUTOMATED') {
         return prefix + (this.showAutomatedCards ? 'automated' : 'automated-transparent');

--- a/src/client/components/PreferencesDialog.vue
+++ b/src/client/components/PreferencesDialog.vue
@@ -73,12 +73,6 @@ export default (Vue as WithRefs<Refs>).extend({
     <div class="preferences_panel" :data="syncPreferences()">
       <div class="preferences_panel_item">
         <label class="form-switch">
-          <input type="checkbox" v-on:change="updatePreferences" v-model="prefs.hide_hand" data-test="hide_hand">
-          <i class="form-icon"></i> <span v-i18n>Hide cards in hand</span>
-        </label>
-      </div>
-      <div class="preferences_panel_item">
-        <label class="form-switch">
           <input type="checkbox" v-on:change="updatePreferences" v-model="prefs.hide_awards_and_milestones" data-test="hide_awards_and_milestones">
           <i class="form-icon"></i> <span v-i18n>Hide awards and milestones</span>
         </label>

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -103,7 +103,7 @@ async function start() {
 
   if (!process.env.SERVER_ID) {
     console.log(`The secret serverId for this server is \x1b[1m${serverId}\x1b[0m.`);
-    console.log(`Adminsitrative routes can be found at admin?serverId=${serverId}`);
+    console.log(`Administrative routes can be found at admin?serverId=${serverId}`);
   }
   console.log('Server is ready.');
 }

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -1032,6 +1032,9 @@
     text-align: center;
     cursor: pointer;
 
+    &.hand-toggle {
+        background-color: rgba(60,60,60, 0.75);
+    }
     &.active {
         background-color: rgba(47,146,225, 0.75);
     }
@@ -1040,6 +1043,10 @@
     }
     &.event {
         background-color: rgba(237,106,21, 0.75);
+    }
+    &.hand-toggle-transparent {
+        background-color: rgba(60,60,60, 0.5);
+        color: #fff8;
     }
     &.active-transparent {
         background-color: rgba(47,146,225, 0.5);

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -314,9 +314,7 @@
 }
 
 /* Hide blocks */
-.preferences_hide_hand .player_home_block--hand,
-.preferences_hide_awards_and_milestones
-    .player_home_block--milestones-and-awards{
+.preferences_hide_awards_and_milestones .player_home_block--milestones-and-awards {
     display: none;
 }
 


### PR DESCRIPTION
In other words add a toggle button similar to other card filters next to the Cards in hand section that allows hiding cards in hand without going into preferences.

Vis when toggled off:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/1269108/235296462-c11c65c1-6df6-4d62-a42d-67a5e0c7f44d.png">

Vis when toggled on:
<img width="557" alt="image" src="https://user-images.githubusercontent.com/1269108/235296479-1b0cfb7a-fc33-40c4-ad3c-3209f08f3013.png">
