### PR TITLE
Fix placement log to correspond to coordinates shown on map

### DIFF
--- a/src/server/LogHelper.ts
+++ b/src/server/LogHelper.ts
@@ -39,12 +39,8 @@ export class LogHelper {
     // Skip solo play random tiles
     if (player.name === 'neutral') return;
 
-    const offset = Math.abs(space.y - 4);
-    const row = space.y + 1;
-    const position = space.x - offset + 1;
-
     player.game.log('${0} ${1} ${2} on row ${3} position ${4}', (b) =>
-      b.player(player).string(action).string(description).number(row).number(position));
+      b.player(player).string(action).string(description).number(space.y).number(space.x));
   }
 
   static logColonyTrackIncrease(player: IPlayer, colony: IColony, steps: number = 1) {

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -522,6 +522,26 @@ describe('Game', () => {
     expect(game.getCardPlayerOrThrow(card.name)).to.eq(player);
   });
 
+  it('Logs position correctly for placement', () => {
+    const player = TestPlayer.BLUE.newPlayer();
+    const game = Game.newInstance('game-logz', [player], player);
+    const spaceId: SpaceId = game.board.getAvailableSpacesForOcean(player)[0].id;
+    addOcean(player, spaceId);
+    
+    const space = game.board.getSpace(spaceId)
+    const oceanPlacementLog = game.gameLog
+      .find((l) => l.message === '${0} ${1} ${2} on row ${3} position ${4}')
+    expect(oceanPlacementLog).to.not.be.undefined;
+    const spaceInLog = {
+      y: parseInt(oceanPlacementLog!.data[3].value),
+      x: parseInt(oceanPlacementLog!.data[4].value)
+    }
+    expect(spaceInLog.x).to.not.be.NaN;
+    expect(spaceInLog.y).to.not.be.NaN;
+    expect(spaceInLog.x).to.eq(space.x)
+    expect(spaceInLog.y).to.eq(space.y)
+  });
+
   it('Does not assign player to ocean after placement', () => {
     const player = TestPlayer.BLUE.newPlayer();
     const game = Game.newInstance('game-oceanz', [player], player);


### PR DESCRIPTION
We played [this game](https://terraforming-mars.herokuapp.com/the-end?id=p80534bc4bdc9) and noticed that when placing tiles, the logs did not match the coordinates we saw on the game board. The coordinates displayed on the game board correctly correspond the `Space` instances (where row is `y` and position from the left on that row is `x`), so I changed the log message to be consistent. I removed the `offset` logic (which I can't rationalize) and I removed the `+ 1` because although humans like 1-based indexing, the coordinates displayed on the map use 0-based indexing. I could be convinced that both the coordinates displayed on the map and the log should use 1-based indexing, though.