### PR TITLE
Improved purge for Postgres and SQLite, and general DB maintenance.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,8 +15,14 @@
 ## Your TLS private key path (=> `privkey.pem` created by certbot)
 # KEY_PATH=
 
-## How many days to keep unfinished games before deleting them
+## Games can only be in the database for this many days.
+## When this is unspecified, PostgresQL deletes games in 10 days, and
+##   SQLite does not delete games at all.
 # MAX_GAME_DAYS=
+
+## How many days to keep a game in its complete state before it is compressed
+## When this is unspecified, games do not compress.
+# COMPRESS_COMPLETED_GAMES_DAYS=
 
 ## How many milliseconds to check for game update on multi-player games
 # WAITING_FOR_TIMEOUT=5000

--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -969,7 +969,7 @@ export class Game implements Logger {
     }
   }
 
-  private gotoEndGame(): void {
+  private async gotoEndGame(): Promise<void> {
     // Log id or cloned game id
     if (this.clonedGamedId !== undefined && this.clonedGamedId.startsWith('#')) {
       const clonedGamedId = this.clonedGamedId;
@@ -988,12 +988,10 @@ export class Game implements Logger {
 
     Database.getInstance().saveGameResults(this.id, this.players.length, this.generation, this.gameOptions, scores);
     this.phase = Phase.END;
-    Database.getInstance().saveGame(this).then(() => {
-      GameLoader.getInstance().mark(this.id);
-      return Database.getInstance().cleanGame(this.id);
-    }).catch((err) => {
-      console.error(err);
-    });
+    await Database.getInstance().saveGame(this);
+    GameLoader.getInstance().mark(this.id);
+    await Database.getInstance().markFinished(this.id);
+    Database.getInstance().maintenance();
   }
 
   // Part of final greenery placement.

--- a/src/server/database/LocalFilesystem.ts
+++ b/src/server/database/LocalFilesystem.ts
@@ -145,12 +145,21 @@ export class LocalFilesystem implements IDatabase {
     writeFileSync(this.completedFilename(gameId), text);
   }
 
-  cleanGame(_gameId: GameId): Promise<void> {
+  markFinished(_gameId: GameId): Promise<void> {
     // Not implemented here.
     return Promise.resolve();
   }
 
+  maintenance(): Promise<void> {
+    return this.purgeUnfinishedGames();
+  }
+
   purgeUnfinishedGames(): Promise<void> {
+    // Not implemented.
+    return Promise.resolve();
+  }
+
+  compressCompletedGames(): Promise<unknown> {
     // Not implemented.
     return Promise.resolve();
   }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -93,7 +93,7 @@ async function start() {
     // Do not fail. Just continue. Stats aren't vital.
     console.error(err);
   }
-  Database.getInstance().purgeUnfinishedGames();
+  Database.getInstance().maintenance();
 
   const port = process.env.PORT || 8080;
   console.log(`Starting ${raw_settings.head}, built at ${raw_settings.builtAt}`);

--- a/tests/database/ITestDatabase.ts
+++ b/tests/database/ITestDatabase.ts
@@ -1,0 +1,31 @@
+import {IDatabase} from '../../src/server/database/IDatabase';
+import {GameId} from '../../src/common/Types';
+
+export type Status = 'running' | 'finished';
+
+export interface ITestDatabase extends IDatabase {
+  /**
+   * On any call to saveGame() store the promise here. That allows the app to wait for database
+   * saves that are otherwise deeply nested in the game code.
+   *
+   * This is usually done by overriding save() and storing the promise returned from it.
+   */
+  lastSaveGamePromise: Promise<void>;
+
+  /**
+   * Shut down operations after each test.
+   */
+  afterEach?: () => Promise<void>;
+  /**
+   * Return the status of a given game id.
+   */
+  status(gameId: GameId): Promise<Status>
+  /**
+   * If the game is waiting to be purged, return the time the game was completed. Otherwise, return `undefined`.
+   */
+  completedTime(gameId: GameId): Promise<number | undefined>;
+  /**
+   *
+   */
+   setCompletedTime(gameId: GameId, timestampSeconds: number): Promise<unknown>;
+}

--- a/tests/database/SQLite.spec.ts
+++ b/tests/database/SQLite.spec.ts
@@ -1,6 +1,9 @@
-import {ITestDatabase, describeDatabaseSuite} from './databaseSuite';
+import {describeDatabaseSuite} from './databaseSuite';
 import {Game} from '../../src/server/Game';
 import {IN_MEMORY_SQLITE_PATH, SQLite} from '../../src/server/database/SQLite';
+import {GameId} from '@/common/Types';
+import {RunResult} from 'sqlite3';
+import {ITestDatabase, Status} from './ITestDatabase';
 
 class TestSQLite extends SQLite implements ITestDatabase {
   public lastSaveGamePromise: Promise<void> = Promise.resolve();
@@ -17,11 +20,33 @@ class TestSQLite extends SQLite implements ITestDatabase {
     this.lastSaveGamePromise = super.saveGame(game);
     return this.lastSaveGamePromise;
   }
+
+  public async status(gameId: GameId): Promise<Status> {
+    const rows = await this.asyncAll('SELECT DISTINCT status FROM games WHERE game_id = ? ORDER BY save_id DESC LIMIT 1', [gameId]);
+    const statusText = rows[0].status;
+
+    if (statusText === 'running' || statusText === 'finished') {
+      return statusText;
+    }
+    throw new Error('Invalid status for ' + gameId + ': ' + statusText);
+  }
+
+  async completedTime(gameId: GameId): Promise<number | undefined> {
+    const row = await this.asyncGet('SELECT completed_time FROM completed_game WHERE game_id = $1', [gameId]);
+    return row.completed_time;
+  }
+
+  setCompletedTime(gameId: GameId, timestampSeconds: number): Promise<RunResult> {
+    return this.asyncRun('UPDATE completed_game SET completed_time = to_timestamp(?) WHERE game_id = ?', [timestampSeconds, gameId]);
+  }
 }
 
 describeDatabaseSuite({
   name: 'SQLite',
   constructor: () => new TestSQLite(),
+  omit: {
+    markFinished: true,
+  },
   stats: {
     type: 'SQLite',
     path: ':memory:',

--- a/tests/integration/LocalFilesystem.spec.ts
+++ b/tests/integration/LocalFilesystem.spec.ts
@@ -1,9 +1,12 @@
-import {ITestDatabase, describeDatabaseSuite} from '../database/databaseSuite';
-import {Game} from '../../src/server/Game';
-import {LocalFilesystem} from '../../src/server/database/LocalFilesystem';
 const path = require('path');
 const fs = require('fs');
 import {tmpdir} from 'os';
+
+import {describeDatabaseSuite} from '../database/databaseSuite';
+import {ITestDatabase, Status} from '../database/ITestDatabase';
+import {Game} from '../../src/server/Game';
+import {LocalFilesystem} from '../../src/server/database/LocalFilesystem';
+import {GameId} from '../../src/common/Types';
 
 /*
  * This test can be run with `npm run test:integration` as long as the test is set up
@@ -35,13 +38,25 @@ class TestLocalFilesystem extends LocalFilesystem implements ITestDatabase {
     response['history_path'] = 'def';
     return response;
   }
+
+  public status(_gameId: GameId): Promise<Status> {
+    throw new Error('Not yet implemented');
+  }
+
+  async completedTime(_gameId: GameId): Promise<number | undefined> {
+    throw new Error('Not yet implemented');
+  }
+
+  async setCompletedTime(_gameId: GameId, _timestampSeconds: number): Promise<void> {
+    throw new Error('Not yet implemented');
+  }
 }
 
 describeDatabaseSuite({
   name: 'LocalFilesystem',
   constructor: () => new TestLocalFilesystem(),
   omit: {
-    cleanGame: true,
+    markFinished: true,
     purgeUnfinishedGames: true,
   },
   stats: {

--- a/tests/integration/PostgreSQL.spec.ts
+++ b/tests/integration/PostgreSQL.spec.ts
@@ -1,6 +1,7 @@
 import * as dotenv from 'dotenv';
 import {expect} from 'chai';
-import {ITestDatabase, describeDatabaseSuite} from '../database/databaseSuite';
+import {describeDatabaseSuite} from '../database/databaseSuite';
+import {ITestDatabase, Status} from '../database/ITestDatabase';
 import {Game} from '../../src/server/Game';
 import {PostgreSQL} from '../../src/server/database/PostgreSQL';
 import {TestPlayer} from '../TestPlayer';
@@ -9,6 +10,8 @@ import {Phase} from '../../src/common/Phase';
 import {runAllActions, testGameOptions} from '../TestingUtils';
 import {Player} from '../../src/server/Player';
 import {GameLoader} from '../../src/server/database/GameLoader';
+import {GameId} from '../../src/common/Types';
+import {QueryResult} from 'pg';
 
 dotenv.config({path: 'tests/integration/.env', debug: true});
 
@@ -60,8 +63,31 @@ class TestPostgreSQL extends PostgreSQL implements ITestDatabase {
     await Promise.all(this.promises);
     this.promises.length = 0;
   }
+
   public async getStat(field: string): Promise<string | number> {
     return (await this.stats())[field];
+  }
+
+  async status(gameId: GameId): Promise<Status> {
+    const result = await this.client.query('SELECT DISTINCT status FROM games WHERE game_id = $1 LIMIT 1', [gameId]);
+    const statusText = result.rows[0].status;
+    if (statusText === 'running' || statusText === 'finished') {
+      return statusText;
+    }
+    throw new Error('Invalid status for ' + gameId + ': ' + statusText);
+  }
+
+  async completedTime(gameId: GameId): Promise<number | undefined> {
+    const res = await this.client.query('SELECT completed_time FROM completed_game WHERE game_id = $1', [gameId]);
+    if (res.rows.length === 0 || res.rows[0] === undefined) {
+      return undefined;
+    }
+    const row = res.rows[0];
+    return row.completed_time;
+  }
+
+  setCompletedTime(gameId: GameId, timestampSeconds: number): Promise<QueryResult<any>> {
+    return this.client.query('UPDATE completed_game SET completed_time = to_timestamp($1) WHERE game_id = $2', [timestampSeconds, gameId]);
   }
 }
 
@@ -70,6 +96,7 @@ describeDatabaseSuite({
   constructor: () => new TestPostgreSQL(),
   omit: {
     purgeUnfinishedGames: true,
+    markFinished: true,
   },
   stats: {
     'type': 'POSTGRESQL',

--- a/tests/testing/InMemoryDatabase.ts
+++ b/tests/testing/InMemoryDatabase.ts
@@ -74,10 +74,16 @@ export class InMemoryDatabase implements IDatabase {
 
     return Promise.resolve();
   }
-  cleanGame(_gameId: GameId): Promise<void> {
+  markFinished(_gameId: GameId): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  maintenance(): Promise<unknown> {
     throw new Error('Method not implemented.');
   }
   purgeUnfinishedGames(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  compressCompletedGames(): Promise<unknown> {
     throw new Error('Method not implemented.');
   }
   stats(): Promise<{[ key: string ]: string | number;}> {

--- a/tests/utils/setup.ts
+++ b/tests/utils/setup.ts
@@ -9,7 +9,7 @@ import {Executor} from '../../src/server/behavior/Executor';
 registerBehaviorExecutor(new Executor());
 
 const FAKE_DATABASE: IDatabase = {
-  cleanGame: () => Promise.resolve(),
+  markFinished: () => Promise.resolve(),
   deleteGameNbrSaves: () => Promise.resolve(),
   getPlayerCount: () => Promise.resolve(0),
   getGame: () => Promise.resolve({} as SerializedGame),
@@ -21,7 +21,9 @@ const FAKE_DATABASE: IDatabase = {
   loadCloneableGame: () => Promise.resolve({} as SerializedGame),
   saveGameResults: () => {},
   saveGame: () => Promise.resolve(),
+  maintenance: () => Promise.resolve(),
   purgeUnfinishedGames: () => Promise.resolve(),
+  compressCompletedGames: () => Promise.resolve(),
   stats: () => Promise.resolve({}),
 
   storeParticipants: () => Promise.resolve(),


### PR DESCRIPTION
This is a pretty significant rewrite, and contains a few things:

1. Completed games remain for two full days by default, making it simple to download games with bug reports filed against them.
2. Database maintenance is separated from cleanGame. So it's now called markFinished.
3. Some comments.