### PR TITLE
Use cast instead of expect().is.undefined.

### DIFF
--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -67,8 +67,7 @@ describe('Player', function() {
     player.production.add(Resource.ENERGY, 1);
     player2.production.add(Resource.ENERGY, 1);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     runAllActions(player.game);
     cast(player.getWaitingFor(), SelectPlayer);
 

--- a/tests/cards/base/ArtificialLake.spec.ts
+++ b/tests/cards/base/ArtificialLake.spec.ts
@@ -54,8 +54,7 @@ describe('ArtificialLake', function() {
     expect(player.simpleCanPlay(card)).is.true;
 
     // ...but an action to place ocean is not unavailable
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Cannot place ocean if all land spaces are occupied', function() {

--- a/tests/cards/base/ArtificialPhotosynthesis.spec.ts
+++ b/tests/cards/base/ArtificialPhotosynthesis.spec.ts
@@ -8,8 +8,7 @@ describe('ArtificialPhotosynthesis', () => {
   it('Should play', () => {
     const card = new ArtificialPhotosynthesis();
     const [game, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     runAllActions(game);
     const options = cast(player.popWaitingFor(), OrOptions);
     expect(options.options).has.lengthOf(2);

--- a/tests/cards/base/AsteroidMining.spec.ts
+++ b/tests/cards/base/AsteroidMining.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {testGame} from '../../TestGame';
 import {AsteroidMining} from '../../../src/server/cards/base/AsteroidMining';
+import {cast} from '../../TestingUtils';
 
 describe('AsteroidMining', function() {
   it('Should play', function() {
     const card = new AsteroidMining();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(2);
     expect(card.getVictoryPoints(player)).to.eq(2);
   });

--- a/tests/cards/base/CallistoPenalMines.spec.ts
+++ b/tests/cards/base/CallistoPenalMines.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {testGame} from '../../TestGame';
 import {CallistoPenalMines} from '../../../src/server/cards/base/CallistoPenalMines';
+import {cast} from '../../TestingUtils';
 
 describe('CallistoPenalMines', function() {
   it('Should play', function() {
     const card = new CallistoPenalMines();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(3);
     expect(card.getVictoryPoints(player)).to.eq(2);
   });

--- a/tests/cards/base/Comet.spec.ts
+++ b/tests/cards/base/Comet.spec.ts
@@ -54,8 +54,7 @@ describe('Comet', function() {
     Game.newInstance('gameid', [player], player);
     player.plants = 8;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.plants).to.eq(8);
   });
 });

--- a/tests/cards/base/EarthOffice.spec.ts
+++ b/tests/cards/base/EarthOffice.spec.ts
@@ -4,6 +4,7 @@ import {Birds} from '../../../src/server/cards/base/Birds';
 import {EarthOffice} from '../../../src/server/cards/base/EarthOffice';
 import {LunaGovernor} from '../../../src/server/cards/colonies/LunaGovernor';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('EarthOffice', function() {
   let card: EarthOffice;
@@ -13,8 +14,7 @@ describe('EarthOffice', function() {
     card = new EarthOffice();
     [/* skipped */, player] = testGame(2);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/ExtremeColdFungus.spec.ts
+++ b/tests/cards/base/ExtremeColdFungus.spec.ts
@@ -29,8 +29,7 @@ describe('ExtremeColdFungus', () => {
   });
 
   it('Should play', () => {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act - single target', () => {

--- a/tests/cards/base/Flooding.spec.ts
+++ b/tests/cards/base/Flooding.spec.ts
@@ -82,7 +82,6 @@ describe('Flooding', function() {
     maxOutOceans(player);
     expect(card.canPlay(player)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 });

--- a/tests/cards/base/GHGProducingBacteria.spec.ts
+++ b/tests/cards/base/GHGProducingBacteria.spec.ts
@@ -25,8 +25,7 @@ describe('GHGProducingBacteria', () => {
 
   it('Should play', () => {
     setOxygenLevel(game, 4);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', () => {

--- a/tests/cards/base/GanymedeColony.spec.ts
+++ b/tests/cards/base/GanymedeColony.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {GanymedeColony} from '../../../src/server/cards/base/GanymedeColony';
 import {testGame} from '../../TestGame';
+import {cast} from '../../TestingUtils';
 
 describe('GanymedeColony', function() {
   it('Should play', function() {
     const card = new GanymedeColony();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     player.playedCards.push(card);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });

--- a/tests/cards/base/GeothermalPower.spec.ts
+++ b/tests/cards/base/GeothermalPower.spec.ts
@@ -6,8 +6,7 @@ describe('GeothermalPower', function() {
   it('Should play', function() {
     const card = new GeothermalPower();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(2);
   });
 });

--- a/tests/cards/base/GiantSpaceMirror.spec.ts
+++ b/tests/cards/base/GiantSpaceMirror.spec.ts
@@ -6,8 +6,7 @@ describe('GiantSpaceMirror', function() {
   it('Should play', function() {
     const card = new GiantSpaceMirror();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(3);
   });
 });

--- a/tests/cards/base/IceAsteroid.spec.ts
+++ b/tests/cards/base/IceAsteroid.spec.ts
@@ -6,7 +6,6 @@ describe('IceAsteroid', function() {
   it('Should play', function() {
     const card = new IceAsteroid();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 });

--- a/tests/cards/base/ImmigrationShuttles.spec.ts
+++ b/tests/cards/base/ImmigrationShuttles.spec.ts
@@ -6,8 +6,7 @@ describe('ImmigrationShuttles', function() {
   it('Should play', function() {
     const card = new ImmigrationShuttles();
     const [game, player, player2] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(5);
     for (let i = 0; i < 5; i++) {
       game.addCity(player, game.board.getAvailableSpacesOnLand(player)[0]);

--- a/tests/cards/base/ImportOfAdvancedGHG.spec.ts
+++ b/tests/cards/base/ImportOfAdvancedGHG.spec.ts
@@ -6,8 +6,7 @@ describe('ImportOfAdvancedGHG', function() {
   it('Should play', function() {
     const card = new ImportOfAdvancedGHG();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(2);
   });
 });

--- a/tests/cards/base/ImportedGHG.spec.ts
+++ b/tests/cards/base/ImportedGHG.spec.ts
@@ -6,8 +6,7 @@ describe('ImportedGHG', function() {
   it('Should play', function() {
     const card = new ImportedGHG();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(1);
     expect(player.heat).to.eq(3);
   });

--- a/tests/cards/base/IndenturedWorkers.spec.ts
+++ b/tests/cards/base/IndenturedWorkers.spec.ts
@@ -15,8 +15,7 @@ describe('IndenturedWorkers', function() {
   });
 
   it('play', () => {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(-1);
     expect(card.getCardDiscount(player)).to.eq(0);
   });

--- a/tests/cards/base/IndustrialMicrobes.spec.ts
+++ b/tests/cards/base/IndustrialMicrobes.spec.ts
@@ -6,8 +6,7 @@ describe('IndustrialMicrobes', function() {
   it('Should play', function() {
     const card = new IndustrialMicrobes();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(1);
     expect(player.production.steel).to.eq(1);
   });

--- a/tests/cards/base/InventorsGuild.spec.ts
+++ b/tests/cards/base/InventorsGuild.spec.ts
@@ -17,8 +17,7 @@ describe('InventorsGuild', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', function() {

--- a/tests/cards/base/InvestmentLoan.spec.ts
+++ b/tests/cards/base/InvestmentLoan.spec.ts
@@ -7,8 +7,7 @@ describe('InvestmentLoan', function() {
   it('Should play', function() {
     const card = new InvestmentLoan();
     const [game, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     runAllActions(game);
     expect(player.production.megacredits).to.eq(-1);
     expect(player.megaCredits).to.eq(10);

--- a/tests/cards/base/IoMiningIndustries.spec.ts
+++ b/tests/cards/base/IoMiningIndustries.spec.ts
@@ -6,8 +6,8 @@ describe('IoMiningIndustries', function() {
   it('Should play', function() {
     const card = new IoMiningIndustries();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
+
     expect(player.production.titanium).to.eq(2);
     expect(player.production.megacredits).to.eq(2);
     player.playedCards.push(card);

--- a/tests/cards/base/LagrangeObservatory.spec.ts
+++ b/tests/cards/base/LagrangeObservatory.spec.ts
@@ -6,8 +6,8 @@ describe('LagrangeObservatory', function() {
   it('Should play', function() {
     const card = new LagrangeObservatory();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
+
     expect(player.cardsInHand).has.lengthOf(1);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });

--- a/tests/cards/base/MarsUniversity.spec.ts
+++ b/tests/cards/base/MarsUniversity.spec.ts
@@ -24,9 +24,7 @@ describe('MarsUniversity', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
-
+  cast(card.play(player), undefined);
     expect(card.onCardPlayed(player, new Pets())).is.undefined;
     expect(game.deferredActions).has.lengthOf(0);
 

--- a/tests/cards/base/MediaArchives.spec.ts
+++ b/tests/cards/base/MediaArchives.spec.ts
@@ -11,8 +11,7 @@ describe('MediaArchives', function() {
     const player2 = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, player2], player);
     player.playedCards.push(card, new Virus());
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.megaCredits).to.eq(1);
   });
 });

--- a/tests/cards/base/MediaGroup.spec.ts
+++ b/tests/cards/base/MediaGroup.spec.ts
@@ -3,14 +3,13 @@ import {MediaGroup} from '../../../src/server/cards/base/MediaGroup';
 import {Virus} from '../../../src/server/cards/base/Virus';
 import {testGame} from '../../TestGame';
 import {runAllActions} from '../../TestingUtils';
+import {cast} from '../../TestingUtils';
 
 describe('MediaGroup', function() {
   it('Should play', function() {
     const card = new MediaGroup();
     const [game, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
-
+    cast(card.play(player), undefined);
     card.onCardPlayed(player, new Virus());
 
     runAllActions(game);

--- a/tests/cards/base/MedicalLab.spec.ts
+++ b/tests/cards/base/MedicalLab.spec.ts
@@ -9,8 +9,7 @@ describe('MedicalLab', function() {
     const card = new MedicalLab();
     const player = TestPlayer.BLUE.newPlayer();
     Game.newInstance('gameid', [player], player);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(0);
     player.playedCards.push(new Capital());
     card.play(player);

--- a/tests/cards/base/MicroMills.spec.ts
+++ b/tests/cards/base/MicroMills.spec.ts
@@ -6,8 +6,8 @@ describe('MicroMills', function() {
   it('Should play', function() {
     const card = new MicroMills();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
+
     expect(player.production.heat).to.eq(1);
   });
 });

--- a/tests/cards/base/MicrobiologyPatents.spec.ts
+++ b/tests/cards/base/MicrobiologyPatents.spec.ts
@@ -4,15 +4,14 @@ import {Virus} from '../../../src/server/cards/base/Virus';
 import {MicroMills} from '../../../src/server/cards/base/MicroMills';
 import {testGame} from '../../TestGame';
 import {Units} from '../../../src/common/Units';
+import {cast} from '../../TestingUtils';
 
 describe('MicrobiologyPatents', function() {
   it('Should play', function() {
     const card = new MicrobiologyPatents();
     const [, player] = testGame(1);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
-
+    cast(card.play(player), undefined);
     card.onCardPlayed(player, new Virus());
     expect(player.production.asUnits()).deep.eq(Units.of({megacredits: 1}));
 

--- a/tests/cards/base/Mine.spec.ts
+++ b/tests/cards/base/Mine.spec.ts
@@ -6,8 +6,7 @@ describe('Mine', function() {
   it('Should play', function() {
     const card = new Mine();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.steel).to.eq(1);
   });
 });

--- a/tests/cards/base/MineralDeposit.spec.ts
+++ b/tests/cards/base/MineralDeposit.spec.ts
@@ -6,8 +6,7 @@ describe('MineralDeposit', function() {
   it('Should play', function() {
     const card = new MineralDeposit();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.steel).to.eq(5);
   });
 });

--- a/tests/cards/base/MirandaResort.spec.ts
+++ b/tests/cards/base/MirandaResort.spec.ts
@@ -9,8 +9,7 @@ describe('MirandaResort', function() {
     const [/* skipped */, player] = testGame(2);
 
     player.playedCards.push(new BusinessNetwork());
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(1);
     expect(player.production.megacredits).to.eq(1);
   });

--- a/tests/cards/base/NitrogenRichAsteroid.spec.ts
+++ b/tests/cards/base/NitrogenRichAsteroid.spec.ts
@@ -7,8 +7,7 @@ describe('NitrogenRichAsteroid', function() {
   it('Should play', function() {
     const card = new NitrogenRichAsteroid();
     const [game, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.getTerraformRating()).to.eq(23);
     expect(game.getTemperature()).to.eq(-28);
     expect(player.production.plants).to.eq(1);

--- a/tests/cards/base/OptimalAerobraking.spec.ts
+++ b/tests/cards/base/OptimalAerobraking.spec.ts
@@ -7,8 +7,7 @@ describe('OptimalAerobraking', function() {
   it('Should play', function() {
     const card = new OptimalAerobraking();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.onCardPlayed(player, card)).is.undefined;
     expect(card.onCardPlayed(player, new BigAsteroid())).is.undefined;
     expect(player.megaCredits).to.eq(3);

--- a/tests/cards/base/PermafrostExtraction.spec.ts
+++ b/tests/cards/base/PermafrostExtraction.spec.ts
@@ -24,8 +24,7 @@ describe('PermafrostExtraction', function() {
     setTemperature(game, -8);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     runAllActions(game);
     const selectSpace = cast(player.getWaitingFor(), SelectSpace);
     selectSpace.cb(selectSpace.availableSpaces[0]);

--- a/tests/cards/base/PeroxidePower.spec.ts
+++ b/tests/cards/base/PeroxidePower.spec.ts
@@ -6,8 +6,7 @@ describe('PeroxidePower', function() {
   it('Should play', function() {
     const card = new PeroxidePower();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(-1);
     expect(player.production.energy).to.eq(2);
   });

--- a/tests/cards/base/Pets.spec.ts
+++ b/tests/cards/base/Pets.spec.ts
@@ -11,8 +11,7 @@ describe('Pets', function() {
     const player2 = TestPlayer.RED.newPlayer();
     player.playedCards.push(card);
     const game = Game.newInstance('gameid', [player, player2], player);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     player.addResourceTo(card, 4);
     expect(card.getVictoryPoints(player)).to.eq(2);
     addCity(player);

--- a/tests/cards/base/PhobosSpaceHaven.spec.ts
+++ b/tests/cards/base/PhobosSpaceHaven.spec.ts
@@ -6,8 +6,7 @@ describe('PhobosSpaceHaven', function() {
   it('Should play', function() {
     const card = new PhobosSpaceHaven();
     const [game, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(1);
     expect(card.getVictoryPoints(player)).to.eq(3);
     expect(game.getCitiesCount()).to.eq(1);

--- a/tests/cards/base/ReleaseOfInertGases.spec.ts
+++ b/tests/cards/base/ReleaseOfInertGases.spec.ts
@@ -6,8 +6,7 @@ describe('ReleaseOfInertGases', function() {
   it('Should play', function() {
     const card = new ReleaseOfInertGases();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.getTerraformRating()).to.eq(22);
   });
 });

--- a/tests/cards/base/Research.spec.ts
+++ b/tests/cards/base/Research.spec.ts
@@ -6,8 +6,7 @@ describe('Research', function() {
   it('Should play', function() {
     const card = new Research();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(1);
     expect(player.cardsInHand).has.lengthOf(2);
     expect(player.cardsInHand[0]).not.to.eq(player.cardsInHand[1]);

--- a/tests/cards/base/RoboticWorkforce.spec.ts
+++ b/tests/cards/base/RoboticWorkforce.spec.ts
@@ -159,16 +159,14 @@ describe('RoboticWorkforce', () => {
     player.playedCards.push(new SolarWindPower());
 
     expect(card.canPlay(player)).is.false;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should not work with Mars University (building tag, no production)', () => {
     player.playedCards.push(new MarsUniversity());
 
     expect(card.canPlay(player)).is.false;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should work with Research Network', () => {

--- a/tests/cards/base/RoverConstruction.spec.ts
+++ b/tests/cards/base/RoverConstruction.spec.ts
@@ -10,8 +10,7 @@ describe('RoverConstruction', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
     const game = Game.newInstance('gameid', [player, player2], player);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(1);
     player.playedCards.push(card);
     addCity(player);

--- a/tests/cards/base/Satellites.spec.ts
+++ b/tests/cards/base/Satellites.spec.ts
@@ -6,8 +6,7 @@ describe('Satellites', function() {
   it('Should play', function() {
     const card = new Satellites();
     const [/* skipped */, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(1);
     player.playedCards.push(card);
     card.play(player);

--- a/tests/cards/base/SolarPower.spec.ts
+++ b/tests/cards/base/SolarPower.spec.ts
@@ -6,8 +6,7 @@ describe('SolarPower', function() {
   it('Should play', function() {
     const card = new SolarPower();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(1);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });

--- a/tests/cards/base/SolarWindPower.spec.ts
+++ b/tests/cards/base/SolarWindPower.spec.ts
@@ -1,14 +1,14 @@
 import {expect} from 'chai';
 import {testGame} from '../../TestGame';
 import {SolarWindPower} from '../../../src/server/cards/base/SolarWindPower';
+import {cast} from '../../TestingUtils';
 
 describe('SolarWindPower', function() {
   it('Should play', function() {
     const card = new SolarWindPower();
     const [, player] = testGame(1);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(1);
     expect(player.titanium).to.eq(2);
   });

--- a/tests/cards/base/Soletta.spec.ts
+++ b/tests/cards/base/Soletta.spec.ts
@@ -2,13 +2,13 @@
 import {expect} from 'chai';
 import {Soletta} from '../../../src/server/cards/base/Soletta';
 import {testGame} from '../../TestGame';
+import {cast} from '../../TestingUtils';
 
 describe('Soletta', function() {
   it('Should play', function() {
     const card = new Soletta();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(7);
   });
 });

--- a/tests/cards/base/SpaceStation.spec.ts
+++ b/tests/cards/base/SpaceStation.spec.ts
@@ -7,8 +7,7 @@ describe('SpaceStation', function() {
   it('Should play', function() {
     const card = new SpaceStation();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(1);
     expect(card.getCardDiscount(player, card)).to.eq(2);
     expect(card.getCardDiscount(player, new Bushes())).to.eq(0);

--- a/tests/cards/base/SpecialDesign.spec.ts
+++ b/tests/cards/base/SpecialDesign.spec.ts
@@ -6,8 +6,7 @@ describe('SpecialDesign', function() {
   it('Should play', function() {
     const card = new SpecialDesign();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getRequirementBonus(player)).to.eq(0);
   });
 });

--- a/tests/cards/base/Sponsors.spec.ts
+++ b/tests/cards/base/Sponsors.spec.ts
@@ -6,8 +6,7 @@ describe('Sponsors', function() {
   it('Should play', function() {
     const card = new Sponsors();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);
   });
 });

--- a/tests/cards/base/SubterraneanReservoir.spec.ts
+++ b/tests/cards/base/SubterraneanReservoir.spec.ts
@@ -7,7 +7,6 @@ describe('SubterraneanReservoir', function() {
   it('Should play', function() {
     const card = new SubterraneanReservoir();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 });

--- a/tests/cards/base/TechnologyDemonstration.spec.ts
+++ b/tests/cards/base/TechnologyDemonstration.spec.ts
@@ -6,8 +6,7 @@ describe('TechnologyDemonstration', function() {
   it('Should play', function() {
     const card = new TechnologyDemonstration();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.cardsInHand).has.lengthOf(2);
     expect(player.cardsInHand[0]).not.to.eq(player.cardsInHand[1]);
   });

--- a/tests/cards/base/TerraformingGanymede.spec.ts
+++ b/tests/cards/base/TerraformingGanymede.spec.ts
@@ -5,6 +5,7 @@ import {Phase} from '../../../src/common/Phase';
 import {PoliticalAgendas} from '../../../src/server/turmoil/PoliticalAgendas';
 import {TestPlayer} from '../../TestPlayer';
 import {Reds} from '../../../src/server/turmoil/parties/Reds';
+import {cast} from '../../TestingUtils';
 
 describe('TerraformingGanymede', function() {
   let card: TerraformingGanymede;
@@ -20,8 +21,7 @@ describe('TerraformingGanymede', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(2);
     player.playedCards.push(card);
     expect(player.getTerraformRating()).to.eq(21);

--- a/tests/cards/base/TitaniumMine.spec.ts
+++ b/tests/cards/base/TitaniumMine.spec.ts
@@ -6,8 +6,7 @@ describe('TitaniumMine', function() {
   it('Should play', function() {
     const card = new TitaniumMine();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(1);
   });
 });

--- a/tests/cards/base/TollStation.spec.ts
+++ b/tests/cards/base/TollStation.spec.ts
@@ -9,8 +9,7 @@ describe('TollStation', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const anotherPlayer = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, anotherPlayer], player);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     anotherPlayer.playedCards.push(card);
     expect(player.production.megacredits).to.eq(0);
     card.play(player);

--- a/tests/cards/base/TropicalResort.spec.ts
+++ b/tests/cards/base/TropicalResort.spec.ts
@@ -9,8 +9,7 @@ describe('TropicalResort', function() {
     const card = new TropicalResort();
     const [, player] = testGame(1);
     player.production.add(Resource.HEAT, 2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(0);
     expect(player.production.megacredits).to.eq(3);
     expect(card.getVictoryPoints(player)).to.eq(2);

--- a/tests/cards/colonies/AtmoCollectors.spec.ts
+++ b/tests/cards/colonies/AtmoCollectors.spec.ts
@@ -18,8 +18,7 @@ describe('AtmoCollectors', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', function() {

--- a/tests/cards/colonies/CommunityServices.spec.ts
+++ b/tests/cards/colonies/CommunityServices.spec.ts
@@ -17,8 +17,7 @@ describe('CommunityServices', function() {
     Game.newInstance('gameid', [player], player);
     player.playedCards.push(prelude, researchCoordination);
     player.setCorporationForTest(corpo);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(1);
     expect(player.production.megacredits).to.eq(4);
   });
@@ -31,8 +30,7 @@ describe('CommunityServices', function() {
     Game.newInstance('gameid', [player], player);
     player.playedCards.push(prelude, researchCoordination);
     player.setCorporationForTest(corpo);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(1);
     expect(player.production.megacredits).to.eq(4);
   });

--- a/tests/cards/colonies/Conscription.spec.ts
+++ b/tests/cards/colonies/Conscription.spec.ts
@@ -15,8 +15,7 @@ describe('Conscription', function() {
   });
 
   it('play', () => {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(-1);
     expect(card.getCardDiscount(player)).to.eq(0);
   });

--- a/tests/cards/colonies/CoronaExtractor.spec.ts
+++ b/tests/cards/colonies/CoronaExtractor.spec.ts
@@ -7,8 +7,7 @@ describe('CoronaExtractor', function() {
     const card = new CoronaExtractor();
     const [, player] = testGame(1);
     expect(player.simpleCanPlay(card)).is.not.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(4);
   });
 });

--- a/tests/cards/colonies/CryoSleep.spec.ts
+++ b/tests/cards/colonies/CryoSleep.spec.ts
@@ -10,8 +10,7 @@ describe('CryoSleep', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, player2], player);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     const ceres = new Ceres();
     ceres.trade(player);
     expect(player.steel).to.eq(2);

--- a/tests/cards/colonies/EarthElevator.spec.ts
+++ b/tests/cards/colonies/EarthElevator.spec.ts
@@ -6,8 +6,7 @@ describe('EarthElevator', function() {
   it('Should play', function() {
     const card = new EarthElevator();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(3);
     expect(card.getVictoryPoints(player)).to.eq(4);
   });

--- a/tests/cards/colonies/EcologyResearch.spec.ts
+++ b/tests/cards/colonies/EcologyResearch.spec.ts
@@ -28,8 +28,7 @@ describe('EcologyResearch', function() {
   });
 
   it('Should play without targets', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.plants).to.eq(1);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });

--- a/tests/cards/colonies/HeavyTaxation.spec.ts
+++ b/tests/cards/colonies/HeavyTaxation.spec.ts
@@ -7,8 +7,7 @@ describe('HeavyTaxation', function() {
     const card = new HeavyTaxation();
     const [, player] = testGame(1);
     expect(player.simpleCanPlay(card)).is.not.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);
     expect(player.megaCredits).to.eq(4);
   });

--- a/tests/cards/colonies/ImpactorSwarm.spec.ts
+++ b/tests/cards/colonies/ImpactorSwarm.spec.ts
@@ -18,8 +18,7 @@ describe('ImpactorSwarm', function() {
   });
 
   it('Should play when no other player has plants', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.heat).to.eq(12);
   });
 

--- a/tests/cards/colonies/JupiterFloatingStation.spec.ts
+++ b/tests/cards/colonies/JupiterFloatingStation.spec.ts
@@ -15,8 +15,7 @@ describe('JupiterFloatingStation', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', function() {

--- a/tests/cards/colonies/LunaGovernor.spec.ts
+++ b/tests/cards/colonies/LunaGovernor.spec.ts
@@ -7,8 +7,7 @@ describe('LunaGovernor', function() {
     const card = new LunaGovernor();
     const [, player] = testGame(1);
     expect(player.simpleCanPlay(card)).is.not.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);
   });
 });

--- a/tests/cards/colonies/LunarMining.spec.ts
+++ b/tests/cards/colonies/LunarMining.spec.ts
@@ -13,8 +13,7 @@ describe('LunarMining', function() {
     const player = TestPlayer.BLUE.newPlayer();
     Game.newInstance('gameid', [player], player);
     player.playedCards.push(card2, card3);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(2);
   });
 });

--- a/tests/cards/colonies/MartianZoo.spec.ts
+++ b/tests/cards/colonies/MartianZoo.spec.ts
@@ -23,8 +23,7 @@ describe('MartianZoo', function() {
     player.game.addCity(player, lands[1]);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Can not act', function() {

--- a/tests/cards/colonies/MolecularPrinting.spec.ts
+++ b/tests/cards/colonies/MolecularPrinting.spec.ts
@@ -22,8 +22,7 @@ describe('MolecularPrinting', function() {
     player.game.colonies.push(colonyTile2);
     addCity(player, '03');
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.megaCredits).to.eq(3);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });

--- a/tests/cards/colonies/QuantumCommunications.spec.ts
+++ b/tests/cards/colonies/QuantumCommunications.spec.ts
@@ -20,8 +20,7 @@ describe('QuantumCommunications', function() {
     player.game.colonies.push(colony1);
     player.game.colonies.push(colony2);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });

--- a/tests/cards/colonies/RedSpotObservatory.spec.ts
+++ b/tests/cards/colonies/RedSpotObservatory.spec.ts
@@ -22,8 +22,7 @@ describe('RedSpotObservatory', function() {
     player.playedCards.push(card, card, card);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', function() {

--- a/tests/cards/colonies/RefugeeCamps.spec.ts
+++ b/tests/cards/colonies/RefugeeCamps.spec.ts
@@ -4,6 +4,7 @@ import {Resource} from '../../../src/common/Resource';
 import {TestPlayer} from '../../TestPlayer';
 import {testGame} from '../../TestGame';
 import {runAllActions} from '../../TestingUtils';
+import {cast} from '../../TestingUtils';
 
 describe('RefugeeCamps', function() {
   let card: RefugeeCamps;
@@ -15,9 +16,7 @@ describe('RefugeeCamps', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
-
+    cast(card.play(player), undefined);
     player.addResourceTo(card, 5);
     expect(card.getVictoryPoints(player)).to.eq(5);
   });

--- a/tests/cards/colonies/RimFreighters.spec.ts
+++ b/tests/cards/colonies/RimFreighters.spec.ts
@@ -7,8 +7,7 @@ describe('RimFreighters', function() {
   it('Should play', function() {
     const card = new RimFreighters();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     const ceres = new Ceres();
     ceres.trade(player);
     expect(player.steel).to.eq(2);

--- a/tests/cards/colonies/SkyDocks.spec.ts
+++ b/tests/cards/colonies/SkyDocks.spec.ts
@@ -7,8 +7,7 @@ describe('SkyDocks', function() {
     const card = new SkyDocks();
     const player = TestPlayer.BLUE.newPlayer();
     expect(player.simpleCanPlay(card)).is.not.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.colonies.getFleetSize()).to.eq(2);
     expect(card.getCardDiscount()).to.eq(1);
     expect(card.getVictoryPoints(player)).to.eq(2);

--- a/tests/cards/colonies/SolarReflectors.spec.ts
+++ b/tests/cards/colonies/SolarReflectors.spec.ts
@@ -6,8 +6,7 @@ describe('SolarReflectors', function() {
   it('Should play', function() {
     const card = new SolarReflectors();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(5);
   });
 });

--- a/tests/cards/colonies/SpinoffDepartment.spec.ts
+++ b/tests/cards/colonies/SpinoffDepartment.spec.ts
@@ -11,8 +11,7 @@ describe('SpinoffDepartment', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, player2], player);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);
     card.onCardPlayed(player, card2);
     expect(player.cardsInHand).has.lengthOf(1);

--- a/tests/cards/colonies/TitanShuttles.spec.ts
+++ b/tests/cards/colonies/TitanShuttles.spec.ts
@@ -22,8 +22,7 @@ describe('TitanShuttles', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Can act', function() {

--- a/tests/cards/colonies/TradeEnvoys.spec.ts
+++ b/tests/cards/colonies/TradeEnvoys.spec.ts
@@ -7,8 +7,7 @@ describe('TradeEnvoys', function() {
   it('Should play', function() {
     const card = new TradeEnvoys();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     const ceres = new Ceres();
     ceres.trade(player);
     expect(player.steel).to.eq(3);

--- a/tests/cards/colonies/WarpDrive.spec.ts
+++ b/tests/cards/colonies/WarpDrive.spec.ts
@@ -11,8 +11,7 @@ describe('WarpDrive', function() {
     const player2 = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, player2], player);
     expect(player.simpleCanPlay(card)).is.not.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getCardDiscount(player, new TollStation())).to.eq(4);
   });
 });

--- a/tests/cards/corporation/BeginnerCorporation.spec.ts
+++ b/tests/cards/corporation/BeginnerCorporation.spec.ts
@@ -6,7 +6,6 @@ describe('BeginnerCorporation', function() {
   it('Should play', function() {
     const card = new BeginnerCorporation();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 });

--- a/tests/cards/corporation/CrediCor.spec.ts
+++ b/tests/cards/corporation/CrediCor.spec.ts
@@ -18,8 +18,7 @@ describe('CrediCor', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     player.setCorporationForTest(card);
     card.onStandardProject(player, new AsteroidStandardProject());
     card.onStandardProject(player, new CityStandardProject());

--- a/tests/cards/corporation/EcoLine.spec.ts
+++ b/tests/cards/corporation/EcoLine.spec.ts
@@ -9,8 +9,7 @@ describe('EcoLine', function() {
     const card = new EcoLine();
     const player = TestPlayer.BLUE.newPlayer();
     Game.newInstance('gameid', [player], player);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.plants).to.eq(2);
     expect(player.plants).to.eq(3);
     expect(player.plantsNeededForGreenery).to.eq(7);

--- a/tests/cards/corporation/Helion.spec.ts
+++ b/tests/cards/corporation/Helion.spec.ts
@@ -14,8 +14,7 @@ describe('Helion', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(3);
 
     player.megaCredits = 3;

--- a/tests/cards/corporation/PhoboLog.spec.ts
+++ b/tests/cards/corporation/PhoboLog.spec.ts
@@ -6,8 +6,7 @@ describe('PhoboLog', function() {
   it('Should play', function() {
     const card = new PhoboLog();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.titanium).to.eq(10);
     expect(player.getTitaniumValue()).to.eq(4);
   });

--- a/tests/cards/corporation/Teractor.spec.ts
+++ b/tests/cards/corporation/Teractor.spec.ts
@@ -5,6 +5,7 @@ import {LunaGovernor} from '../../../src/server/cards/colonies/LunaGovernor';
 import {Teractor} from '../../../src/server/cards/corporation/Teractor';
 import {testGame} from '../../TestGame';
 import {TestPlayer} from '../../TestPlayer';
+import {cast} from '../../TestingUtils';
 
 describe('Teractor', function() {
   let card: Teractor;
@@ -14,8 +15,7 @@ describe('Teractor', function() {
     card = new Teractor();
     [/* skipped */, player] = testGame(2);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
 

--- a/tests/cards/corporation/Thorgate.spec.ts
+++ b/tests/cards/corporation/Thorgate.spec.ts
@@ -9,8 +9,7 @@ describe('Thorgate', function() {
   it('Should play', function() {
     const card = new Thorgate();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     player.setCorporationForTest(card);
     expect(player.production.energy).to.eq(1);
     expect(card.getCardDiscount(player, new EnergySaving())).to.eq(3);

--- a/tests/cards/pathfinders/PowerPlant.spec.ts
+++ b/tests/cards/pathfinders/PowerPlant.spec.ts
@@ -16,8 +16,7 @@ describe('PowerPlant', function() {
   });
 
   it('play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.asUnits()).deep.eq(Units.of({heat: 2, energy: 1}));
   });
 });

--- a/tests/cards/prelude/AlliedBanks.spec.ts
+++ b/tests/cards/prelude/AlliedBanks.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {testGame} from '../../TestGame';
 import {AlliedBanks} from '../../../src/server/cards/prelude/AlliedBanks';
+import {cast} from '../../TestingUtils';
 
 describe('AlliedBanks', function() {
   it('Should play', function() {
     const card = new AlliedBanks();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.megaCredits).to.eq(3);
     expect(player.production.megacredits).to.eq(4);
   });

--- a/tests/cards/prelude/Biofuels.spec.ts
+++ b/tests/cards/prelude/Biofuels.spec.ts
@@ -6,8 +6,7 @@ describe('Biofuels', function() {
   it('Should play', function() {
     const card = new Biofuels();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(1);
     expect(player.production.plants).to.eq(1);
     expect(player.plants).to.eq(2);

--- a/tests/cards/prelude/DomeFarming.spec.ts
+++ b/tests/cards/prelude/DomeFarming.spec.ts
@@ -6,8 +6,7 @@ describe('DomeFarming', function() {
   it('Should play', function() {
     const card = new DomeFarming();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.plants).to.eq(1);
     expect(player.production.megacredits).to.eq(2);
   });

--- a/tests/cards/prelude/Donation.spec.ts
+++ b/tests/cards/prelude/Donation.spec.ts
@@ -6,8 +6,7 @@ describe('Donation', function() {
   it('Should play', function() {
     const card = new Donation();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.megaCredits).to.eq(21);
   });
 });

--- a/tests/cards/prelude/GreatAquifer.spec.ts
+++ b/tests/cards/prelude/GreatAquifer.spec.ts
@@ -1,12 +1,11 @@
-import {expect} from 'chai';
 import {GreatAquifer} from '../../../src/server/cards/prelude/GreatAquifer';
 import {testGame} from '../../TestGame';
+import {cast} from '../../TestingUtils';
 
 describe('GreatAquifer', function() {
   it('Should play', function() {
     const card = new GreatAquifer();
     const [, player] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 });

--- a/tests/cards/prelude/HousePrinting.spec.ts
+++ b/tests/cards/prelude/HousePrinting.spec.ts
@@ -6,8 +6,7 @@ describe('HousePrinting', function() {
   it('Should play', function() {
     const card = new HousePrinting();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(1);
     expect(player.production.steel).to.eq(1);
   });

--- a/tests/cards/prelude/MartianIndustries.spec.ts
+++ b/tests/cards/prelude/MartianIndustries.spec.ts
@@ -6,8 +6,7 @@ describe('MartianIndustries', function() {
   it('Should play', function() {
     const card = new MartianIndustries();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(1);
     expect(player.production.steel).to.eq(1);
     expect(player.megaCredits).to.eq(6);

--- a/tests/cards/prelude/MetalRichAsteroid.spec.ts
+++ b/tests/cards/prelude/MetalRichAsteroid.spec.ts
@@ -6,8 +6,7 @@ describe('Metal-RichAsteroid', function() {
   it('Should play', function() {
     const card = new MetalRichAsteroid();
     const [game, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.titanium).to.eq(4);
     expect(player.steel).to.eq(4);
     expect(game.getTemperature()).to.equal(-28);

--- a/tests/cards/prelude/MetalsCompany.spec.ts
+++ b/tests/cards/prelude/MetalsCompany.spec.ts
@@ -6,8 +6,7 @@ describe('MetalsCompany', function() {
   it('Should play', function() {
     const card = new MetalsCompany();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(1);
     expect(player.production.steel).to.eq(1);
     expect(player.production.megacredits).to.eq(1);

--- a/tests/cards/prelude/MiningOperations.spec.ts
+++ b/tests/cards/prelude/MiningOperations.spec.ts
@@ -6,8 +6,7 @@ describe('MiningOperations', function() {
   it('Should play', function() {
     const card = new MiningOperations();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.steel).to.eq(2);
     expect(player.steel).to.eq(4);
   });

--- a/tests/cards/prelude/Mohole.spec.ts
+++ b/tests/cards/prelude/Mohole.spec.ts
@@ -6,8 +6,7 @@ describe('Mohole', function() {
   it('Should play', function() {
     const card = new Mohole();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(3);
     expect(player.heat).to.eq(3);
   });

--- a/tests/cards/prelude/MoholeExcavation.spec.ts
+++ b/tests/cards/prelude/MoholeExcavation.spec.ts
@@ -6,8 +6,7 @@ describe('MoholeExcavation', function() {
   it('Should play', function() {
     const card = new MoholeExcavation();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(2);
     expect(player.heat).to.eq(2);
     expect(player.production.steel).to.eq(1);

--- a/tests/cards/prelude/OrbitalConstructionYard.spec.ts
+++ b/tests/cards/prelude/OrbitalConstructionYard.spec.ts
@@ -7,8 +7,7 @@ describe('OrbitalConstructionYard', function() {
   it('Should play', function() {
     const card = new OrbitalConstructionYard();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(1);
     expect(player.titanium).to.eq(4);
   });

--- a/tests/cards/prelude/PowerGeneration.spec.ts
+++ b/tests/cards/prelude/PowerGeneration.spec.ts
@@ -6,8 +6,7 @@ describe('PowerGeneration', function() {
   it('Should play', function() {
     const card = new PowerGeneration();
     const [, player] = testGame(1);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(3);
   });
 });

--- a/tests/cards/prelude/Psychrophiles.spec.ts
+++ b/tests/cards/prelude/Psychrophiles.spec.ts
@@ -27,8 +27,7 @@ describe('Psychrophiles', () => {
 
   it('Should play', () => {
     expect(player.simpleCanPlay(card)).is.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Can act', () => {

--- a/tests/cards/prelude/ResearchCoordination.spec.ts
+++ b/tests/cards/prelude/ResearchCoordination.spec.ts
@@ -2,14 +2,13 @@ import {expect} from 'chai';
 import {testGame} from '../../TestGame';
 import {ResearchCoordination} from '../../../src/server/cards/prelude/ResearchCoordination';
 import {Tag} from '../../../src/common/cards/Tag';
+import {cast} from '../../TestingUtils';
 
 describe('ResearchCoordination', function() {
   it('Should play', function() {
     const [, player] = testGame(1);
     const card = new ResearchCoordination();
-    const action = card.play(player);
-    expect(action).is.undefined;
-
+    cast(card.play(player), undefined);
     expect(player.tags.count(Tag.WILD)).eq(0);
     expect(player.tags.count(Tag.BUILDING)).eq(0);
 

--- a/tests/cards/prelude/ResearchNetwork.spec.ts
+++ b/tests/cards/prelude/ResearchNetwork.spec.ts
@@ -3,6 +3,7 @@ import {testGame} from '../../TestGame';
 import {ResearchNetwork} from '../../../src/server/cards/prelude/ResearchNetwork';
 import {Tag} from '../../../src/common/cards/Tag';
 import {Units} from '../../../src/common/Units';
+import {cast} from '../../TestingUtils';
 
 describe('ResearchNetwork', function() {
   it('Should play', function() {
@@ -12,9 +13,7 @@ describe('ResearchNetwork', function() {
     expect(player.cardsInHand).has.length(0);
     expect(player.production.asUnits()).deep.eq(Units.of({}));
 
-    const action = card.play(player);
-    expect(action).is.undefined;
-
+    cast(card.play(player), undefined);
     expect(player.cardsInHand).has.length(3);
     expect(player.production.asUnits()).deep.eq(Units.of({megacredits: 1}));
 

--- a/tests/cards/prelude/SmeltingPlant.spec.ts
+++ b/tests/cards/prelude/SmeltingPlant.spec.ts
@@ -6,8 +6,7 @@ describe('SmeltingPlant', function() {
   it('Should play', function() {
     const [game, player] = testGame(1);
     const card = new SmeltingPlant();
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.steel).to.eq(5);
     expect(game.getOxygenLevel()).to.eq(2);
   });

--- a/tests/cards/prelude/SocietySupport.spec.ts
+++ b/tests/cards/prelude/SocietySupport.spec.ts
@@ -6,8 +6,7 @@ describe('SocietySupport', function() {
   it('Should play', function() {
     const [, player] = testGame(1);
     const card = new SocietySupport();
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(-1);
     expect(player.production.plants).to.eq(1);
     expect(player.production.energy).to.eq(1);

--- a/tests/cards/prelude/Supplier.spec.ts
+++ b/tests/cards/prelude/Supplier.spec.ts
@@ -6,8 +6,7 @@ describe('Supplier', function() {
   it('Should play', function() {
     const [, player] = testGame(1);
     const card = new Supplier();
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(2);
     expect(player.steel).to.eq(4);
   });

--- a/tests/cards/prelude/SupplyDrop.spec.ts
+++ b/tests/cards/prelude/SupplyDrop.spec.ts
@@ -6,8 +6,7 @@ describe('SupplyDrop', function() {
   it('Should play', function() {
     const [, player] = testGame(1);
     const card = new SupplyDrop();
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.steel).to.eq(8);
     expect(player.titanium).to.eq(3);
     expect(player.plants).to.eq(3);

--- a/tests/cards/prelude/Vitor.spec.ts
+++ b/tests/cards/prelude/Vitor.spec.ts
@@ -21,8 +21,7 @@ describe('Vitor', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.megaCredits).to.eq(0);
   });
 

--- a/tests/cards/promo/16Psyche.spec.ts
+++ b/tests/cards/promo/16Psyche.spec.ts
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import {testGame} from '../../TestGame';
 import {Psyche} from '../../../src/server/cards/promo/16Psyche';
+import {cast} from '../../TestingUtils';
 
 describe('16 Psyche', function() {
   it('Should play', function() {
@@ -10,9 +11,7 @@ describe('16 Psyche', function() {
     // Sanity
     expect(player.getVictoryPoints().victoryPoints).to.eq(0);
     player.playedCards.push(card);
-    const action = card.play(player);
-    expect(action).is.undefined;
-
+    cast(card.play(player), undefined);
     // Effect
     expect(player.production.titanium).to.eq(2);
     expect(player.titanium).to.eq(3);

--- a/tests/cards/promo/BioPrintingFacility.spec.ts
+++ b/tests/cards/promo/BioPrintingFacility.spec.ts
@@ -18,8 +18,7 @@ describe('BioPrintingFacility', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
 

--- a/tests/cards/venusNext/AerialMappers.spec.ts
+++ b/tests/cards/venusNext/AerialMappers.spec.ts
@@ -21,8 +21,7 @@ describe('AerialMappers', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act - multiple targets', function() {

--- a/tests/cards/venusNext/Aphrodite.spec.ts
+++ b/tests/cards/venusNext/Aphrodite.spec.ts
@@ -6,8 +6,7 @@ describe('Aphrodite', function() {
   it('Should play', function() {
     const card = new Aphrodite();
     const [game, player, player2] = testGame(2);
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.plants).to.eq(1);
     player.setCorporationForTest(card);
     expect(player.megaCredits).to.eq(0);

--- a/tests/cards/venusNext/AtalantaPlanitiaLab.spec.ts
+++ b/tests/cards/venusNext/AtalantaPlanitiaLab.spec.ts
@@ -7,8 +7,7 @@ describe('AtalantaPlanitiaLab', function() {
     const card = new AtalantaPlanitiaLab();
     const [, player] = testGame(2);
     expect(player.simpleCanPlay(card)).is.not.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.cardsInHand).has.lengthOf(2);
     expect(card.getVictoryPoints(player)).to.eq(2);
   });

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -85,9 +85,7 @@ describe('Atmoscoop', function() {
     player.playedCards.push(dirigibles);
     setTemperature(game, constants.MAX_TEMPERATURE);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
-
+  cast(card.play(player), undefined);
     runAllActions(game);
     expect(player.popWaitingFor()).is.undefined;
 

--- a/tests/cards/venusNext/DawnCity.spec.ts
+++ b/tests/cards/venusNext/DawnCity.spec.ts
@@ -10,8 +10,7 @@ describe('DawnCity', function() {
     player.production.add(Resource.ENERGY, 1);
     expect(player.simpleCanPlay(card)).is.not.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(0);
     expect(player.production.titanium).to.eq(1);
   });

--- a/tests/cards/venusNext/DeuteriumExport.spec.ts
+++ b/tests/cards/venusNext/DeuteriumExport.spec.ts
@@ -15,8 +15,7 @@ describe('DeuteriumExport', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', function() {

--- a/tests/cards/venusNext/Dirigibles.spec.ts
+++ b/tests/cards/venusNext/Dirigibles.spec.ts
@@ -17,8 +17,7 @@ describe('Dirigibles', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act - single target', function() {

--- a/tests/cards/venusNext/ExtractorBalloons.spec.ts
+++ b/tests/cards/venusNext/ExtractorBalloons.spec.ts
@@ -17,8 +17,7 @@ describe('ExtractorBalloons', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     runAllActions(game);
     expect(card.resourceCount).to.eq(3);
   });

--- a/tests/cards/venusNext/Extremophiles.spec.ts
+++ b/tests/cards/venusNext/Extremophiles.spec.ts
@@ -25,8 +25,7 @@ describe('Extremophiles', function() {
   it('Should play', function() {
     player.playedCards.push(new Research());
     expect(player.simpleCanPlay(card)).is.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', function() {

--- a/tests/cards/venusNext/FloatingHabs.spec.ts
+++ b/tests/cards/venusNext/FloatingHabs.spec.ts
@@ -25,8 +25,7 @@ describe('FloatingHabs', function() {
   it('Should play', function() {
     player.playedCards.push(new Research());
     expect(player.simpleCanPlay(card)).is.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act - single target', function() {

--- a/tests/cards/venusNext/ForcedPrecipitation.spec.ts
+++ b/tests/cards/venusNext/ForcedPrecipitation.spec.ts
@@ -17,8 +17,7 @@ describe('ForcedPrecipitation', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act - both actions available', function() {

--- a/tests/cards/venusNext/GHGImportFromVenus.spec.ts
+++ b/tests/cards/venusNext/GHGImportFromVenus.spec.ts
@@ -7,8 +7,7 @@ describe('GHGImportFromVenus', function() {
     const card = new GHGImportFromVenus();
     const [game, player] = testGame(2);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.heat).to.eq(3);
     expect(game.getVenusScaleLevel()).to.eq(2);
   });

--- a/tests/cards/venusNext/GiantSolarShade.spec.ts
+++ b/tests/cards/venusNext/GiantSolarShade.spec.ts
@@ -21,8 +21,7 @@ describe('GiantSolarShade', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(game.getVenusScaleLevel()).to.eq(6);
     expect(player.getTerraformRating()).to.eq(23);
   });

--- a/tests/cards/venusNext/HydrogenToVenus.spec.ts
+++ b/tests/cards/venusNext/HydrogenToVenus.spec.ts
@@ -62,8 +62,7 @@ describe('HydrogenToVenus', function() {
   });
 
   it('Should play with no venus cards', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     runAllActions(game);
     expect(player.popWaitingFor()).is.undefined;
     expect(game.getVenusScaleLevel()).to.eq(2);

--- a/tests/cards/venusNext/IoSulphurResearch.spec.ts
+++ b/tests/cards/venusNext/IoSulphurResearch.spec.ts
@@ -7,8 +7,7 @@ describe('IoSulphurResearch', function() {
     const card = new IoSulphurResearch();
     const [, player] = testGame(2);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.cardsInHand).has.lengthOf(1);
   });
 });

--- a/tests/cards/venusNext/IshtarMining.spec.ts
+++ b/tests/cards/venusNext/IshtarMining.spec.ts
@@ -11,8 +11,7 @@ describe('IshtarMining', function() {
     game.increaseVenusScaleLevel(player, 3);
     expect(game.getVenusScaleLevel()).to.eq(12);
     expect(player.simpleCanPlay(card)).is.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(1);
   });
 });

--- a/tests/cards/venusNext/JetStreamMicroscrappers.spec.ts
+++ b/tests/cards/venusNext/JetStreamMicroscrappers.spec.ts
@@ -17,8 +17,7 @@ describe('JetStreamMicroscrappers', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', function() {

--- a/tests/cards/venusNext/LocalShading.spec.ts
+++ b/tests/cards/venusNext/LocalShading.spec.ts
@@ -15,8 +15,7 @@ describe('LocalShading', function() {
   });
 
   it('Should play', function() {
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act', function() {

--- a/tests/cards/venusNext/LunaMetropolis.spec.ts
+++ b/tests/cards/venusNext/LunaMetropolis.spec.ts
@@ -7,8 +7,7 @@ describe('LunaMetropolis', function() {
     const card = new LunaMetropolis();
     const [, player] = testGame(2, {venusNextExtension: true});
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(1);
   });
 });

--- a/tests/cards/venusNext/LuxuryFoods.spec.ts
+++ b/tests/cards/venusNext/LuxuryFoods.spec.ts
@@ -29,8 +29,7 @@ describe('LuxuryFoods', function() {
     player.tagsForTest = {venus: 1, jovian: 1, earth: 1};
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(2);
   });
 });

--- a/tests/cards/venusNext/MaxwellBase.spec.ts
+++ b/tests/cards/venusNext/MaxwellBase.spec.ts
@@ -41,8 +41,7 @@ describe('MaxwellBase', function() {
     setVenusScaleLevel(game, 12);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     runAllActions(game);
     expect(player.production.energy).to.eq(0);
   });

--- a/tests/cards/venusNext/MiningQuota.spec.ts
+++ b/tests/cards/venusNext/MiningQuota.spec.ts
@@ -31,8 +31,7 @@ describe('MiningQuota', function() {
     player.tagsForTest = {venus: 1, jovian: 1, earth: 1};
     expect(card.canPlay(player)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.steel).to.eq(2);
   });
 });

--- a/tests/cards/venusNext/NeutralizerFactory.spec.ts
+++ b/tests/cards/venusNext/NeutralizerFactory.spec.ts
@@ -7,8 +7,7 @@ describe('NeutralizerFactory', function() {
     const card = new NeutralizerFactory();
     const [game, player] = testGame(2);
     expect(player.simpleCanPlay(card)).is.not.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(game.getVenusScaleLevel()).to.eq(2);
   });
 });

--- a/tests/cards/venusNext/Omnicourt.spec.ts
+++ b/tests/cards/venusNext/Omnicourt.spec.ts
@@ -29,8 +29,7 @@ describe('Omnicourt', function() {
     player.tagsForTest = {venus: 1, jovian: 1, earth: 1};
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.getTerraformRating()).to.eq(22);
   });
 });

--- a/tests/cards/venusNext/OrbitalReflectors.spec.ts
+++ b/tests/cards/venusNext/OrbitalReflectors.spec.ts
@@ -7,8 +7,7 @@ describe('OrbitalReflectors', function() {
     const card = new OrbitalReflectors();
     const [game, player] = testGame(2);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(game.getVenusScaleLevel()).to.eq(4);
     expect(player.production.heat).to.eq(2);
   });

--- a/tests/cards/venusNext/RotatorImpacts.spec.ts
+++ b/tests/cards/venusNext/RotatorImpacts.spec.ts
@@ -30,8 +30,7 @@ describe('RotatorImpacts', () => {
 
   it('Should play', () => {
     expect(player.simpleCanPlay(card)).is.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Works with MSI corporation', () => {

--- a/tests/cards/venusNext/SisterPlanetSupport.spec.ts
+++ b/tests/cards/venusNext/SisterPlanetSupport.spec.ts
@@ -17,8 +17,7 @@ describe('SisterPlanetSupport', function() {
     player.tagsForTest = {venus: 1, earth: 1};
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(3);
   });
 });

--- a/tests/cards/venusNext/Solarnet.spec.ts
+++ b/tests/cards/venusNext/Solarnet.spec.ts
@@ -29,8 +29,7 @@ describe('Solarnet', function() {
     player.tagsForTest = {venus: 1, jovian: 1, earth: 1};
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.cardsInHand).has.lengthOf(2);
   });
 });

--- a/tests/cards/venusNext/TerraformingContract.spec.ts
+++ b/tests/cards/venusNext/TerraformingContract.spec.ts
@@ -12,8 +12,7 @@ describe('TerraformingContract', function() {
     player.setTerraformRating(25);
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(4);
   });
 });

--- a/tests/cards/venusNext/Thermophiles.spec.ts
+++ b/tests/cards/venusNext/Thermophiles.spec.ts
@@ -26,8 +26,7 @@ describe('Thermophiles', function() {
   it('Should play', function() {
     setVenusScaleLevel(game, 6);
     expect(player.simpleCanPlay(card)).is.true;
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Should act - multiple targets', function() {

--- a/tests/cards/venusNext/VenusGovernor.spec.ts
+++ b/tests/cards/venusNext/VenusGovernor.spec.ts
@@ -12,8 +12,7 @@ describe('VenusGovernor', function() {
     player.tagsForTest = {venus: 2};
     expect(player.simpleCanPlay(card)).is.true;
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);
   });
 });

--- a/tests/cards/venusNext/VenusWaystation.spec.ts
+++ b/tests/cards/venusNext/VenusWaystation.spec.ts
@@ -3,6 +3,7 @@ import {LocalShading} from '../../../src/server/cards/venusNext/LocalShading';
 import {VenusGovernor} from '../../../src/server/cards/venusNext/VenusGovernor';
 import {VenusWaystation} from '../../../src/server/cards/venusNext/VenusWaystation';
 import {testGame} from '../../TestGame';
+import {cast} from '../../TestingUtils';
 
 describe('VenusWaystation', function() {
   it('Should play', function() {
@@ -11,8 +12,7 @@ describe('VenusWaystation', function() {
     const card3 = new VenusGovernor();
     const [, player] = testGame(2);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(1);
     expect(card.getCardDiscount(player, card2)).to.eq(2);
     expect(card.getCardDiscount(player, card3)).to.eq(4);

--- a/tests/cards/venusNext/VenusianInsects.spec.ts
+++ b/tests/cards/venusNext/VenusianInsects.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {runAllActions, setVenusScaleLevel} from '../../TestingUtils';
+import {cast, runAllActions, setVenusScaleLevel} from '../../TestingUtils';
 import {VenusianInsects} from '../../../src/server/cards/venusNext/VenusianInsects';
 import {Game} from '../../../src/server/Game';
 import {TestPlayer} from '../../TestPlayer';
@@ -30,8 +30,7 @@ describe('VenusianInsects', () => {
     expect(player.simpleCanPlay(card)).is.true;
     player.playedCards.push(card);
 
-    const action = card.play(player);
-    expect(action).is.undefined;
+    cast(card.play(player), undefined);
   });
 
   it('Gives victory points', () => {


### PR DESCRIPTION
This provides a better error message, because the returned type is most probably a class.