### PR TITLE
abstract away http

### DIFF
--- a/src/server/Request.ts
+++ b/src/server/Request.ts
@@ -1,6 +1,10 @@
 
 import type * as http from 'http';
 
+/**
+ * Limits Request to what we use. This is used to ease in unit testing
+ * and to allow for javascript without 'http' to run the server code.
+ */
 export type Request = Pick<http.IncomingMessage, 'headers' | 'method' | 'url'> & {
   once: (type: 'end', func: () => void) => void;
   on: (type: 'data', func: (dat: Buffer) => void) => void;

--- a/src/server/Request.ts
+++ b/src/server/Request.ts
@@ -1,0 +1,15 @@
+
+import type * as http from 'http';
+
+export type Request = Pick<http.IncomingMessage, 'headers' | 'method' | 'url'> & {
+  once: (type: 'end', func: () => void) => void;
+  on: (type: 'data', func: (dat: Buffer) => void) => void;
+  socket: {
+    address(): string | {
+      address: string;
+      family: string;
+      port: number;
+    };
+  }
+};
+

--- a/src/server/Response.ts
+++ b/src/server/Response.ts
@@ -1,6 +1,10 @@
 
 import type * as http from 'http';
 
+/**
+ * Limits Response to what we use. This is used to ease in unit testing
+ * and to allow for javascript without 'http' to run the server code.
+ */
 export type Response = Pick<http.ServerResponse, 'setHeader' | 'write' | 'writeHead'> & {
   end: (data?: string | Buffer) => void;
 };

--- a/src/server/Response.ts
+++ b/src/server/Response.ts
@@ -1,0 +1,6 @@
+
+import type * as http from 'http';
+
+export type Response = Pick<http.ServerResponse, 'setHeader' | 'write' | 'writeHead'> & {
+  end: (data?: string | Buffer) => void;
+};

--- a/src/server/routes/ApiCloneableGame.ts
+++ b/src/server/routes/ApiCloneableGame.ts
@@ -1,8 +1,9 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {Database} from '../database/Database';
 import {isGameId} from '../../common/Types';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiCloneableGame extends Handler {
   public static readonly INSTANCE = new ApiCloneableGame();
@@ -10,7 +11,7 @@ export class ApiCloneableGame extends Handler {
     super();
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const gameId = ctx.url.searchParams.get('id');
     if (gameId === null) {
       ctx.route.badRequest(req, res, 'missing id parameter');

--- a/src/server/routes/ApiGame.ts
+++ b/src/server/routes/ApiGame.ts
@@ -1,9 +1,10 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {Server} from '../models/ServerModel';
 import {isGameId} from '../../common/Types';
 import {IGame} from '../IGame';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiGame extends Handler {
   public static readonly INSTANCE = new ApiGame();
@@ -11,7 +12,7 @@ export class ApiGame extends Handler {
     super();
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const gameId = ctx.url.searchParams.get('id');
     if (!gameId) {
       ctx.route.badRequest(req, res, 'missing id parameter');

--- a/src/server/routes/ApiGameHistory.ts
+++ b/src/server/routes/ApiGameHistory.ts
@@ -1,9 +1,9 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {Database} from '../database/Database';
 import {isGameId} from '../../common/Types';
-
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiGameHistory extends Handler {
   public static readonly INSTANCE = new ApiGameHistory();
@@ -11,7 +11,7 @@ export class ApiGameHistory extends Handler {
     super({validateServerId: true});
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const gameId = ctx.url.searchParams.get('id');
     if (!gameId) {
       ctx.route.badRequest(req, res, 'missing id parameter');

--- a/src/server/routes/ApiGameLogs.ts
+++ b/src/server/routes/ApiGameLogs.ts
@@ -1,8 +1,9 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {GameLogs} from './GameLogs';
 import {isPlayerId, isSpectatorId} from '../../common/Types';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiGameLogs extends Handler {
   public static readonly INSTANCE = new ApiGameLogs();
@@ -10,7 +11,7 @@ export class ApiGameLogs extends Handler {
     super();
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const searchParams = ctx.url.searchParams;
     const id = searchParams.get('id');
     if (!id) {

--- a/src/server/routes/ApiGames.ts
+++ b/src/server/routes/ApiGames.ts
@@ -1,6 +1,7 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiGames extends Handler {
   public static readonly INSTANCE = new ApiGames();
@@ -8,7 +9,7 @@ export class ApiGames extends Handler {
     super({validateServerId: true});
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const list = await ctx.gameLoader.getIds();
     if (list === undefined) {
       ctx.route.notFound(req, res, 'could not load game list');

--- a/src/server/routes/ApiIPs.ts
+++ b/src/server/routes/ApiIPs.ts
@@ -1,6 +1,7 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiIPs extends Handler {
   public static readonly INSTANCE = new ApiIPs();
@@ -8,7 +9,7 @@ export class ApiIPs extends Handler {
     super({validateServerId: true});
   }
 
-  public override get(_req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override get(_req: Request, res: Response, ctx: Context): Promise<void> {
     ctx.route.writeJson(res, ctx.ipTracker.toJSON(), 2);
     return Promise.resolve();
   }

--- a/src/server/routes/ApiMetrics.ts
+++ b/src/server/routes/ApiMetrics.ts
@@ -1,8 +1,8 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import * as prometheus from 'prom-client';
-
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiMetrics extends Handler {
   public static readonly INSTANCE = new ApiMetrics();
@@ -10,7 +10,7 @@ export class ApiMetrics extends Handler {
     super({validateServerId: true});
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     try {
       const register = prometheus.register;
       res.setHeader('Content-Type', register.contentType);

--- a/src/server/routes/ApiPlayer.ts
+++ b/src/server/routes/ApiPlayer.ts
@@ -1,8 +1,9 @@
 import {isPlayerId} from '../../common/Types';
-import * as http from 'http';
 import {Server} from '../models/ServerModel';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiPlayer extends Handler {
   public static readonly INSTANCE = new ApiPlayer();
@@ -11,7 +12,7 @@ export class ApiPlayer extends Handler {
     super();
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const playerId = ctx.url.searchParams.get('id');
     if (playerId === null) {
       ctx.route.badRequest(req, res, 'missing id parameter');

--- a/src/server/routes/ApiSpectator.ts
+++ b/src/server/routes/ApiSpectator.ts
@@ -1,9 +1,10 @@
-import * as http from 'http';
 import {Server} from '../models/ServerModel';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {IGame} from '../IGame';
 import {isSpectatorId} from '../../common/Types';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiSpectator extends Handler {
   public static readonly INSTANCE = new ApiSpectator();
@@ -12,7 +13,7 @@ export class ApiSpectator extends Handler {
     super();
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const id = ctx.url.searchParams.get('id');
     if (!id) {
       ctx.route.badRequest(req, res, 'invalid id');

--- a/src/server/routes/ApiStats.ts
+++ b/src/server/routes/ApiStats.ts
@@ -1,8 +1,8 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {Database} from '../database/Database';
-
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiStats extends Handler {
   public static readonly INSTANCE = new ApiStats();
@@ -10,7 +10,7 @@ export class ApiStats extends Handler {
     super({validateStatsId: true});
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     try {
       const stats = await Database.getInstance().stats();
       ctx.route.writeJson(res, stats, 2);

--- a/src/server/routes/ApiWaitingFor.ts
+++ b/src/server/routes/ApiWaitingFor.ts
@@ -1,4 +1,3 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {Phase} from '../../common/Phase';
@@ -6,6 +5,8 @@ import {IPlayer} from '../IPlayer';
 import {WaitingForModel} from '../../common/models/WaitingForModel';
 import {IGame} from '../IGame';
 import {isPlayerId, isSpectatorId} from '../../common/Types';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ApiWaitingFor extends Handler {
   public static readonly INSTANCE = new ApiWaitingFor();
@@ -34,7 +35,7 @@ export class ApiWaitingFor extends Handler {
     return {result: 'WAIT'};
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const id = String(ctx.url.searchParams.get('id'));
     const gameAge = Number(ctx.url.searchParams.get('gameAge'));
     const undoCount = Number(ctx.url.searchParams.get('undoCount'));

--- a/src/server/routes/Game.ts
+++ b/src/server/routes/Game.ts
@@ -1,4 +1,3 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {Database} from '../database/Database';
@@ -15,6 +14,8 @@ import {NewGameConfig} from '../../common/game/NewGameConfig';
 import {GameId, PlayerId, SpectatorId} from '../../common/Types';
 import {generateRandomId} from '../utils/server-ids';
 import {IGame} from '../IGame';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 // Oh, this could be called Game, but that would introduce all kinds of issues.
 
@@ -40,14 +41,14 @@ export class GameHandler extends Handler {
     return [board];
   }
 
-  public override get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override get(req: Request, res: Response, ctx: Context): Promise<void> {
     req.url = '/assets/index.html';
     return ServeAsset.INSTANCE.get(req, res, ctx);
   }
 
   // TODO(kberg): much of this code can be moved outside of handler, and that
   // would be better.
-  public override put(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override put(req: Request, res: Response, ctx: Context): Promise<void> {
     return new Promise((resolve) => {
       let body = '';
       req.on('data', function(data) {

--- a/src/server/routes/GamesOverview.ts
+++ b/src/server/routes/GamesOverview.ts
@@ -1,8 +1,9 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {ServeApp} from './ServeApp';
 import {ServeAsset} from './ServeAsset';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 // A strange way to get a games overview, by serving index.html with a validated server id.
 // Is this hackable?
@@ -11,7 +12,7 @@ export class GamesOverview extends Handler {
   private constructor() {
     super({validateServerId: true});
   }
-  public override get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override get(req: Request, res: Response, ctx: Context): Promise<void> {
     req.url = '/assets/index.html';
     return ServeAsset.INSTANCE.get(req, res, ctx);
   }

--- a/src/server/routes/Handler.ts
+++ b/src/server/routes/Handler.ts
@@ -1,5 +1,6 @@
-import * as http from 'http';
 import {IHandler, Context} from './IHandler';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export type Options = {
   validateServerId: boolean;
@@ -25,7 +26,7 @@ export abstract class Handler implements IHandler {
     return serverId !== null && serverId === ctx.ids.statsId;
   }
 
-  processRequest(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  processRequest(req: Request, res: Response, ctx: Context): Promise<void> {
     if (this.options.validateServerId && !this.isServerIdValid(ctx)) {
       ctx.route.notAuthorized(req, res);
       return Promise.resolve();
@@ -56,15 +57,15 @@ export abstract class Handler implements IHandler {
     }
   }
 
-  public get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public get(req: Request, res: Response, ctx: Context): Promise<void> {
     ctx.route.notFound(req, res);
     return Promise.resolve();
   }
-  public put(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public put(req: Request, res: Response, ctx: Context): Promise<void> {
     ctx.route.notFound(req, res);
     return Promise.resolve();
   }
-  public post(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public post(req: Request, res: Response, ctx: Context): Promise<void> {
     ctx.route.notFound(req, res);
     return Promise.resolve();
   }

--- a/src/server/routes/IHandler.ts
+++ b/src/server/routes/IHandler.ts
@@ -1,10 +1,11 @@
-import * as http from 'http';
 import {IGameLoader} from '../database/IGameLoader';
 import {Route} from './Route';
 import {IPTracker} from '../server/IPTracker';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export interface IHandler {
-  processRequest(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void>;
+  processRequest(req: Request, res: Response, ctx: Context): Promise<void>;
 }
 
 export type Context = {

--- a/src/server/routes/Load.ts
+++ b/src/server/routes/Load.ts
@@ -1,7 +1,8 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {ServeApp} from './ServeApp';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class Load extends Handler {
   public static readonly INSTANCE = new Load();
@@ -9,7 +10,7 @@ export class Load extends Handler {
     super({validateServerId: true});
   }
 
-  public override get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override get(req: Request, res: Response, ctx: Context): Promise<void> {
     req.url = '/assets/index.html';
     return ServeApp.INSTANCE.get(req, res, ctx);
   }

--- a/src/server/routes/LoadGame.ts
+++ b/src/server/routes/LoadGame.ts
@@ -1,10 +1,11 @@
-import * as http from 'http';
 import {Database} from '../database/Database';
 import {GameLoader} from '../database/GameLoader';
 import {Server} from '../models/ServerModel';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {LoadGameFormModel} from '../../common/models/LoadGameFormModel';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class LoadGame extends Handler {
   public static readonly INSTANCE = new LoadGame();
@@ -12,7 +13,7 @@ export class LoadGame extends Handler {
     super();
   }
 
-  public override put(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override put(req: Request, res: Response, ctx: Context): Promise<void> {
     return new Promise((resolve) => {
       let body = '';
       req.on('data', function(data) {

--- a/src/server/routes/PlayerInput.ts
+++ b/src/server/routes/PlayerInput.ts
@@ -1,4 +1,3 @@
-import * as http from 'http';
 import {IPlayer} from '../IPlayer';
 import {Server} from '../models/ServerModel';
 import {Handler} from './Handler';
@@ -7,6 +6,8 @@ import {OrOptions} from '../inputs/OrOptions';
 import {UndoActionOption} from '../inputs/UndoActionOption';
 import {InputResponse} from '../../common/inputs/InputResponse';
 import {isPlayerId} from '../../common/Types';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class PlayerInput extends Handler {
   public static readonly INSTANCE = new PlayerInput();
@@ -14,7 +15,7 @@ export class PlayerInput extends Handler {
     super();
   }
 
-  public override async post(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async post(req: Request, res: Response, ctx: Context): Promise<void> {
     const playerId = ctx.url.searchParams.get('id');
     if (playerId === null) {
       ctx.route.badRequest(req, res, 'missing id parameter');
@@ -56,7 +57,7 @@ export class PlayerInput extends Handler {
     return false;
   }
 
-  private async performUndo(_req: http.IncomingMessage, res: http.ServerResponse, ctx: Context, player: IPlayer): Promise<void> {
+  private async performUndo(_req: Request, res: Response, ctx: Context, player: IPlayer): Promise<void> {
     /**
      * The `lastSaveId` property is incremented during every `takeAction`.
      * The first save being decremented is the increment during `takeAction` call
@@ -77,7 +78,7 @@ export class PlayerInput extends Handler {
     ctx.route.writeJson(res, Server.getPlayerModel(player));
   }
 
-  private processInput(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context, player: IPlayer): Promise<void> {
+  private processInput(req: Request, res: Response, ctx: Context, player: IPlayer): Promise<void> {
     return new Promise((resolve) => {
       let body = '';
       req.on('data', (data) => {

--- a/src/server/routes/Reset.ts
+++ b/src/server/routes/Reset.ts
@@ -1,9 +1,10 @@
-import * as http from 'http';
 import {Server} from '../models/ServerModel';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {IPlayer} from '../IPlayer';
 import {isPlayerId} from '../../common/Types';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 /**
  * Reloads the game from the last action.
@@ -21,7 +22,7 @@ export class Reset extends Handler {
     super();
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     const playerId = ctx.url.searchParams.get('id');
     if (playerId === null) {
       ctx.route.badRequest(req, res, 'missing id parameter');

--- a/src/server/routes/Route.ts
+++ b/src/server/routes/Route.ts
@@ -1,9 +1,10 @@
-import * as http from 'http';
 import {escape} from 'html-escaper';
 import {Context} from './IHandler';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class Route {
-  public badRequest(req: http.IncomingMessage, res: http.ServerResponse, err?: string): void {
+  public badRequest(req: Request, res: Response, err?: string): void {
     console.warn('bad request', req.url);
     res.writeHead(400);
     res.write('Bad request');
@@ -13,7 +14,7 @@ export class Route {
     }
     res.end();
   }
-  public notFound(req: http.IncomingMessage, res: http.ServerResponse, err?: string): void {
+  public notFound(req: Request, res: Response, err?: string): void {
     if (!process.argv.includes('hide-not-found-warnings')) {
       console.warn('Not found', req.method, req.url);
     }
@@ -25,13 +26,13 @@ export class Route {
     }
     res.end();
   }
-  public notModified(res: http.ServerResponse): void {
+  public notModified(res: Response): void {
     res.writeHead(304);
     res.end();
   }
   public internalServerError(
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
+    req: Request,
+    res: Response,
     err: unknown): void {
     console.warn('internal server error: ', req.url, err);
     res.writeHead(500);
@@ -48,21 +49,21 @@ export class Route {
 
     res.end();
   }
-  public notAuthorized(req: http.IncomingMessage, res: http.ServerResponse): void {
+  public notAuthorized(req: Request, res: Response): void {
     console.warn('Not authorized', req.method, req.url);
     res.writeHead(403);
     res.write('Not authorized');
     res.end();
   }
 
-  public downgradeRedirect(_req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): void {
+  public downgradeRedirect(_req: Request, res: Response, ctx: Context): void {
     const url = new URL(ctx.url); // defensive copty
     url.searchParams.set('serverId', ctx.ids.statsId);
     res.writeHead(301, {Location: url.pathname + url.search});
     res.end();
   }
 
-  public writeJson(res: http.ServerResponse, json: any, space?: string | number | undefined) {
+  public writeJson(res: Response, json: any, space?: string | number | undefined) {
     res.setHeader('Content-Type', 'application/json');
     const s = JSON.stringify(json, undefined, space);
     res.end(s);

--- a/src/server/routes/ServeApp.ts
+++ b/src/server/routes/ServeApp.ts
@@ -1,14 +1,15 @@
-import * as http from 'http';
 import {Handler} from './Handler';
 import {Context} from './IHandler';
 import {ServeAsset} from './ServeAsset';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 export class ServeApp extends Handler {
   public static INSTANCE: ServeApp = new ServeApp();
   private constructor() {
     super();
   }
-  public override get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override get(req: Request, res: Response, ctx: Context): Promise<void> {
     req.url = '/assets/index.html';
     return ServeAsset.INSTANCE.get(req, res, ctx);
   }

--- a/src/server/routes/ServeAsset.ts
+++ b/src/server/routes/ServeAsset.ts
@@ -1,4 +1,3 @@
-import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -7,6 +6,8 @@ import {BufferCache} from './BufferCache';
 import {ContentType} from './ContentType';
 import {Handler} from './Handler';
 import {isProduction} from '../utils/server';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 type Encoding = 'gzip' | 'br';
 
@@ -52,7 +53,7 @@ export class ServeAsset extends Handler {
     this.cache.set('build/styles.css.br', brotli);
   }
 
-  public override async get(req: http.IncomingMessage, res: http.ServerResponse, ctx: Context): Promise<void> {
+  public override async get(req: Request, res: Response, ctx: Context): Promise<void> {
     if (req.url === undefined) {
       ctx.route.internalServerError(req, res, new Error('no url on request'));
       return;
@@ -180,7 +181,7 @@ export class ServeAsset extends Handler {
     return {};
   }
 
-  private supportedEncodings(req: http.IncomingMessage): Set<Encoding> {
+  private supportedEncodings(req: Request): Set<Encoding> {
     const result = new Set<Encoding>();
     for (const header of String(req.headers['accept-encoding']).split(', ')) {
       if (header === 'br' || header === 'gzip') {

--- a/src/server/server/heroku.ts
+++ b/src/server/server/heroku.ts
@@ -1,4 +1,4 @@
-import {IncomingMessage} from 'http';
+import {Request} from '../Request';
 
 function deArray<T>(input: T | Array<T>): T | undefined {
   if (!Array.isArray(input)) {
@@ -10,7 +10,7 @@ function deArray<T>(input: T | Array<T>): T | undefined {
   return undefined;
 }
 
-export function getHerokuIpAddress(req: IncomingMessage): string | undefined {
+export function getHerokuIpAddress(req: Request): string | undefined {
   const address = deArray(req.headers['x-forwarded-for']);
   if (address === undefined) {
     return undefined;

--- a/src/server/server/requestProcessor.ts
+++ b/src/server/server/requestProcessor.ts
@@ -1,5 +1,5 @@
-import * as http from 'http';
 import * as prometheus from 'prom-client';
+
 import {paths} from '../../common/app/paths';
 
 import {ApiCloneableGame} from '../routes/ApiCloneableGame';
@@ -28,6 +28,8 @@ import {newIpBlocklist} from './IPBlocklist';
 import {ApiIPs} from '../routes/ApiIPs';
 import {newIpTracker} from './IPTracker';
 import {getHerokuIpAddress} from './heroku';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
 const metrics = {
   count: new prometheus.Counter({
@@ -84,7 +86,7 @@ const handlers: Map<string, IHandler> = new Map(
   ],
 );
 
-function getIPAddress(req: http.IncomingMessage): string {
+function getIPAddress(req: Request): string {
   const herokuIpAddress = getHerokuIpAddress(req);
   if (herokuIpAddress !== undefined) {
     return herokuIpAddress;
@@ -108,8 +110,8 @@ function getHandler(pathname: string): IHandler | undefined {
 }
 
 export function processRequest(
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
+  req: Request,
+  res: Response,
   route: Route): void {
   const start = process.hrtime.bigint();
   let pathnameForLatency: string | undefined = undefined;

--- a/src/server/tools/analyze_ma.ts
+++ b/src/server/tools/analyze_ma.ts
@@ -7,8 +7,10 @@ import {DEFAULT_GAME_OPTIONS, GameOptions} from '../game/GameOptions';
 import {BoardName} from '../../common/boards/BoardName';
 import {RandomMAOptionType} from '../../common/ma/RandomMAOptionType';
 import {MultiSet} from 'mnemonist';
+import {Request} from '../Request';
+import {Response} from '../Response';
 
-function processRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+function processRequest(req: Request, res: Response): void {
   if (req.url === undefined) {
     return;
   }

--- a/tests/routes/ApiGames.spec.ts
+++ b/tests/routes/ApiGames.spec.ts
@@ -17,21 +17,21 @@ describe('ApiGames', function() {
 
   it('validates server id', () => {
     scaffolding.url = '/api/games';
-    ApiGames.INSTANCE.processRequest(scaffolding.req, res.hide(), scaffolding.ctx);
+    ApiGames.INSTANCE.processRequest(scaffolding.req, res, scaffolding.ctx);
     expect(res.content).eq('Not authorized');
   });
 
   it('simple', async () => {
     scaffolding.url = '/api/games?serverId=1';
     scaffolding.req.method = 'GET';
-    await ApiGames.INSTANCE.processRequest(scaffolding.req, res.hide(), scaffolding.ctx);
+    await ApiGames.INSTANCE.processRequest(scaffolding.req, res, scaffolding.ctx);
     expect(res.content).eq('[]');
   });
 
   it('a game', async () => {
     const player = TestPlayer.BLACK.newPlayer();
     await scaffolding.ctx.gameLoader.add(Game.newInstance('game-id', [player], player));
-    await ApiGames.INSTANCE.get(scaffolding.req, res.hide(), scaffolding.ctx);
+    await ApiGames.INSTANCE.get(scaffolding.req, res, scaffolding.ctx);
     // Player ids aren't exactly available in the fake game loader.
     // A base class shared between GameLoader and FakeGameLoader would fix that.
     expect(res.content).eq('[{"gameId":"game-id","participantIds":[]}]');

--- a/tests/routes/ApiIPs.spec.ts
+++ b/tests/routes/ApiIPs.spec.ts
@@ -16,14 +16,14 @@ describe('ApiIPs', function() {
 
   it('validates server id', () => {
     scaffolding.url = '/api/ips';
-    ApiIPs.INSTANCE.processRequest(scaffolding.req, res.hide(), scaffolding.ctx);
+    ApiIPs.INSTANCE.processRequest(scaffolding.req, res, scaffolding.ctx);
     expect(res.content).eq('Not authorized');
   });
 
   it('simple', async () => {
     scaffolding.url = '/api/ips?serverId=1';
     scaffolding.req.method = 'GET';
-    await ApiIPs.INSTANCE.processRequest(scaffolding.req, res.hide(), scaffolding.ctx);
+    await ApiIPs.INSTANCE.processRequest(scaffolding.req, res, scaffolding.ctx);
     expect(res.content).eq('{}');
   });
 
@@ -38,7 +38,7 @@ describe('ApiIPs', function() {
     ipTracker.addParticipant(spectatorId, '12.15.0.5');
     ipTracker.addParticipant(playerId, '12.15.0.5');
     ipTracker.add('12.23.34.45:80');
-    await ApiIPs.INSTANCE.get(scaffolding.req, res.hide(), scaffolding.ctx);
+    await ApiIPs.INSTANCE.get(scaffolding.req, res, scaffolding.ctx);
     const expected = {
       '12.15.0.4': {
         'count': 3,

--- a/tests/routes/HttpMocks.ts
+++ b/tests/routes/HttpMocks.ts
@@ -1,6 +1,6 @@
-import * as http from 'http';
+import {Response} from '../../src/server/Response';
 
-export class MockResponse {
+export class MockResponse implements Response {
   public headers: Map<string, string> = new Map();
   public content = '';
   public statusCode = 200;
@@ -8,22 +8,16 @@ export class MockResponse {
   public setHeader(key: string, value: string) {
     this.headers.set(key, value);
   }
-  public write(content: string) {
+  public write(content: string): boolean {
     this.content += content;
+    return true;
   }
-  public end(content: string | undefined = undefined) {
+  public end(content?: string | Buffer) {
     if (content) {
       this.content += content;
     }
   }
   public writeHead(statusCode: number): void {
     this.statusCode = statusCode;
-  }
-
-  // MockResponse isn't really of type ServerResponse,
-  // and this makes it seem like it is so we can sneak
-  // one of these past the compiler.
-  public hide(): http.ServerResponse {
-    return this as unknown as http.ServerResponse;
   }
 }

--- a/tests/routes/HttpMocks.ts
+++ b/tests/routes/HttpMocks.ts
@@ -1,4 +1,22 @@
+import * as EventEmitter from 'events';
+import {Request} from '../../src/server/Request';
 import {Response} from '../../src/server/Response';
+
+export class MockRequest implements Request {
+  public headers: {[x: string]: string} = {};
+  public method: string = 'GET';
+  public url: string = 'http://website.com';
+  public emitter = new EventEmitter();
+  public socket = {
+    address: () => '127.0.0.1',
+  };
+  public once(type: 'end', cb: () => void): void {
+    this.emitter.once(type, cb);
+  }
+  public on(type: 'data', cb: (dat: Buffer) => void): void {
+    this.emitter.on(type, cb);
+  }
+}
 
 export class MockResponse implements Response {
   public headers: Map<string, string> = new Map();

--- a/tests/routes/PlayerInput.spec.ts
+++ b/tests/routes/PlayerInput.spec.ts
@@ -1,7 +1,6 @@
-import * as EventEmitter from 'events';
 import {expect} from 'chai';
 import {PlayerInput} from '../../src/server/routes/PlayerInput';
-import {MockResponse} from './HttpMocks';
+import {MockRequest, MockResponse} from './HttpMocks';
 import {Game} from '../../src/server/Game';
 import {TestPlayer} from '../TestPlayer';
 import {OrOptions} from '../../src/server/inputs/OrOptions';
@@ -10,15 +9,14 @@ import {RouteTestScaffolding} from './RouteTestScaffolding';
 import {cast} from '../TestingUtils';
 import {OrOptionsResponse} from '../../src/common/inputs/InputResponse';
 import {CardName} from '../../src/common/cards/CardName';
-import {Request} from '../../src/server/Request';
 
 describe('PlayerInput', function() {
   let scaffolding: RouteTestScaffolding;
-  let req: Request;
+  let req: MockRequest;
   let res: MockResponse;
 
   beforeEach(() => {
-    req = new EventEmitter() as unknown as Request;
+    req = new MockRequest();
     res = new MockResponse();
     scaffolding = new RouteTestScaffolding(req);
   });
@@ -47,8 +45,8 @@ describe('PlayerInput', function() {
     const post = scaffolding.post(PlayerInput.INSTANCE, res);
     const emit = Promise.resolve().then(() => {
       const orOptionsResponse: OrOptionsResponse = {type: 'or', index: options.options.length - 1, response: {type: 'option'}};
-      (req as unknown as EventEmitter).emit('data', JSON.stringify(orOptionsResponse));
-      (req as unknown as EventEmitter).emit('end');
+      req.emitter.emit('data', JSON.stringify(orOptionsResponse));
+      req.emitter.emit('end');
     });
     await Promise.all(([emit, post]));
 
@@ -75,8 +73,8 @@ describe('PlayerInput', function() {
     const post = scaffolding.post(PlayerInput.INSTANCE, res);
     const emit = Promise.resolve().then(() => {
       const orOptionsResponse: OrOptionsResponse = {type: 'or', index: options.options.length - 1, response: {type: 'option'}};
-      (scaffolding.req as unknown as EventEmitter).emit('data', JSON.stringify(orOptionsResponse));
-      (scaffolding.req as unknown as EventEmitter).emit('end');
+      scaffolding.req.emitter.emit('data', JSON.stringify(orOptionsResponse));
+      scaffolding.req.emitter.emit('end');
     });
     await Promise.all(([emit, post]));
 
@@ -93,8 +91,8 @@ describe('PlayerInput', function() {
 
     const post = scaffolding.post(PlayerInput.INSTANCE, res);
     const emit = Promise.resolve().then(() => {
-      (scaffolding.req as unknown as EventEmitter).emit('data', '}{');
-      (scaffolding.req as unknown as EventEmitter).emit('end');
+      scaffolding.req.emitter.emit('data', '}{');
+      scaffolding.req.emitter.emit('end');
     });
     await Promise.all(([emit, post]));
 

--- a/tests/routes/PlayerInput.spec.ts
+++ b/tests/routes/PlayerInput.spec.ts
@@ -1,4 +1,3 @@
-import * as http from 'http';
 import * as EventEmitter from 'events';
 import {expect} from 'chai';
 import {PlayerInput} from '../../src/server/routes/PlayerInput';
@@ -11,16 +10,17 @@ import {RouteTestScaffolding} from './RouteTestScaffolding';
 import {cast} from '../TestingUtils';
 import {OrOptionsResponse} from '../../src/common/inputs/InputResponse';
 import {CardName} from '../../src/common/cards/CardName';
+import {Request} from '../../src/server/Request';
 
 describe('PlayerInput', function() {
   let scaffolding: RouteTestScaffolding;
-  let req: EventEmitter;
+  let req: Request;
   let res: MockResponse;
 
   beforeEach(() => {
-    req = new EventEmitter();
+    req = new EventEmitter() as unknown as Request;
     res = new MockResponse();
-    scaffolding = new RouteTestScaffolding(req as http.IncomingMessage);
+    scaffolding = new RouteTestScaffolding(req);
   });
 
   it('fails when id not provided', async () => {
@@ -47,8 +47,8 @@ describe('PlayerInput', function() {
     const post = scaffolding.post(PlayerInput.INSTANCE, res);
     const emit = Promise.resolve().then(() => {
       const orOptionsResponse: OrOptionsResponse = {type: 'or', index: options.options.length - 1, response: {type: 'option'}};
-      req.emit('data', JSON.stringify(orOptionsResponse));
-      req.emit('end');
+      (req as unknown as EventEmitter).emit('data', JSON.stringify(orOptionsResponse));
+      (req as unknown as EventEmitter).emit('end');
     });
     await Promise.all(([emit, post]));
 
@@ -75,8 +75,8 @@ describe('PlayerInput', function() {
     const post = scaffolding.post(PlayerInput.INSTANCE, res);
     const emit = Promise.resolve().then(() => {
       const orOptionsResponse: OrOptionsResponse = {type: 'or', index: options.options.length - 1, response: {type: 'option'}};
-      scaffolding.req.emit('data', JSON.stringify(orOptionsResponse));
-      scaffolding.req.emit('end');
+      (scaffolding.req as unknown as EventEmitter).emit('data', JSON.stringify(orOptionsResponse));
+      (scaffolding.req as unknown as EventEmitter).emit('end');
     });
     await Promise.all(([emit, post]));
 
@@ -93,8 +93,8 @@ describe('PlayerInput', function() {
 
     const post = scaffolding.post(PlayerInput.INSTANCE, res);
     const emit = Promise.resolve().then(() => {
-      scaffolding.req.emit('data', '}{');
-      scaffolding.req.emit('end');
+      (scaffolding.req as unknown as EventEmitter).emit('data', '}{');
+      (scaffolding.req as unknown as EventEmitter).emit('end');
     });
     await Promise.all(([emit, post]));
 

--- a/tests/routes/Route.spec.ts
+++ b/tests/routes/Route.spec.ts
@@ -17,7 +17,7 @@ describe('Route', () => {
   it('internalServerError expects predictable errors', () => {
     scaffolding.url = 'goo.goo.gaa.gaa';
     scaffolding.req.headers['accept-encoding'] = '';
-    instance.internalServerError(scaffolding.req, res.hide(), {'<img src=x onerror=alert(1)>': 'foo'});
+    instance.internalServerError(scaffolding.req, res, {'<img src=x onerror=alert(1)>': 'foo'});
     expect(res.statusCode).eq(500);
     expect(res.content).eq('Internal server error: unknown error');
   });
@@ -25,7 +25,7 @@ describe('Route', () => {
   it('internalServerError prevents xss', () => {
     scaffolding.url = 'goo.goo.gaa.gaa';
     scaffolding.req.headers['accept-encoding'] = '';
-    instance.internalServerError(scaffolding.req, res.hide(), '<img src=x onerror=alert(1)>');
+    instance.internalServerError(scaffolding.req, res, '<img src=x onerror=alert(1)>');
     expect(res.statusCode).eq(500);
     expect(res.content).eq('Internal server error: &lt;img src=x onerror=alert(1)&gt;');
   });

--- a/tests/routes/RouteTestScaffolding.ts
+++ b/tests/routes/RouteTestScaffolding.ts
@@ -1,20 +1,20 @@
-import * as http from 'http';
 import {Context} from '../../src/server/routes/IHandler';
 import {Handler} from '../../src/server/routes/Handler';
 import {Route} from '../../src/server/routes/Route';
 import {FakeGameLoader} from './FakeGameLoader';
 import {MockResponse} from './HttpMocks';
 import {newIpTracker} from '../../src/server/server/IPTracker';
+import {Request} from '../../src/server/Request';
 
 export type Header = 'accept-encoding';
 
 // Reusable components for testing routes.
 export class RouteTestScaffolding {
-  public req: http.IncomingMessage;
+  public req: Request;
   public ctx: Context;
 
-  constructor(req: Partial<http.IncomingMessage> = {}) {
-    this.req = req as http.IncomingMessage;
+  constructor(req: Partial<Request> = {}) {
+    this.req = req as Request;
     this.ctx = {
       route: new Route(),
       url: new URL('http://boo.com'),
@@ -36,10 +36,10 @@ export class RouteTestScaffolding {
   }
 
   public get(handler: Handler, res: MockResponse): Promise<void> {
-    return handler.get(this.req, res.hide(), this.ctx);
+    return handler.get(this.req, res, this.ctx);
   }
 
   public post(handler: Handler, res: MockResponse) {
-    return handler.post(this.req, res.hide(), this.ctx);
+    return handler.post(this.req, res, this.ctx);
   }
 }

--- a/tests/routes/RouteTestScaffolding.ts
+++ b/tests/routes/RouteTestScaffolding.ts
@@ -2,19 +2,16 @@ import {Context} from '../../src/server/routes/IHandler';
 import {Handler} from '../../src/server/routes/Handler';
 import {Route} from '../../src/server/routes/Route';
 import {FakeGameLoader} from './FakeGameLoader';
-import {MockResponse} from './HttpMocks';
+import {MockRequest, MockResponse} from './HttpMocks';
 import {newIpTracker} from '../../src/server/server/IPTracker';
-import {Request} from '../../src/server/Request';
 
 export type Header = 'accept-encoding';
 
 // Reusable components for testing routes.
 export class RouteTestScaffolding {
-  public req: Request;
   public ctx: Context;
 
-  constructor(req: Partial<Request> = {}) {
-    this.req = req as Request;
+  constructor(public req: MockRequest = new MockRequest()) {
     this.ctx = {
       route: new Route(),
       url: new URL('http://boo.com'),


### PR DESCRIPTION
I want to add support for an offline mode and allow the current server javascript to run in a worker. Currently we rely on http.IncomingMessage and http.ServerResponse for taking in a request and serving response. We don't use many parts of these types yet require the full type. This change creates a Request and Response type which picks from http for the parts we use. If nothing else this makes unit testing simpler as we only have to create the smaller Request and Response objects versus the full http.IncomingMessage and http.ServerResponse.