### PR TITLE
St. Joseph + Helion: Fix payment with heat

### DIFF
--- a/src/server/cards/promo/StJosephOfCupertinoMission.ts
+++ b/src/server/cards/promo/StJosephOfCupertinoMission.ts
@@ -59,7 +59,7 @@ export class StJosephOfCupertinoMission extends Card implements IActionCard {
           spaceOwner.defer(
             new OrOptions(
               new SelectOption('Do not buy a card', undefined, () => undefined),
-              new SelectPayment('Pay 2 M€ to draw a card', 2, {heat: player.canUseHeatAsMegaCredits}, (payment) => {
+              new SelectPayment('Pay 2 M€ to draw a card', 2, {heat: spaceOwner.canUseHeatAsMegaCredits}, (payment) => {
                 // TODO(kberg): pay should have an afterPay for the heat / floaters costs.
                 spaceOwner.pay(payment);
                 spaceOwner.drawCard();


### PR DESCRIPTION
The city owner should be able to use heat to pay 2 M€ for 1 card iff she/he is Helion (and not iff the player building the cathedral is Helion).