### PR TITLE
Update PostgreSQL.ts

### DIFF
--- a/src/server/database/PostgreSQL.ts
+++ b/src/server/database/PostgreSQL.ts
@@ -193,7 +193,7 @@ export class PostgreSQL implements IDatabase {
     const maxSaveId = await this.getMaxSaveId(gameId);
     return this.client.query('DELETE FROM games WHERE game_id = $1 AND save_id < $2 AND save_id > 0', [gameId, maxSaveId])
       .then(() => {
-        return this.client.query('DELETE FROM completed_games where game_id = $1', [gameId]);
+        return this.client.query('DELETE FROM completed_game where game_id = $1', [gameId]);
       });
   }
 


### PR DESCRIPTION
Fixing a typo in the table relation name when attempting to archive old games

Example error message from `docker logs`:
```
[2023-09-02 16:31:50 GMT+0000] Preloading IDs.
[2023-09-02 16:31:50 GMT+0000] Starting REDACTED, built at Fri, 25 Aug 2023 08:57:59 -0400
[2023-09-02 16:31:50 GMT+0000] Starting server on port 8080
[2023-09-02 16:31:50 GMT+0000] Server is ready.
[2023-09-02 16:31:50 GMT+0000] Preloaded 5 IDs.
[2023-09-02 16:31:50 GMT+0000] Sweeper sleeping for 300000ms
[2023-09-02 16:31:50 GMT+0000] 0 games to be purged.
[2023-09-02 16:31:50 GMT+0000] Purged 0 rows from games
[2023-09-02 16:31:50 GMT+0000] Purged 0 rows from participants
[2023-09-02 16:31:50 GMT+0000] 1 completed games to be compressed.
[2023-09-02 16:31:50 GMT+0000] UNCAUGHT EXCEPTION error: relation "completed_games" does not exist
    at Parser.parseErrorMessage (/usr/src/app/node_modules/pg-protocol/dist/parser.js:287:98)
    at Parser.handlePacket (/usr/src/app/node_modules/pg-protocol/dist/parser.js:126:29)
    at Parser.parse (/usr/src/app/node_modules/pg-protocol/dist/parser.js:39:38)
    at TLSSocket.<anonymous> (/usr/src/app/node_modules/pg-protocol/dist/index.js:11:42)
    at TLSSocket.emit (node:events:390:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at TLSSocket.Readable.push (node:internal/streams/readable:228:10)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:199:23) {
  length: 114,
  severity: 'ERROR',
  code: '42P01',
  detail: undefined,
  hint: undefined,
  position: '13',
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'parse_relation.c',
  line: '1373',
  routine: 'parserOpenTable'
```