### PR TITLE
Replace canAffordCard, and put `cost` in CanAffordOptions.

### DIFF
--- a/src/server/IPlayer.ts
+++ b/src/server/IPlayer.ts
@@ -34,6 +34,7 @@ import {Stock} from './player/Stock';
 export type ResourceSource = IPlayer | GlobalEventName | ICard;
 
 export interface CanAffordOptions extends Partial<Payment.Options> {
+  cost: number,
   reserveUnits?: Units,
   tr?: TRSource | DynamicTRSource,
 }
@@ -228,14 +229,16 @@ export interface IPlayer {
   pass(): void;
   takeActionForFinalGreenery(): void;
   getPlayableCards(): Array<PlayableCard>;
-  // TODO(kberg): After migration, see if this can become private again.
-  // Or perhaps moved into card?
-  canAffordCard(card: IProjectCard): boolean;
   canPlay(card: IProjectCard): boolean | YesAnd;
   simpleCanPlay(card: IProjectCard): boolean | YesAnd;
   canSpend(payment: Payment, reserveUnits?: Units): boolean;
   payingAmount(payment: Payment, options?: Partial<Payment.Options>): number;
-  canAfford(cost: number, options?: CanAffordOptions): boolean;
+  /**
+   * Returns a summary of how much a player would have to spend to play a card,
+   * any associated costs, and ways the player can pay.
+   */
+  affordOptionsForCard(card: IProjectCard): CanAffordOptions;
+  canAfford(options: number | CanAffordOptions): boolean;
   getStandardProjectOption(): SelectCard<IStandardProjectCard>;
   takeAction(saveBeforeTakingAction?: boolean): void;
   runInitialAction(corp: ICorporationCard): void;

--- a/src/server/boards/HellasBoard.ts
+++ b/src/server/boards/HellasBoard.ts
@@ -54,7 +54,7 @@ export class HellasBoard extends MarsBoard {
   }
 
   private filterHellas(player: IPlayer, spaces: ReadonlyArray<Space>) {
-    return player.canAfford(HELLAS_BONUS_OCEAN_COST, {tr: {oceans: 1}}) ? spaces : spaces.filter((space) => space.id !== SpaceName.HELLAS_OCEAN_TILE);
+    return player.canAfford({cost: HELLAS_BONUS_OCEAN_COST, tr: {oceans: 1}}) ? spaces : spaces.filter((space) => space.id !== SpaceName.HELLAS_OCEAN_TILE);
   }
 
   public override getSpaces(spaceType: SpaceType, player: IPlayer): ReadonlyArray<Space> {

--- a/src/server/boards/VastitasBorealisBoard.ts
+++ b/src/server/boards/VastitasBorealisBoard.ts
@@ -55,7 +55,7 @@ export class VastitasBorealisBoard extends MarsBoard {
   }
 
   private filterVastitasBorealis(player: IPlayer, spaces: ReadonlyArray<Space>) {
-    return player.canAfford(VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST, {tr: {temperature: 1}}) ? spaces : spaces.filter((space) => space.id !== SpaceName.VASTITAS_BOREALIS_NORTH_POLE);
+    return player.canAfford({cost: VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST, tr: {temperature: 1}}) ? spaces : spaces.filter((space) => space.id !== SpaceName.VASTITAS_BOREALIS_NORTH_POLE);
   }
 
   public override getSpaces(spaceType: SpaceType, player: IPlayer): ReadonlyArray<Space> {

--- a/src/server/cards/StandardProjectCard.ts
+++ b/src/server/cards/StandardProjectCard.ts
@@ -45,8 +45,9 @@ export abstract class StandardProjectCard extends Card implements IActionCard, I
   public canAct(player: IPlayer): boolean {
     const canPayWith = this.canPayWith(player);
     return player.canAfford(
-      this.cost - this.discount(player), {
+      {
         ...canPayWith,
+        cost: this.cost - this.discount(player),
         tr: this.tr,
         auroraiData: true,
         reserveUnits: MoonExpansion.adjustedReserveCosts(player, this),

--- a/src/server/cards/base/AquiferPumping.ts
+++ b/src/server/cards/base/AquiferPumping.ts
@@ -28,7 +28,7 @@ export class AquiferPumping extends Card implements IActionCard, IProjectCard {
   }
 
   public canAct(player: IPlayer): boolean {
-    return player.canAfford(OCEAN_COST, {steel: true, tr: {oceans: 1}});
+    return player.canAfford({cost: OCEAN_COST, steel: true, tr: {oceans: 1}});
   }
   public action(player: IPlayer) {
     player.game.defer(new SelectPaymentDeferred(player, 8, {canUseSteel: true, title: 'Select how to pay for action', afterPay: () => {

--- a/src/server/cards/base/CaretakerContract.ts
+++ b/src/server/cards/base/CaretakerContract.ts
@@ -27,7 +27,8 @@ export class CaretakerContract extends Card implements IActionCard, IProjectCard
     });
   }
   public canAct(player: IPlayer): boolean {
-    return player.availableHeat() >= 8 && player.canAfford(0, {
+    return player.availableHeat() >= 8 && player.canAfford({
+      cost: 0,
       reserveUnits: Units.of({heat: 8}),
       tr: {tr: 1},
     });

--- a/src/server/cards/base/WaterImportFromEuropa.ts
+++ b/src/server/cards/base/WaterImportFromEuropa.ts
@@ -32,7 +32,7 @@ export class WaterImportFromEuropa extends Card implements IActionCard, IProject
     });
   }
   public canAct(player: IPlayer): boolean {
-    return player.canAfford(ACTION_COST, {titanium: true, tr: {oceans: 1}});
+    return player.canAfford({cost: ACTION_COST, titanium: true, tr: {oceans: 1}});
   }
   public action(player: IPlayer) {
     player.game.defer(new SelectPaymentDeferred(player, ACTION_COST, {canUseTitanium: true, title: 'Select how to pay for action', afterPay: () => {

--- a/src/server/cards/base/standardActions/ConvertHeat.ts
+++ b/src/server/cards/base/standardActions/ConvertHeat.ts
@@ -31,7 +31,8 @@ export class ConvertHeat extends StandardActionCard {
       return false;
     }
 
-    return player.canAfford(0, {
+    return player.canAfford({
+      cost: 0,
       tr: {temperature: 1},
       reserveUnits: Units.of({heat: 8}),
     });

--- a/src/server/cards/base/standardActions/ConvertPlants.ts
+++ b/src/server/cards/base/standardActions/ConvertPlants.ts
@@ -35,7 +35,8 @@ export class ConvertPlants extends StandardActionCard {
       // player can afford the reds tax when increasing the oxygen level.
       return true;
     }
-    return player.canAfford(0, {
+    return player.canAfford({
+      cost: 0,
       tr: {oxygen: 1},
       reserveUnits: Units.of({plants: player.plantsNeededForGreenery}),
     });

--- a/src/server/cards/colonies/BuildColonyStandardProject.ts
+++ b/src/server/cards/colonies/BuildColonyStandardProject.ts
@@ -33,7 +33,7 @@ export class BuildColonyStandardProject extends StandardProjectCard {
       colony.isActive);
 
     // TODO(kberg): Europa sometimes costs additional 3.
-    const canAffordVenus = player.canAfford(this.cost, {tr: {venus: 1}});
+    const canAffordVenus = player.canAfford({cost: this.cost, tr: {venus: 1}});
     if (!canAffordVenus) {
       openColonies = openColonies.filter((colony) => colony.name !== ColonyName.VENUS);
     }

--- a/src/server/cards/colonies/TitanAirScrapping.ts
+++ b/src/server/cards/colonies/TitanAirScrapping.ts
@@ -41,7 +41,7 @@ export class TitanAirScrapping extends Card implements IProjectCard {
       return true;
     }
     if (this.resourceCount >= 2) {
-      return player.canAfford(0, {tr: {tr: 1}});
+      return player.canAfford({cost: 0, tr: {tr: 1}});
     }
     return false;
   }
@@ -52,7 +52,7 @@ export class TitanAirScrapping extends Card implements IProjectCard {
     const addResource = new SelectOption('Spend 1 titanium to add 2 floaters on this card', 'Spend titanium', () => this.addResource(player));
     const spendResource = new SelectOption('Remove 2 floaters on this card to increase your TR 1 step', 'Remove floaters', () => this.spendResource(player));
 
-    if (this.resourceCount >= 2 && player.canAfford(0, {tr: {tr: 1}})) {
+    if (this.resourceCount >= 2 && player.canAfford({cost: 0, tr: {tr: 1}})) {
       opts.push(spendResource);
     }
 

--- a/src/server/cards/community/Playwrights.ts
+++ b/src/server/cards/community/Playwrights.ts
@@ -117,7 +117,8 @@ export class Playwrights extends Card implements ICorporationCard {
         playedEvents.push(...p.playedCards.filter((card) => {
           return card.type === CardType.EVENT &&
           // Can player.canPlay(card) replace this?
-          player.canAfford(player.getCardCost(card), {
+          player.canAfford({
+            cost: player.getCardCost(card),
             reserveUnits: MoonExpansion.adjustedReserveCosts(player, card),
           }) && player.simpleCanPlay(card);
         }));

--- a/src/server/cards/corporation/UnitedNationsMarsInitiative.ts
+++ b/src/server/cards/corporation/UnitedNationsMarsInitiative.ts
@@ -33,7 +33,7 @@ export class UnitedNationsMarsInitiative extends Card implements IActionCard, IC
     });
   }
   public canAct(player: IPlayer): boolean {
-    return player.hasIncreasedTerraformRatingThisGeneration && player.canAfford(ACTION_COST, {tr: {tr: 1}});
+    return player.hasIncreasedTerraformRatingThisGeneration && player.canAfford({cost: ACTION_COST, tr: {tr: 1}});
   }
   public action(player: IPlayer) {
     player.payMegacreditsDeferred(

--- a/src/server/cards/moon/DarksideIncubationPlant.ts
+++ b/src/server/cards/moon/DarksideIncubationPlant.ts
@@ -50,7 +50,7 @@ export class DarksideIncubationPlant extends Card implements IActionCard, IProje
   }
 
   private canRaiseHabitatRate(player: IPlayer) {
-    return this.resourceCount >= 2 && player.canAfford(0, {tr: {moonHabitat: 1}});
+    return this.resourceCount >= 2 && player.canAfford({cost: 0, tr: {moonHabitat: 1}});
   }
 
   public action(player: IPlayer) {

--- a/src/server/cards/moon/LunaEcumenopolis.ts
+++ b/src/server/cards/moon/LunaEcumenopolis.ts
@@ -55,7 +55,7 @@ export class LunaEcumenopolis extends Card {
     const moonData = MoonExpansion.moonData(player.game);
     const expectedHabitatRate = Math.min(moonData.habitatRate + 2, 8);
     const expectedTRBump = Math.floor(expectedHabitatRate / 2);
-    return player.canAfford(0, {tr: {moonHabitat: 2, tr: expectedTRBump}});
+    return player.canAfford({cost: 0, tr: {moonHabitat: 2, tr: expectedTRBump}});
   }
 
   public override bespokeCanPlay(player: IPlayer) {

--- a/src/server/cards/moon/TheArchaicFoundationInstitute.ts
+++ b/src/server/cards/moon/TheArchaicFoundationInstitute.ts
@@ -55,7 +55,7 @@ export class TheArchaicFoundationInstitute extends Card implements ICorporationC
   }
 
   public canAct(player: IPlayer) {
-    return (this.resourceCount >= 3 && player.canAfford(0, {tr: {tr: 1}}));
+    return (this.resourceCount >= 3 && player.canAfford({cost: 0, tr: {tr: 1}}));
   }
 
   // The only reason Archaic Foundation Institute has an action is if Reds is
@@ -65,7 +65,7 @@ export class TheArchaicFoundationInstitute extends Card implements ICorporationC
   public action(player: IPlayer) {
     // How should this interact in a Merger with UNMO?
     let tr = Math.floor(this.resourceCount / 3);
-    while (!player.canAfford(0, {tr: {tr: tr}})) {
+    while (!player.canAfford({cost: 0, tr: {tr: tr}})) {
       tr--;
     }
     player.removeResourceFrom(this, tr * 3);

--- a/src/server/cards/pathfinders/Ambient.ts
+++ b/src/server/cards/pathfinders/Ambient.ts
@@ -60,7 +60,7 @@ export class Ambient extends Card implements ICorporationCard {
   }
 
   public canAct(player: IPlayer) {
-    return player.heat >= 8 && player.game.getTemperature() === MAX_TEMPERATURE && player.canAfford(0, {tr: {tr: 1}});
+    return player.heat >= 8 && player.game.getTemperature() === MAX_TEMPERATURE && player.canAfford({cost: 0, tr: {tr: 1}});
   }
 
   public action(player: IPlayer) {

--- a/src/server/cards/pathfinders/RobinHaulings.ts
+++ b/src/server/cards/pathfinders/RobinHaulings.ts
@@ -50,11 +50,11 @@ export class RobinHaulings extends Card implements ICorporationCard {
   }
 
   private canRaiseVenus(player: IPlayer) {
-    return player.game.getVenusScaleLevel() < MAX_VENUS_SCALE && player.canAfford(0, {tr: {venus: 1}});
+    return player.game.getVenusScaleLevel() < MAX_VENUS_SCALE && player.canAfford({cost: 0, tr: {venus: 1}});
   }
 
   private canRaiseOxygen(player: IPlayer) {
-    return player.game.getOxygenLevel() < MAX_OXYGEN_LEVEL && player.canAfford(0, {tr: {oxygen: 1}});
+    return player.game.getOxygenLevel() < MAX_OXYGEN_LEVEL && player.canAfford({cost: 0, tr: {oxygen: 1}});
   }
 
   public canAct(player: IPlayer) {

--- a/src/server/cards/pathfinders/SecretLabs.ts
+++ b/src/server/cards/pathfinders/SecretLabs.ts
@@ -40,8 +40,8 @@ export class SecretLabs extends Card implements IProjectCard {
     });
   }
 
-  private canAfford(player: IPlayer, tr: TRSource, megacrdits: number = this.cost): boolean {
-    return player.canAfford(megacrdits, {steel: true, titanium: true, tr});
+  private canAfford(player: IPlayer, tr: TRSource, megacredits: number = this.cost): boolean {
+    return player.canAfford({cost: megacredits, steel: true, titanium: true, tr});
   }
 
   public override bespokeCanPlay(player: IPlayer) {

--- a/src/server/cards/pathfinders/ValuableGases.ts
+++ b/src/server/cards/pathfinders/ValuableGases.ts
@@ -44,7 +44,7 @@ export class ValuableGases extends PreludeCard implements IProjectCard {
     const playableCards = player.cardsInHand.filter((card) => {
       return card.resourceType === CardResource.FLOATER &&
         card.type === CardType.ACTIVE &&
-        player.canAffordCard(card);
+        player.canAfford(player.affordOptionsForCard(card));
     }).map((card) => {
       return {
         card: card,

--- a/src/server/cards/promo/CometAiming.ts
+++ b/src/server/cards/promo/CometAiming.ts
@@ -40,7 +40,7 @@ export class CometAiming extends Card implements IActionCard, IProjectCard {
   }
 
   private canPlaceOcean(player: IPlayer) {
-    return player.game.canAddOcean() && player.canAfford(0, {tr: {oceans: 1}});
+    return player.game.canAddOcean() && player.canAfford({cost: 0, tr: {oceans: 1}});
   }
 
   public canAct(player: IPlayer): boolean {

--- a/src/server/cards/promo/DirectedImpactors.ts
+++ b/src/server/cards/promo/DirectedImpactors.ts
@@ -40,12 +40,12 @@ export class DirectedImpactors extends Card implements IActionCard, IProjectCard
 
   public canAct(player: IPlayer): boolean {
     const cardHasResources = this.resourceCount > 0;
-    const canPayForAsteroid = player.canAfford(6, {titanium: true});
+    const canPayForAsteroid = player.canAfford({cost: 6, titanium: true});
 
     if (player.game.getTemperature() === MAX_TEMPERATURE && cardHasResources) return true;
     if (canPayForAsteroid) return true;
 
-    return player.canAfford(0, {tr: {temperature: 1}}) && cardHasResources;
+    return player.canAfford({cost: 0, tr: {temperature: 1}}) && cardHasResources;
   }
 
   public action(player: IPlayer) {
@@ -57,14 +57,14 @@ export class DirectedImpactors extends Card implements IActionCard, IProjectCard
     const temperatureIsMaxed = player.game.getTemperature() === MAX_TEMPERATURE;
 
     if (this.resourceCount > 0) {
-      if (!temperatureIsMaxed && player.canAfford(0, {tr: {temperature: 1}})) {
+      if (!temperatureIsMaxed && player.canAfford({cost: 0, tr: {temperature: 1}})) {
         opts.push(spendResource);
       }
     } else {
       return this.addResource(player, asteroidCards);
     }
 
-    if (player.canAfford(6, {titanium: true})) {
+    if (player.canAfford({cost: 6, titanium: true})) {
       opts.push(addResource);
     } else {
       return this.spendResource(player);

--- a/src/server/cards/promo/PharmacyUnion.ts
+++ b/src/server/cards/promo/PharmacyUnion.ts
@@ -80,7 +80,7 @@ export class PharmacyUnion extends Card implements ICorporationCard {
     // Edge case, let player pick order of resolution (see https://github.com/bafolts/terraforming-mars/issues/1286)
     if (isPharmacyUnion && hasScienceTag && hasMicrobesTag && this.resourceCount === 0) {
       // TODO (Lynesth): Modify this when https://github.com/bafolts/terraforming-mars/issues/1670 is fixed
-      if (player.canAfford(0, {tr: {tr: 3}})) {
+      if (player.canAfford({cost: 0, tr: {tr: 3}})) {
         game.defer(new SimpleDeferredAction(
           player,
           () => {
@@ -119,7 +119,7 @@ export class PharmacyUnion extends Card implements ICorporationCard {
             if (this.isDisabled) return undefined;
 
             if (this.resourceCount > 0) {
-              if (player.canAfford(0, {tr: {tr: 1}}) === false) {
+              if (player.canAfford({cost: 0, tr: {tr: 1}}) === false) {
                 // TODO (Lynesth): Remove this when #1670 is fixed
                 game.log('${0} cannot remove a disease from ${1} to gain 1 TR because of unaffordable Reds policy cost', (b) => b.player(player).card(this));
               } else {
@@ -130,7 +130,7 @@ export class PharmacyUnion extends Card implements ICorporationCard {
               return undefined;
             }
 
-            if (player.canAfford(0, {tr: {tr: 3}}) === false) {
+            if (player.canAfford({cost: 0, tr: {tr: 3}}) === false) {
               // TODO (Lynesth): Remove this when #1670 is fixed
               game.log('${0} cannot turn ${1} face down to gain 3 TR because of unaffordable Reds policy cost', (b) => b.player(player).card(this));
               return undefined;

--- a/src/server/cards/venusNext/Atmoscoop.ts
+++ b/src/server/cards/venusNext/Atmoscoop.ts
@@ -48,7 +48,7 @@ export class Atmoscoop extends Card implements IProjectCard {
 
     if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       // TODO(kberg): this is not correct, because the titanium can't be used for the reds cost.
-      return player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST * stepsRaised, {titanium: true});
+      return player.canAfford({cost: this.cost + constants.REDS_RULING_POLICY_COST * stepsRaised, titanium: true});
     }
 
     return true;

--- a/src/server/cards/venusNext/ExtractorBalloons.ts
+++ b/src/server/cards/venusNext/ExtractorBalloons.ts
@@ -62,7 +62,7 @@ export class ExtractorBalloons extends Card implements IActionCard {
   }
   public action(player: IPlayer) {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    const canAffordReds = player.canAfford(0, {tr: {venus: 1}});
+    const canAffordReds = player.canAfford({cost: 0, tr: {venus: 1}});
     if (this.resourceCount < 2 || venusMaxed || !canAffordReds) {
       player.addResourceTo(this, {log: true});
       return undefined;

--- a/src/server/cards/venusNext/ForcedPrecipitation.ts
+++ b/src/server/cards/venusNext/ForcedPrecipitation.ts
@@ -40,7 +40,7 @@ export class ForcedPrecipitation extends Card implements IActionCard {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
     const canSpendResource = this.resourceCount > 1 && !venusMaxed;
 
-    return player.canAfford(2) || (canSpendResource && player.canAfford(0, {tr: {venus: 1}}));
+    return player.canAfford(2) || (canSpendResource && player.canAfford({cost: 0, tr: {venus: 1}}));
   }
 
   public action(player: IPlayer) {
@@ -48,7 +48,7 @@ export class ForcedPrecipitation extends Card implements IActionCard {
 
     const addResource = new SelectOption('Pay 2 M€ to add 1 floater to this card', 'Pay', () => this.addResource(player));
     const spendResource = new SelectOption('Remove 2 floaters to raise Venus 1 step', 'Remove floaters', () => this.spendResource(player));
-    if (this.resourceCount > 1 && player.game.getVenusScaleLevel() < MAX_VENUS_SCALE && player.canAfford(0, {tr: {venus: 1}})) {
+    if (this.resourceCount > 1 && player.game.getVenusScaleLevel() < MAX_VENUS_SCALE && player.canAfford({cost: 0, tr: {venus: 1}})) {
       opts.push(spendResource);
     } else {
       return this.addResource(player);

--- a/src/server/cards/venusNext/JetStreamMicroscrappers.ts
+++ b/src/server/cards/venusNext/JetStreamMicroscrappers.ts
@@ -40,7 +40,7 @@ export class JetStreamMicroscrappers extends Card implements IActionCard {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
     const canSpendResource = this.resourceCount > 1 && !venusMaxed;
 
-    return player.titanium > 0 || (canSpendResource && player.canAfford(0, {tr: {venus: 1}}));
+    return player.titanium > 0 || (canSpendResource && player.canAfford({cost: 0, tr: {venus: 1}}));
   }
 
   public action(player: IPlayer) {

--- a/src/server/cards/venusNext/RotatorImpacts.ts
+++ b/src/server/cards/venusNext/RotatorImpacts.ts
@@ -42,7 +42,7 @@ export class RotatorImpacts extends Card implements IActionCard {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
     const canSpendResource = this.resourceCount > 0 && !venusMaxed;
 
-    return player.canAfford(6, {titanium: true}) || (canSpendResource && player.canAfford(0, {tr: {venus: 1}}));
+    return player.canAfford({cost: 6, titanium: true}) || (canSpendResource && player.canAfford({cost: 0, tr: {venus: 1}}));
   }
 
   public action(player: IPlayer) {
@@ -57,7 +57,7 @@ export class RotatorImpacts extends Card implements IActionCard {
       return this.addResource(player);
     }
 
-    if (player.canAfford(6, {titanium: true})) {
+    if (player.canAfford({cost: 6, titanium: true})) {
       opts.push(addResource);
     } else {
       return this.spendResource(player);

--- a/tests/cards/moon/LunaTradeFederation.spec.ts
+++ b/tests/cards/moon/LunaTradeFederation.spec.ts
@@ -76,11 +76,11 @@ describe('LunaTradeFederation', () => {
     player.megaCredits = 6;
     player.titanium = 1;
 
-    expect(player.canAffordCard(card)).is.false;
+    expect(player.canAfford(player.affordOptionsForCard(card))).is.false;
 
     player.megaCredits = 7;
     player.titanium = 1;
-    expect(player.canAffordCard(card)).is.true;
+    expect(player.canAfford(player.affordOptionsForCard(card))).is.true;
   });
 
   it('can use titanium to pay for non-space project cards at a discount', () => {
@@ -93,12 +93,12 @@ describe('LunaTradeFederation', () => {
     player.titanium = 1;
 
     expect(player.spendableMegacredits()).eq(9);
-    expect(player.canAffordCard(card)).is.false;
+    expect(player.canAfford(player.affordOptionsForCard(card))).is.false;
 
     player.megaCredits = 8;
     player.titanium = 1;
     expect(player.spendableMegacredits()).eq(10);
-    expect(player.canAffordCard(card)).is.true;
+    expect(player.canAfford(player.affordOptionsForCard(card))).is.true;
 
     player.megaCredits = 8;
     player.titanium = 3;


### PR DESCRIPTION
This is going to be significant when the next PR comes in that vastly simplifies Ares cost prediction.