### PR TITLE
Remove BETA tag from CEOs

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -137,7 +137,7 @@
                             <input type="checkbox" name="ceo" id="ceo-checkbox" v-model="ceoExtension">
                             <label for="ceo-checkbox" class="expansion-button">
                                 <div class="create-game-expansion-icon expansion-icon-ceo"></div>
-                                <span v-i18n>CEOs (BETA)</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/CEOs" class="tooltip" target="_blank">&#9432;</a>
+                                <span v-i18n>CEOs</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/CEOs" class="tooltip" target="_blank">&#9432;</a>
                             </label>
                         </div>
 

--- a/src/locales/de/ui.json
+++ b/src/locales/de/ui.json
@@ -54,7 +54,7 @@
     "prel": "Präludium",
     "Prelude": "Präludium",
     "Venus Next": "Nächster Halt: Venus",
-    "CEOs (BETA)": "Geschäftsführer (BETA)",
+    "CEOs": "Geschäftsführer",
     "Custom Corporation list": "Benutzerdefinierte Konzernauswahl",
     "Custom Preludes list": "Benutzerdefinierte Präludiumauswahl",
     "World Government Terraforming": "Terraforming der Weltregierung",

--- a/src/locales/ru/ui.json
+++ b/src/locales/ru/ui.json
@@ -48,7 +48,7 @@
     "prel": "пролог",
     "Prelude": "Пролог",
     "Venus Next": "Венера",
-    "CEOs (BETA)": "Директора (BETA)",
+    "CEOs": "Директора",
     "Custom Corporation list": "Настроить корпорации",
     "Custom Preludes list": "Настроить список прологов",
     "Custom Colonies list": "Настроить колонии",


### PR DESCRIPTION
All the core components are done, remaining issues are external from the CEO application itself.

Wiki is up to date: https://github.com/terraforming-mars/terraforming-mars/wiki/CEOs

All future issues/bugs can be reported as regular App bugs, not part of the CEO Beta