### PR TITLE
Reset the Road Piracy ledger on error.

### DIFF
--- a/src/server/cards/moon/RoadPiracy.ts
+++ b/src/server/cards/moon/RoadPiracy.ts
@@ -39,14 +39,14 @@ export class RoadPiracy extends Card implements IProjectCard {
 
   private generateOption(player: Player, resource: Resource, title: Message, limit: number) {
     const selectAmounts: Array<SelectAmount> = [];
-    const ledger: Array<[Player, number]> = [];
+    const ledger: Map<Player, number> = new Map();
     for (const opponent of player.game.getPlayers()) {
       if (opponent === player) {
         continue;
       }
       if (opponent.getResource(resource) > 0) {
         const cb = (amount: number) => {
-          ledger.push([opponent, amount]);
+          ledger.set(opponent, amount);
           return undefined;
         };
         const selectAmount =
@@ -64,9 +64,10 @@ export class RoadPiracy extends Card implements IProjectCard {
     }
 
     const cb = () => {
-      const total = sum(ledger.map((e) => e[1]));
+      const total = sum(Array.from(ledger.values()));
       if (total > limit) {
         // throw new Error(newMessage('You may only steal up to ${0} ${1} from all players', (b) => b.number(limit).string(resource)));
+        ledger.clear();
         throw new Error(`You may only steal up to ${limit} ${resource} from all players`);
       }
       for (const entry of ledger) {

--- a/tests/cards/moon/RoadPiracy.spec.ts
+++ b/tests/cards/moon/RoadPiracy.spec.ts
@@ -71,9 +71,22 @@ describe('RoadPiracy', () => {
       type: 'and',
       responses: [
         {type: 'amount', amount: 3},
-        {type: 'amount', amount: 1},
+        {type: 'amount', amount: 3},
       ],
     }, player)).to.throw(/Amount provided too high/);
+
+    // This verifies that even if the option has an error state, it can be re-run.
+    titanium.process({
+      type: 'and',
+      responses: [
+        {type: 'amount', amount: 2},
+        {type: 'amount', amount: 2},
+      ],
+    }, player);
+
+    expect(player.titanium).eq(4);
+    expect(player2.titanium).eq(0);
+    expect(player3.titanium).eq(3);
   });
 
 
@@ -90,6 +103,19 @@ describe('RoadPiracy', () => {
         {type: 'amount', amount: 3},
       ],
     }, player)).to.throw(/You may only steal up to 4 titanium/);
+
+    // This verifies that even if the option has an error state, it can be re-run.
+    titanium.process({
+      type: 'and',
+      responses: [
+        {type: 'amount', amount: 2},
+        {type: 'amount', amount: 2},
+      ],
+    }, player);
+
+    expect(player.titanium).eq(4);
+    expect(player2.titanium).eq(0);
+    expect(player3.titanium).eq(3);
   });
 
   it('Do not select', () => {


### PR DESCRIPTION
This prevents an endless loop.