### PR TITLE
Two turmoil cleanups

### DIFF
--- a/src/client/components/SelectParty.vue
+++ b/src/client/components/SelectParty.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="wf-component wf-component--select-party">
         <div v-if="showtitle === true" class="nofloat wf-component-title">{{ $t(playerinput.title) }}</div>
-        <div class="wf-component--list-party" v-if="playerinput.turmoil !== undefined">
-          <label v-for="party in playerinput.turmoil.parties" :key="party.name">
+        <div class="wf-component--list-party" v-if="turmoil !== undefined">
+          <label v-for="party in turmoil.parties" :key="party.name">
               <input type="radio" v-model="selectedParty" :value="party.name" v-if="partyAvailableToSelect(party.name)"/>
               <Party :party="party" :isDominant="isDominant(party.name)" :isAvailable="partyAvailableToSelect(party.name)"/>
           </label>
@@ -19,10 +19,15 @@ import {SelectPartyModel} from '@/common/models/PlayerInputModel';
 import Party from '@/client/components/Party.vue';
 import {PartyName} from '@/common/turmoil/PartyName';
 import {SelectPartyResponse} from '@/common/inputs/InputResponse';
+import {PlayerViewModel} from '@/common/models/PlayerModel';
+import {TurmoilModel} from '@/common/models/TurmoilModel';
 
 export default Vue.extend({
   name: 'SelectParty',
   props: {
+    playerView: {
+      type: Object as () => PlayerViewModel,
+    },
     playerinput: {
       type: Object as () => SelectPartyModel,
     },
@@ -50,7 +55,7 @@ export default Vue.extend({
       this.onsave({type: 'party', partyName: this.selectedParty});
     },
     isDominant(partyName: PartyName): boolean {
-      return partyName === this.playerinput.turmoil.dominant;
+      return partyName === this.turmoil?.dominant;
     },
     partyAvailableToSelect(partyName: PartyName): boolean {
       if (this.playerinput.parties === undefined) {
@@ -58,6 +63,11 @@ export default Vue.extend({
       } else {
         return this.playerinput.parties.includes(partyName);
       }
+    },
+  },
+  computed: {
+    turmoil(): TurmoilModel | undefined {
+      return this.playerView.game.turmoil;
     },
   },
 });

--- a/src/client/components/SelectSpace.vue
+++ b/src/client/components/SelectSpace.vue
@@ -100,7 +100,6 @@ export default (Vue as WithRefs<Refs>).extend({
       if (this.selectedTile === undefined) {
         throw new Error('unexpected, no tile selected!');
       }
-      // TODO(kberg): Do something about this typing.
       const spaceId = this.selectedTile.getAttribute('data_space_id') as SpaceId;
       if (spaceId === null) {
         throw new Error('unexpected, space has no id');

--- a/src/common/models/PlayerInputModel.ts
+++ b/src/common/models/PlayerInputModel.ts
@@ -5,7 +5,6 @@ import {PayProductionModel} from './PayProductionUnitsModel';
 import {AresData} from '../ares/AresData';
 import {Message} from '../logs/Message';
 import {PartyName} from '../turmoil/PartyName';
-import {TurmoilModel} from './TurmoilModel';
 import {SpaceId} from '../Types';
 import {PaymentOptions} from '../inputs/Payment';
 
@@ -95,10 +94,7 @@ export type SelectDelegateModel = BaseInputModel & {
 
 export type SelectPartyModel = BaseInputModel & {
   type: 'party';
-  // TODO(kberg): Rename to 'parties'
   parties: Array<PartyName>;
-  // Is this necessary?
-  turmoil: TurmoilModel;
 }
 
 export type SelectProductionToLoseModel = BaseInputModel & {

--- a/src/server/inputs/SelectParty.ts
+++ b/src/server/inputs/SelectParty.ts
@@ -27,7 +27,6 @@ export class SelectParty extends BasePlayerInput {
       buttonLabel: this.buttonLabel,
       type: 'party',
       parties: this.parties,
-      turmoil: turmoil,
     };
   }
 

--- a/src/server/turmoil/Turmoil.ts
+++ b/src/server/turmoil/Turmoil.ts
@@ -249,6 +249,17 @@ export class Turmoil {
       currentGlobalEvent.resolve(game, this);
     }
 
+    this.startNewGovernment(game);
+  }
+
+  private startNewGovernment(game: IGame) {
+    if (game.deferredActions.length > 0) {
+      game.deferredActions.runAll(() => {
+        this.startNewGovernment(game);
+      });
+      return;
+    }
+
     // 3 - New Government
 
     // 3.a - Ruling Policy change

--- a/tests/client/components/PlayerInputFactory.spec.ts
+++ b/tests/client/components/PlayerInputFactory.spec.ts
@@ -8,6 +8,8 @@ import {Units} from '@/common/Units';
 import {CardName} from '@/common/cards/CardName';
 import {SELECT_CORPORATION_TITLE, SELECT_PROJECTS_TITLE} from '@/common/inputs/SelectInitialCards';
 import {PlayerViewModel, PublicPlayerModel} from '@/common/models/PlayerModel';
+import {PartyName} from '@/common/turmoil/PartyName';
+import {RecursivePartial} from '@/common/utils/utils';
 
 describe('PlayerInputFactory', function() {
   it('AndOptions', async () => {
@@ -88,19 +90,7 @@ describe('PlayerInputFactory', function() {
   it('SelectParty', async () => {
     runTest({
       type: 'party',
-      turmoil: {
-        dominant: undefined,
-        ruling: undefined,
-        chairman: undefined,
-        parties: [],
-        lobby: [],
-        reserve: [],
-        distant: undefined,
-        coming: undefined,
-        current: undefined,
-        politicalAgendas: undefined,
-        policyActionUsers: [],
-      },
+      parties: [PartyName.GREENS, PartyName.REDS],
     });
   });
 
@@ -152,10 +142,13 @@ function runTest(playerInput: Partial<PlayerInputModel>) {
     tableau: [],
   };
 
-  const playerView: Partial<PlayerViewModel> = {
+  const playerView: RecursivePartial<PlayerViewModel> = {
     id: 'p-player-id',
     dealtCorporationCards: [],
     thisPlayer: thisPlayer as PublicPlayerModel,
+    game: {
+      turmoil: {},
+    },
   };
 
   const component = mount(PlayerInputFactory, {

--- a/tests/turmoil/Turmoil.spec.ts
+++ b/tests/turmoil/Turmoil.spec.ts
@@ -36,6 +36,8 @@ import {DarksideMeteorBombardment} from '../../src/server/cards/moon/DarksideMet
 import {LunaStagingStation} from '../../src/server/cards/moon/LunaStagingStation';
 import {MoonExpansion} from '../../src/server/moon/MoonExpansion';
 import {TileType} from '../../src/common/TileType';
+import {AquiferReleasedByPublicCouncil} from '../../src/server/turmoil/globalEvents/AquiferReleasedByPublicCouncil';
+import {testGame} from '../TestGame';
 
 describe('Turmoil', function() {
   let player: TestPlayer;
@@ -44,12 +46,9 @@ describe('Turmoil', function() {
   let turmoil: Turmoil;
 
   beforeEach(function() {
-    player = TestPlayer.BLUE.newPlayer();
-    player2 = TestPlayer.RED.newPlayer();
-
-    game = Game.newInstance('gameid', [player, player2], player, {turmoilExtension: true});
+    [game, player, player2] = testGame(2, {turmoilExtension: true});
     game.phase = Phase.ACTION;
-    turmoil = game.turmoil!;
+    turmoil = Turmoil.getTurmoil(game);
     // Eliminate the flaky cases where the current global event sends delegates to
     // parties, changing the dominant party outcome.
     turmoil.parties.forEach((p) => p.delegates.clear());
@@ -71,16 +70,6 @@ describe('Turmoil', function() {
     expect(Array.from(greens.delegates.values())).to.deep.eq([player.id]);
     expect(turmoil.usedFreeDelegateAction).does.not.contain(player.id);
   });
-
-  it('Correctly send delegate from the reserve', function() {
-    const greens = turmoil.getPartyByName(PartyName.GREENS);
-    greens.delegates.clear();
-
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
-
-    expect(Array.from(greens.delegates.values())).to.deep.eq([player.id]);
-  });
-
 
   it('Do not send delegate from reserve when reserve is empty', function() {
     const greens = turmoil.getPartyByName(PartyName.GREENS);
@@ -177,6 +166,38 @@ describe('Turmoil', function() {
     expect(turmoil.usedFreeDelegateAction).is.empty;
     expect(turmoil.rulingParty).to.eq(turmoil.getPartyByName(PartyName.REDS));
     expect(turmoil.dominantParty).to.eq(turmoil.getPartyByName(PartyName.GREENS));
+  });
+
+  it('Correctly run end of generation when global event introduces actions', function() {
+    player.setTerraformRating(20);
+    player2.setTerraformRating(21);
+
+    turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player2.id, PartyName.GREENS, game);
+
+    // Requires placing an ocean
+    turmoil.currentGlobalEvent = new AquiferReleasedByPublicCouncil();
+    game.phase = Phase.SOLAR;
+    turmoil.endGeneration(game);
+    runAllActions(game);
+
+    // Both players lost their TR, but the new policy isn't in effect.
+    expect(player.getTerraformRating()).to.eq(19);
+    expect(player2.getTerraformRating()).to.eq(20);
+    expect(turmoil.chairman).to.eq('NEUTRAL');
+
+    cast(player.getWaitingFor(), SelectSpace);
+    player.process({
+      type: 'space',
+      spaceId: player.game.board.getAvailableSpacesForOcean(player)[0].id,
+    });
+    runAllActions(game);
+
+    expect(turmoil.chairman).to.eq(player.id);
+    // player gains 1 TR from Reds ruling bonus, and 1 TR from becoming the chairman
+    expect(player.getTerraformRating()).to.eq(21);
+    expect(player2.getTerraformRating()).to.eq(20);
   });
 
   it('Does not give Mars First bonus for World Government terraforming', function() {


### PR DESCRIPTION
1. Reduce data sent to client.
2. Improve global event processing order when a global event requires player input.