### PR TITLE
Update reserveUnits when a new card is selected (#5840)

### DIFF
--- a/src/client/components/SelectProjectCardToPlay.vue
+++ b/src/client/components/SelectProjectCardToPlay.vue
@@ -264,7 +264,7 @@ export default Vue.extend({
       this.card = this.getCard();
       this.cost = this.card.calculatedCost || 0;
       this.tags = this.getCardTags();
-
+      this.reserveUnits = this.card.reserveUnits ?? Units.EMPTY;
       this.megaCredits = (this as unknown as typeof PaymentWidgetMixin.methods).getMegaCreditsMax();
 
       this.setDefaultValues();


### PR DESCRIPTION
Currently, the reserveUnits variable for playing a card is fixed to the first card selected and when the selected card is changed, the variable is not updated. This may allow a user to try and play a card they cannot afford or be unable to play a card that they can afford. The bug is fixed by updating reserveUnits as the selected card changes.