### PR TITLE
Fix Set Production to Lose form +/- buttons

### DIFF
--- a/src/client/components/SelectProductionToLose.vue
+++ b/src/client/components/SelectProductionToLose.vue
@@ -127,12 +127,12 @@ export default Vue.extend({
         }
         return -1;
       };
-      const current = this.$data[type];
+      const current = this.$data.units[type];
       let newValue = current + direction;
       const lowestValue = (type === 'megacredit') ? -5 : 0;
       const expendableQuantity = expendableProductionQuantity(type, this.playerinput.payProduction);
       newValue = Math.min(Math.max(newValue, lowestValue), expendableQuantity);
-      this.$data[type] = newValue;
+      this.$data.units[type] = newValue;
     },
     saveData() {
       const total = sum(Units.values(this.units));

--- a/src/client/components/SelectProductionToLose.vue
+++ b/src/client/components/SelectProductionToLose.vue
@@ -109,8 +109,8 @@ export default Vue.extend({
     hasWarning() {
       return this.warning !== undefined;
     },
-    delta(type: string, direction: number) {
-      const expendableProductionQuantity = function(type: string, model: PayProductionModel): number {
+    delta(type: keyof Units, direction: number) {
+      const expendableProductionQuantity = function(type: keyof Units, model: PayProductionModel): number {
         switch (type) {
         case 'megacredits':
           return model.units.megacredits + 5;
@@ -124,15 +124,16 @@ export default Vue.extend({
           return model.units.energy;
         case 'heat':
           return model.units.heat;
+        default:
+          return -1;
         }
-        return -1;
       };
-      const current = this.$data.units[type];
+      const current = this.units[type];
       let newValue = current + direction;
       const lowestValue = (type === 'megacredits') ? -5 : 0;
       const expendableQuantity = expendableProductionQuantity(type, this.playerinput.payProduction);
       newValue = Math.min(Math.max(newValue, lowestValue), expendableQuantity);
-      this.$data.units[type] = newValue;
+      this.units[type] = newValue;
     },
     saveData() {
       const total = sum(Units.values(this.units));

--- a/src/client/components/SelectProductionToLose.vue
+++ b/src/client/components/SelectProductionToLose.vue
@@ -129,7 +129,7 @@ export default Vue.extend({
       };
       const current = this.$data.units[type];
       let newValue = current + direction;
-      const lowestValue = (type === 'megacredit') ? -5 : 0;
+      const lowestValue = (type === 'megacredits') ? -5 : 0;
       const expendableQuantity = expendableProductionQuantity(type, this.playerinput.payProduction);
       newValue = Math.min(Math.max(newValue, lowestValue), expendableQuantity);
       this.$data.units[type] = newValue;

--- a/src/client/components/SelectProductionToLose.vue
+++ b/src/client/components/SelectProductionToLose.vue
@@ -130,9 +130,8 @@ export default Vue.extend({
       };
       const current = this.units[type];
       let newValue = current + direction;
-      const lowestValue = (type === 'megacredits') ? -5 : 0;
       const expendableQuantity = expendableProductionQuantity(type, this.playerinput.payProduction);
-      newValue = Math.min(Math.max(newValue, lowestValue), expendableQuantity);
+      newValue = Math.min(Math.max(newValue, 0), expendableQuantity);
       this.units[type] = newValue;
     },
     saveData() {


### PR DESCRIPTION
Fixes Set Production to Lose Form's +/- buttons and removes last references to $.data

# Summary
I noticed a bug last week when selecting production to lose (as a result of hazards on the map), where the plus/minus buttons weren't working at all and you have to type in to edit the value.  I believe this bug change was introduced in https://github.com/terraforming-mars/terraforming-mars/pull/6136 when cleaning up `$.data` usage.

This PR contains the following changes:
- Updated the `delta` function to mutate the new nested `data.units` structure
- Fixes typo on `megacredit` in the `delta` function which prevents reducing megacredits production below 0
- Updates type matching on the delta function to use `keyof Units` instead of a `string` which enables indexing into `this.units[unit]` instead of `this.$data.units[strUnit]` (removing the last `this.$data` ref in this file

# How this was tested
Running in docker locally, confirmed that the plus and minus buttons now update the appropriate input field's value

# Notes
I would love to chat about taking on a larger refactor of this vue component (similar to the newer `SelectPayment` and `PaymentUnit` components) if you'd be open to it! 🤓 

P.S. I've become a bit obsessed w/ TFMars and have been really loving this community's version! Thanks for all your hard work, and I hope to contribute in the future! :)