### PR TITLE
Replace player input type enum with string type.

### DIFF
--- a/src/client/components/OrOptions.vue
+++ b/src/client/components/OrOptions.vue
@@ -33,7 +33,6 @@ import {PlayerViewModel, PublicPlayerModel} from '@/common/models/PlayerModel';
 import {PlayerInputModel} from '@/common/models/PlayerInputModel';
 import {getPreferences} from '@/client/utils/PreferencesManager';
 import {InputResponse, OrOptionsResponse} from '@/common/inputs/InputResponse';
-import {PlayerInputType} from '@/common/input/PlayerInputType';
 
 let unique = 0;
 
@@ -70,7 +69,7 @@ export default Vue.extend({
     // Special case: If the first displayed option is SelectCard, and none of them are enabled, skip it.
     let selectedOption = displayedOptions[0];
     if (displayedOptions.length > 1 &&
-      selectedOption.inputType === PlayerInputType.SELECT_CARD &&
+      selectedOption.inputType === 'card' &&
       !selectedOption.cards?.some((card) => card.isDisabled === false)) {
       selectedOption = displayedOptions[1];
     }

--- a/src/client/components/PlayerInputFactory.vue
+++ b/src/client/components/PlayerInputFactory.vue
@@ -32,21 +32,21 @@ import ShiftAresGlobalParameters from '@/client/components/ShiftAresGlobalParame
 import {InputResponse} from '@/common/inputs/InputResponse';
 
 const typeToComponentName: Record<PlayerInputType, string> = {
-  [PlayerInputType.AND_OPTIONS]: 'and-options',
-  [PlayerInputType.SELECT_CARD]: 'SelectCard',
-  [PlayerInputType.SELECT_PROJECT_CARD_TO_PLAY]: 'SelectProjectCardToPlay',
-  [PlayerInputType.SELECT_INITIAL_CARDS]: 'SelectInitialCards',
-  [PlayerInputType.OR_OPTIONS]: 'or-options',
-  [PlayerInputType.SELECT_OPTION]: 'select-option',
-  [PlayerInputType.SELECT_PAYMENT]: 'SelectPayment',
-  [PlayerInputType.SELECT_SPACE]: 'select-space',
-  [PlayerInputType.SELECT_PLAYER]: 'select-player',
-  [PlayerInputType.SELECT_AMOUNT]: 'select-amount',
-  [PlayerInputType.SELECT_DELEGATE]: 'select-party-player',
-  [PlayerInputType.SELECT_PARTY_TO_SEND_DELEGATE]: 'select-party-to-send-delegate',
-  [PlayerInputType.SELECT_COLONY]: 'select-colony',
-  [PlayerInputType.SELECT_PRODUCTION_TO_LOSE]: 'select-production-to-lose',
-  [PlayerInputType.SHIFT_ARES_GLOBAL_PARAMETERS]: 'shift-ares-global-parameters',
+  'and': 'and-options',
+  'card': 'SelectCard',
+  'projectCard': 'SelectProjectCardToPlay',
+  'initialCards': 'SelectInitialCards',
+  'or': 'or-options',
+  'option': 'select-option',
+  'payment': 'SelectPayment',
+  'space': 'select-space',
+  'player': 'select-player',
+  'amount': 'select-amount',
+  'delegate': 'select-party-player',
+  'party': 'select-party-to-send-delegate',
+  'colony': 'select-colony',
+  'productionToLose': 'select-production-to-lose',
+  'aresGlobalParameters': 'shift-ares-global-parameters',
 };
 
 export default Vue.component('player-input-factory', {

--- a/src/common/input/PlayerInputType.ts
+++ b/src/common/input/PlayerInputType.ts
@@ -1,17 +1,16 @@
-export enum PlayerInputType {
-    AND_OPTIONS, // 0
-    OR_OPTIONS, // 1
-    SELECT_AMOUNT, // 2
-    SELECT_CARD, // 3
-    SELECT_DELEGATE, // 4
-    SELECT_PAYMENT, // 5
-    SELECT_PROJECT_CARD_TO_PLAY, // 6
-    SELECT_INITIAL_CARDS, // 7
-    SELECT_OPTION, // 8
-    SELECT_PARTY_TO_SEND_DELEGATE, // 9
-    SELECT_PLAYER, // 10
-    SELECT_SPACE, // 11
-    SELECT_COLONY, // 12
-    SELECT_PRODUCTION_TO_LOSE, // 13
-    SHIFT_ARES_GLOBAL_PARAMETERS, // 14
-}
+export type PlayerInputType =
+    'and' |
+    'or' |
+    'amount' |
+    'card' |
+    'delegate' |
+    'payment' |
+    'projectCard' |
+    'initialCards' |
+    'option' |
+    'party' |
+    'player' |
+    'space' |
+    'colony' |
+    'productionToLose' |
+    'aresGlobalParameters';

--- a/src/server/inputs/AndOptions.ts
+++ b/src/server/inputs/AndOptions.ts
@@ -1,12 +1,11 @@
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {InputResponse, isAndOptionsResponse} from '../../common/inputs/InputResponse';
 import {Player} from '../Player';
 
 export class AndOptions extends BasePlayerInput {
   public options: Array<PlayerInput>;
   constructor(public cb: () => PlayerInput | undefined, ...options: Array<PlayerInput>) {
-    super(PlayerInputType.AND_OPTIONS);
+    super('and');
     this.options = options;
   }
 

--- a/src/server/inputs/OrOptions.ts
+++ b/src/server/inputs/OrOptions.ts
@@ -1,5 +1,4 @@
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {InputResponse, isOrOptionsResponse} from '../../common/inputs/InputResponse';
 import {Player} from '../Player';
 
@@ -9,7 +8,7 @@ export class OrOptions extends BasePlayerInput {
   }
   public options: Array<PlayerInput>;
   constructor(...options: Array<PlayerInput>) {
-    super(PlayerInputType.OR_OPTIONS, 'Select one option');
+    super('or', 'Select one option');
     this.options = options;
   }
 

--- a/src/server/inputs/SelectAmount.ts
+++ b/src/server/inputs/SelectAmount.ts
@@ -1,6 +1,5 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {InputResponse, isSelectAmountResponse} from '../../common/inputs/InputResponse';
 
 export class SelectAmount extends BasePlayerInput {
@@ -12,7 +11,7 @@ export class SelectAmount extends BasePlayerInput {
     public max: number,
     public maxByDefault?: boolean,
   ) {
-    super(PlayerInputType.SELECT_AMOUNT, title);
+    super('amount', title);
     this.buttonLabel = buttonLabel;
   }
 

--- a/src/server/inputs/SelectCard.ts
+++ b/src/server/inputs/SelectCard.ts
@@ -1,7 +1,6 @@
 import {ICard} from '../cards/ICard';
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, getCardFromPlayerInput, PlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {CardName} from '../../common/cards/CardName';
 import {InputResponse, isSelectCardResponse} from '../../common/inputs/InputResponse';
 
@@ -23,7 +22,7 @@ export class SelectCard<T extends ICard> extends BasePlayerInput {
     public cb: (cards: Array<T>) => PlayerInput | undefined,
     config?: Partial<Options>,
   ) {
-    super(PlayerInputType.SELECT_CARD, title);
+    super('card', title);
     this.config = {
       max: config?.max ?? 1,
       min: config?.min ?? 1,

--- a/src/server/inputs/SelectColony.ts
+++ b/src/server/inputs/SelectColony.ts
@@ -1,6 +1,5 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {IColony} from '../colonies/IColony';
 import {InputResponse, isSelectColonyResponse} from '../../common/inputs/InputResponse';
 
@@ -16,7 +15,7 @@ export class SelectColony extends BasePlayerInput {
     public colonies: Array<IColony>,
     public cb: (colony: IColony) => PlayerInput | undefined,
   ) {
-    super(PlayerInputType.SELECT_COLONY, title);
+    super('colony', title);
     this.buttonLabel = buttonLabel;
   }
 

--- a/src/server/inputs/SelectDelegate.ts
+++ b/src/server/inputs/SelectDelegate.ts
@@ -1,7 +1,6 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
 import {Player} from '../Player';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {NeutralPlayer} from '../turmoil/Turmoil';
 import {InputResponse, isSelectDelegateResponse} from '../../common/inputs/InputResponse';
 
@@ -11,7 +10,7 @@ export class SelectDelegate extends BasePlayerInput {
     public players: Array<Player | NeutralPlayer>,
     title: string | Message,
     public cb: (player: Player | NeutralPlayer) => PlayerInput | undefined) {
-    super(PlayerInputType.SELECT_DELEGATE, title);
+    super('delegate', title);
   }
 
   public process(input: InputResponse) {

--- a/src/server/inputs/SelectInitialCards.ts
+++ b/src/server/inputs/SelectInitialCards.ts
@@ -2,7 +2,6 @@ import {AndOptions} from './AndOptions';
 import {ICorporationCard} from '../cards/corporation/ICorporationCard';
 import {IProjectCard} from '../cards/IProjectCard';
 import {Player} from '../Player';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {SelectCard} from './SelectCard';
 import {Merger} from '../cards/promo/Merger';
 import {CardName} from '../../common/cards/CardName';
@@ -11,7 +10,7 @@ import * as titles from '../../common/inputs/SelectInitialCards';
 
 
 export class SelectInitialCards extends AndOptions {
-  public override readonly inputType = PlayerInputType.SELECT_INITIAL_CARDS;
+  public override readonly inputType = 'initialCards';
   constructor(private player: Player, cb: (corporation: ICorporationCard) => undefined) {
     super(() => {
       this.completed(corporation);

--- a/src/server/inputs/SelectOption.ts
+++ b/src/server/inputs/SelectOption.ts
@@ -1,6 +1,5 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {InputResponse, isSelectOptionResponse} from '../../common/inputs/InputResponse';
 
 export class SelectOption extends BasePlayerInput {
@@ -8,7 +7,7 @@ export class SelectOption extends BasePlayerInput {
     title: string | Message,
     buttonLabel: string = 'Select',
     public cb: () => PlayerInput | undefined) {
-    super(PlayerInputType.SELECT_OPTION, title);
+    super('option', title);
     this.buttonLabel = buttonLabel;
   }
 

--- a/src/server/inputs/SelectPartyToSendDelegate.ts
+++ b/src/server/inputs/SelectPartyToSendDelegate.ts
@@ -1,6 +1,5 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {PartyName} from '../../common/turmoil/PartyName';
 import {InputResponse, isSelectPartyResponse} from '../../common/inputs/InputResponse';
 
@@ -12,7 +11,7 @@ export class SelectPartyToSendDelegate extends BasePlayerInput {
     public availableParties: PartyName[],
     public cb: (party: PartyName) => undefined,
   ) {
-    super(PlayerInputType.SELECT_PARTY_TO_SEND_DELEGATE, title);
+    super('party', title);
     this.buttonLabel = buttonLabel;
   }
 

--- a/src/server/inputs/SelectPayment.ts
+++ b/src/server/inputs/SelectPayment.ts
@@ -1,6 +1,5 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {isPayment, Payment} from '../../common/inputs/Payment';
 import {InputResponse, isSelectPaymentResponse} from '../../common/inputs/InputResponse';
 import {Player} from '../Player';
@@ -17,7 +16,7 @@ export class SelectPayment extends BasePlayerInput {
     public amount: number,
     public cb: (payment: Payment) => PlayerInput | undefined,
   ) {
-    super(PlayerInputType.SELECT_PAYMENT, title);
+    super('payment', title);
     this.buttonLabel = 'Pay'; // no input button
   }
 

--- a/src/server/inputs/SelectPlayer.ts
+++ b/src/server/inputs/SelectPlayer.ts
@@ -1,12 +1,11 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
 import {Player} from '../Player';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {InputResponse, isSelectPlayerResponse} from '../../common/inputs/InputResponse';
 
 export class SelectPlayer extends BasePlayerInput {
   constructor(public players: Array<Player>, title: string | Message, buttonLabel: string = 'Save', public cb: (player: Player) => PlayerInput | undefined) {
-    super(PlayerInputType.SELECT_PLAYER, title);
+    super('player', title);
     this.buttonLabel = buttonLabel;
   }
 

--- a/src/server/inputs/SelectProductionToLose.ts
+++ b/src/server/inputs/SelectProductionToLose.ts
@@ -1,6 +1,5 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {Player} from '../Player';
 import {Units} from '../../common/Units';
 import {InputResponse, isSelectProductionToLoseResponse} from '../../common/inputs/InputResponse';
@@ -14,7 +13,7 @@ export class SelectProductionToLose extends BasePlayerInput {
     public cb: (units: Units) => PlayerInput | undefined,
     buttonLabel: string = 'Save',
   ) {
-    super(PlayerInputType.SELECT_PRODUCTION_TO_LOSE, title);
+    super('productionToLose', title);
     this.buttonLabel = buttonLabel;
   }
 

--- a/src/server/inputs/SelectProjectCardToPlay.ts
+++ b/src/server/inputs/SelectProjectCardToPlay.ts
@@ -1,5 +1,4 @@
 import {BasePlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {isPayment, Payment} from '../../common/inputs/Payment';
 import {IProjectCard, PlayableCard} from '../cards/IProjectCard';
 import {Units} from '../../common/Units';
@@ -26,7 +25,7 @@ export class SelectProjectCardToPlay extends BasePlayerInput {
       action?: CardAction,
       cb?: (cardToPlay: IProjectCard) => void,
     }) {
-    super(PlayerInputType.SELECT_PROJECT_CARD_TO_PLAY, 'Play project card');
+    super('projectCard', 'Play project card');
     this.buttonLabel = 'Play card';
     this.cards = cards.map((card) => card.card);
     this.extras = new Map(

--- a/src/server/inputs/SelectSpace.ts
+++ b/src/server/inputs/SelectSpace.ts
@@ -1,7 +1,6 @@
 import {Message} from '../../common/logs/Message';
 import {BasePlayerInput, PlayerInput} from '../PlayerInput';
 import {ISpace} from '../boards/ISpace';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {InputResponse, isSelectSpaceResponse} from '../../common/inputs/InputResponse';
 
 export class SelectSpace extends BasePlayerInput {
@@ -9,7 +8,7 @@ export class SelectSpace extends BasePlayerInput {
     title: string | Message,
     public availableSpaces: ReadonlyArray<ISpace>,
     public cb: (space: ISpace) => PlayerInput | undefined) {
-    super(PlayerInputType.SELECT_SPACE, title);
+    super('space', title);
     if (availableSpaces.length === 0) {
       throw new Error('No available spaces');
     }

--- a/src/server/inputs/ShiftAresGlobalParameters.ts
+++ b/src/server/inputs/ShiftAresGlobalParameters.ts
@@ -1,5 +1,4 @@
 import {BasePlayerInput} from '../PlayerInput';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {Player} from '../Player';
 import {AresGlobalParametersResponse} from '../../common/inputs/AresGlobalParametersResponse';
 import {InputResponse, isAresGlobalParametersResponse, isShiftAresGlobalParametersResponse} from '../../common/inputs/InputResponse';
@@ -8,7 +7,7 @@ export class ShiftAresGlobalParameters extends BasePlayerInput {
   constructor(
     public player: Player,
     public cb: (units: AresGlobalParametersResponse) => undefined) {
-    super(PlayerInputType.SHIFT_ARES_GLOBAL_PARAMETERS, 'Adjust Ares global parameters up to 1 step.');
+    super('aresGlobalParameters', 'Adjust Ares global parameters up to 1 step.');
   }
 
   public process(input: InputResponse, _player: Player) {

--- a/src/server/models/ServerModel.ts
+++ b/src/server/models/ServerModel.ts
@@ -13,7 +13,6 @@ import {ISpace} from '../boards/ISpace';
 import {Player} from '../Player';
 import {PlayerInput} from '../PlayerInput';
 import {PlayerInputModel} from '../../common/models/PlayerInputModel';
-import {PlayerInputType} from '../../common/input/PlayerInputType';
 import {PlayerViewModel, Protection, PublicPlayerModel} from '../../common/models/PlayerModel';
 import {SelectAmount} from '../inputs/SelectAmount';
 import {SelectCard} from '../inputs/SelectCard';
@@ -244,9 +243,9 @@ export class Server {
       showReset: player.game.inputsThisRound > 0 && player.game.resettable === true && player.game.phase === Phase.ACTION,
     };
     switch (waitingFor.inputType) {
-    case PlayerInputType.AND_OPTIONS:
-    case PlayerInputType.OR_OPTIONS:
-    case PlayerInputType.SELECT_INITIAL_CARDS:
+    case 'and':
+    case 'or':
+    case 'initialCards':
       playerInputModel.options = [];
       if (waitingFor.options !== undefined) {
         for (const option of waitingFor.options) {
@@ -259,7 +258,7 @@ export class Server {
         throw new Error('required options not defined');
       }
       break;
-    case PlayerInputType.SELECT_PROJECT_CARD_TO_PLAY:
+    case 'projectCard':
       const spctp: SelectProjectCardToPlay = waitingFor as SelectProjectCardToPlay;
       playerInputModel.cards = this.getCards(player, spctp.cards, {showCalculatedCost: true, extras: spctp.extras});
       playerInputModel.microbes = player.getSpendableMicrobes();
@@ -269,7 +268,7 @@ export class Server {
       playerInputModel.science = player.getSpendableScienceResources();
       playerInputModel.seeds = player.getSpendableSeedResources();
       break;
-    case PlayerInputType.SELECT_CARD:
+    case 'card':
       const selectCard = waitingFor as SelectCard<ICard>;
       playerInputModel.cards = this.getCards(player, selectCard.cards, {
         showCalculatedCost: selectCard.config.played === false || selectCard.config.played === CardName.SELF_REPLICATING_ROBOTS,
@@ -282,11 +281,11 @@ export class Server {
       playerInputModel.selectBlueCardAction = selectCard.config.selectBlueCardAction;
       playerInputModel.showOwner = selectCard.config.showOwner === true;
       break;
-    case PlayerInputType.SELECT_COLONY:
+    case 'colony':
       const selectColony = waitingFor as SelectColony;
       playerInputModel.coloniesModel = this.getColonyModel(player.game, selectColony.colonies, selectColony.showTileOnly);
       break;
-    case PlayerInputType.SELECT_PAYMENT:
+    case 'payment':
       const sp = waitingFor as SelectPayment;
       playerInputModel.amount = sp.amount;
       playerInputModel.canUseSteel = sp.canUseSteel;
@@ -298,22 +297,22 @@ export class Server {
       playerInputModel.canUseData = sp.canUseData;
       playerInputModel.auroraiData = player.getSpendableData();
       break;
-    case PlayerInputType.SELECT_PLAYER:
+    case 'player':
       playerInputModel.players = (waitingFor as SelectPlayer).players.map(
         (player) => player.color,
       );
       break;
-    case PlayerInputType.SELECT_SPACE:
+    case 'space':
       playerInputModel.availableSpaces = (waitingFor as SelectSpace).availableSpaces.map(
         (space) => space.id,
       );
       break;
-    case PlayerInputType.SELECT_AMOUNT:
+    case 'amount':
       playerInputModel.min = (waitingFor as SelectAmount).min;
       playerInputModel.max = (waitingFor as SelectAmount).max;
       playerInputModel.maxByDefault = (waitingFor as SelectAmount).maxByDefault;
       break;
-    case PlayerInputType.SELECT_DELEGATE:
+    case 'delegate':
       playerInputModel.players = (waitingFor as SelectDelegate).players.map(
         (player) => {
           if (player === 'NEUTRAL') {
@@ -324,13 +323,13 @@ export class Server {
         },
       );
       break;
-    case PlayerInputType.SELECT_PARTY_TO_SEND_DELEGATE:
+    case 'party':
       playerInputModel.availableParties = (waitingFor as SelectPartyToSendDelegate).availableParties;
       if (player.game !== undefined) {
         playerInputModel.turmoil = getTurmoilModel(player.game);
       }
       break;
-    case PlayerInputType.SELECT_PRODUCTION_TO_LOSE:
+    case 'productionToLose':
       const _player = (waitingFor as SelectProductionToLose).player;
       playerInputModel.payProduction = {
         cost: (waitingFor as SelectProductionToLose).unitsToLose,
@@ -344,7 +343,7 @@ export class Server {
         },
       };
       break;
-    case PlayerInputType.SHIFT_ARES_GLOBAL_PARAMETERS:
+    case 'aresGlobalParameters':
       AresHandler.ifAres((waitingFor as ShiftAresGlobalParameters).player.game, (aresData) => {
         playerInputModel.aresData = aresData;
       });

--- a/tests/client/components/AndOptions.spec.ts
+++ b/tests/client/components/AndOptions.spec.ts
@@ -4,7 +4,6 @@ import {getLocalVue} from './getLocalVue';
 
 import {expect} from 'chai';
 import AndOptions from '@/client/components/AndOptions.vue';
-import {PlayerInputType} from '@/common/input/PlayerInputType';
 import {InputResponse} from '@/common/inputs/InputResponse';
 import PlayerInputFactory from '@/client/components/PlayerInputFactory.vue';
 
@@ -20,11 +19,11 @@ describe('AndOptions', function() {
         playerinput: {
           title: 'foo',
           options: [{
-            inputType: PlayerInputType.SELECT_OPTION,
+            inputType: 'option',
             title: 'select a',
           }, {
             title: 'select b',
-            inputType: PlayerInputType.SELECT_OPTION,
+            inputType: 'option',
           }],
         },
         onsave: function(data: InputResponse) {

--- a/tests/client/components/OrOptions.spec.ts
+++ b/tests/client/components/OrOptions.spec.ts
@@ -2,7 +2,6 @@ import {mount} from '@vue/test-utils';
 import {getLocalVue} from './getLocalVue';
 import {expect} from 'chai';
 import OrOptions from '@/client/components/OrOptions.vue';
-import {PlayerInputType} from '@/common/input/PlayerInputType';
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 import {InputResponse} from '@/common/inputs/InputResponse';
 import PlayerInputFactory from '@/client/components/PlayerInputFactory.vue';
@@ -20,15 +19,15 @@ describe('OrOptions', function() {
         playerinput: {
           title: 'foo',
           options: [{
-            inputType: PlayerInputType.SELECT_OPTION,
+            inputType: 'option',
             title: 'hide this',
             showOnlyInLearnerMode: true,
           }, {
-            inputType: PlayerInputType.SELECT_OPTION,
+            inputType: 'option',
             title: 'select a',
           }, {
             title: 'select b',
-            inputType: PlayerInputType.SELECT_OPTION,
+            inputType: 'option',
           }],
         },
         onsave: function(data: InputResponse) {
@@ -58,11 +57,11 @@ describe('OrOptions', function() {
         playerinput: {
           title: 'foo',
           options: [{
-            inputType: PlayerInputType.SELECT_OPTION,
+            inputType: 'option',
             title: 'select a',
           }, {
             title: 'select b',
-            inputType: PlayerInputType.SELECT_OPTION,
+            inputType: 'option',
           }],
         },
         onsave: function(data: InputResponse) {

--- a/tests/client/components/PlayerInputFactory.spec.ts
+++ b/tests/client/components/PlayerInputFactory.spec.ts
@@ -2,7 +2,6 @@ import {mount} from '@vue/test-utils';
 import {getLocalVue} from './getLocalVue';
 import {expect} from 'chai';
 import PlayerInputFactory from '@/client/components/PlayerInputFactory.vue';
-import {PlayerInputType} from '@/common/input/PlayerInputType';
 import {CardModel} from '@/common/models/CardModel';
 import {PlayerInputModel} from '@/common/models/PlayerInputModel';
 import {Units} from '@/common/Units';
@@ -12,52 +11,52 @@ import {SELECT_CORPORATION_TITLE, SELECT_PROJECTS_TITLE} from '@/common/inputs/S
 describe('PlayerInputFactory2', function() {
   it('AndOptions', async () => {
     runTest({
-      inputType: PlayerInputType.AND_OPTIONS,
+      inputType: 'and',
       options: [],
     });
   });
 
   it('OrOptions', async () => {
     runTest({
-      inputType: PlayerInputType.OR_OPTIONS,
+      inputType: 'or',
       options: [],
     });
   });
 
   it('SelectAmount', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_AMOUNT,
+      inputType: 'amount',
     });
   });
 
   it('SelectAmount', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_CARD,
+      inputType: 'card',
     });
   });
 
   it('SelectOption', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_OPTION,
+      inputType: 'option',
     });
   });
 
   it('SelectPayment', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_PAYMENT,
+      inputType: 'payment',
     });
   });
 
   it('SelectProjectCardToPlay', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_PROJECT_CARD_TO_PLAY,
+      inputType: 'projectCard',
       cards: [{name: CardName.ANTS, reserveUnits: {}} as CardModel],
     });
   });
 
   it('SelectInitialCards', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_INITIAL_CARDS,
+      inputType: 'initialCards',
       options: [
         {title: SELECT_CORPORATION_TITLE} as PlayerInputModel,
         {title: SELECT_PROJECTS_TITLE} as PlayerInputModel,
@@ -67,19 +66,19 @@ describe('PlayerInputFactory2', function() {
 
   it('SelectSpace', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_SPACE,
+      inputType: 'space',
     });
   });
 
   it('SelectPlayer', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_PLAYER,
+      inputType: 'player',
     });
   });
 
   it('SelectPartyToSendDelegate', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_PARTY_TO_SEND_DELEGATE,
+      inputType: 'party',
       turmoil: {
         dominant: undefined,
         ruling: undefined,
@@ -98,13 +97,13 @@ describe('PlayerInputFactory2', function() {
 
   it('SelectColony', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_COLONY,
+      inputType: 'colony',
     });
   });
 
   it('SelectProductionToLose', async () => {
     runTest({
-      inputType: PlayerInputType.SELECT_PRODUCTION_TO_LOSE,
+      inputType: 'productionToLose',
       payProduction: {
         cost: 0,
         units: Units.EMPTY,
@@ -114,7 +113,7 @@ describe('PlayerInputFactory2', function() {
 
   it('ShiftAresGlobalParameters', async () => {
     runTest({
-      inputType: PlayerInputType.SHIFT_ARES_GLOBAL_PARAMETERS,
+      inputType: 'aresGlobalParameters',
       aresData: {
         includeHazards: false,
         hazardData: {

--- a/tests/client/components/ShiftAresGlobalParameters.spec.ts
+++ b/tests/client/components/ShiftAresGlobalParameters.spec.ts
@@ -3,14 +3,13 @@ import {getLocalVue} from './getLocalVue';
 import {expect} from 'chai';
 import ShiftAresGlobalParameters from '@/client/components/ShiftAresGlobalParameters.vue';
 import {PlayerInputModel} from '@/common/models/PlayerInputModel';
-import {PlayerInputType} from '@/common/input/PlayerInputType';
 import {PartyName} from '@/common/turmoil/PartyName';
 
 describe('ShiftAresGlobalParameters', function() {
   const mockPlayerModel: PlayerInputModel = {
     title: 'Testing, baby!',
     buttonLabel: 'Click me!',
-    inputType: PlayerInputType.SHIFT_ARES_GLOBAL_PARAMETERS,
+    inputType: 'aresGlobalParameters',
     amount: undefined,
     options: undefined,
     cards: undefined,


### PR DESCRIPTION
This increases readability and debuggability. Plus, `enum` is considered no longer that great for ongoing Typescript projects.