### PR TITLE
Adding scrolling for cards with huge description

### DIFF
--- a/src/client/components/card/Card.vue
+++ b/src/client/components/card/Card.vue
@@ -7,7 +7,7 @@
               <CardTags :tags="getTags()" />
           </div>
           <CardTitle :title="card.name" :type="getCardType()"/>
-          <CardContent v-if="getCardMetadata() !== undefined" :metadata="getCardMetadata()" :requirements="getCardRequirements()" :isCorporation="isCorporationCard()"/>
+          <CardContent v-if="getCardMetadata() !== undefined" :metadata="getCardMetadata()" :requirements="getCardRequirements()" :isCorporation="isCorporationCard()" :padBottom="hasResourceType" />
       </div>
       <CardExpansion :expansion="getCardExpansion()" :isCorporation="isCorporationCard()"/>
       <CardResourceCounter v-if="hasResourceType" :amount="getResourceAmount()" :type="resourceType" />

--- a/src/client/components/card/CardContent.vue
+++ b/src/client/components/card/CardContent.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
       required: true,
     },
     padBottom: {
-      type: Boolean
+      type: Boolean,
     },
   },
   components: {

--- a/src/client/components/card/CardContent.vue
+++ b/src/client/components/card/CardContent.vue
@@ -4,6 +4,7 @@
     <CardRenderData v-if="metadata.renderData" :renderData="metadata.renderData" />
     <CardDescription v-if="metadata.description" :item="metadata.description" />
     <CardVictoryPoints v-if="metadata.victoryPoints" :victoryPoints="metadata.victoryPoints" />
+    <div class="padBottom" v-if="padBottom" style="padding-bottom: 22px;"></div>
   </div>
 </template>
 
@@ -30,6 +31,9 @@ export default Vue.extend({
     isCorporation: {
       type: Boolean,
       required: true,
+    },
+    padBottom: {
+      type: Boolean
     },
   },
   components: {

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -898,6 +898,22 @@
             line-height: 20px;
             font-weight: bold;
             text-align: center;
+
+            // Adding scrolling for cards with huge description
+            overflow-x: hidden;
+            &::-webkit-scrollbar-track {
+                background-color: transparent;
+                border-radius: 0 0 32px 0;
+            }
+            &::-webkit-scrollbar {
+                width: 4px;
+                background-color: transparent;
+            }
+            &::-webkit-scrollbar-thumb {
+                background-color: #898989;
+                border-radius: 0 0 32px 0;
+            }
+
             .card-corporation-box {
                 position: absolute;
                 display: flex;


### PR DESCRIPTION
Splitted from #5640

When card has a huge of description, it can be scrolled.
It will look like (pointed scroll at the right side)
![image](https://user-images.githubusercontent.com/2452201/235373421-e9062293-0b43-4f11-b14c-9413b597a82a.png) ![image](https://user-images.githubusercontent.com/2452201/235373490-aa5c921a-2ccd-49b3-941f-0e05ac4c0292.png)

Needs almost for every locale
![image](https://user-images.githubusercontent.com/2452201/235445559-80f8abc1-df3d-41bc-ba89-a4add37d95e3.png) ![image](https://user-images.githubusercontent.com/2452201/235445620-867a3317-1123-4646-9f0b-f5948cc809bc.png)
![image](https://user-images.githubusercontent.com/2452201/235445679-6a677b34-898f-43bb-bcbf-6191da0895b7.png) ![image](https://user-images.githubusercontent.com/2452201/235445746-624634a0-820f-4306-a0cf-9e6f8aa698f4.png)
