### PR TITLE
Store IPlayer instead of PlayerId in Turmoil components.

### DIFF
--- a/src/server/behavior/Executor.ts
+++ b/src/server/behavior/Executor.ts
@@ -168,7 +168,7 @@ export class Executor implements BehaviorExecutor {
 
     if (behavior.turmoil) {
       if (behavior.turmoil.sendDelegates) {
-        if (Turmoil.getTurmoil(player.game).getAvailableDelegateCount(player.id) < behavior.turmoil.sendDelegates.count) {
+        if (Turmoil.getTurmoil(player.game).getAvailableDelegateCount(player) < behavior.turmoil.sendDelegates.count) {
           return false;
         }
       }

--- a/src/server/cards/ceos/Oscar.ts
+++ b/src/server/cards/ceos/Oscar.ts
@@ -33,13 +33,13 @@ export class Oscar extends CeoCard {
       return false;
     }
     const turmoil = Turmoil.getTurmoil(player.game);
-    return turmoil.hasDelegatesInReserve(player.id) && turmoil.chairman !== player.id;
+    return turmoil.hasDelegatesInReserve(player) && turmoil.chairman !== player;
   }
 
   public action(player: IPlayer): PlayerInput | undefined {
     const turmoil = Turmoil.getTurmoil(player.game);
-    turmoil.setNewChairman(player.id, player.game, /* setAgenda*/false, /* gainTR*/false);
-    turmoil.delegateReserve.remove(player.id);
+    turmoil.setNewChairman(player, player.game, /* setAgenda*/false, /* gainTR*/false);
+    turmoil.delegateReserve.remove(player);
     // Increase totalDelegatesPlaced manually since we're not using SendDeletageToArea()
     // If we dont do this player will not get the bonus for POLITICAN Awards
     player.totalDelegatesPlaced += 1;

--- a/src/server/cards/ceos/Petra.ts
+++ b/src/server/cards/ceos/Petra.ts
@@ -38,7 +38,7 @@ export class Petra extends CeoCard {
     const turmoil = player.game.turmoil;
     if (turmoil === undefined || this.isDisabled === true) return false;
     const numNeutralDelegates = DELEGATES_FOR_NEUTRAL_PLAYER - turmoil.getAvailableDelegateCount('NEUTRAL');
-    const playerTotalDelegateCount = turmoil.getAvailableDelegateCount(player.id);
+    const playerTotalDelegateCount = turmoil.getAvailableDelegateCount(player);
     return playerTotalDelegateCount >= numNeutralDelegates;
   }
 
@@ -55,7 +55,7 @@ export class Petra extends CeoCard {
       for (let i = 0; i < neutralDelegates; i++) {
         // Add the delegate _before_ removing the Neutral, otherwise we get errors when it
         // attempts to find the new party leader if there are no remaining members in the party.
-        turmoil.sendDelegateToParty(player.id, party.name, player.game);
+        turmoil.sendDelegateToParty(player, party.name, player.game);
         turmoil.removeDelegateFromParty('NEUTRAL', party.name, player.game);
         // This would be nice to use:
         // turmoil.replaceDelegateFromParty('NEUTRAL', player.id, party.name, player.game);
@@ -69,8 +69,8 @@ export class Petra extends CeoCard {
 
     // Replace chairman if it is neutral
     if (turmoil.chairman === 'NEUTRAL') {
-      turmoil.setNewChairman(player.id, player.game, /* setAgenda */ false);
-      turmoil.delegateReserve.remove(player.id);
+      turmoil.setNewChairman(player, player.game, /* setAgenda */ false);
+      turmoil.delegateReserve.remove(player);
       count += 1;
     }
     // If we dont do this player will not get the bonus for POLITICAN Awards

--- a/src/server/cards/ceos/Zan.ts
+++ b/src/server/cards/ceos/Zan.ts
@@ -29,9 +29,9 @@ export class Zan extends CeoCard {
     this.isDisabled = true;
     const game = player.game;
     const turmoil = Turmoil.getTurmoil(game);
-    const totalAvailableDelegates = turmoil.getAvailableDelegateCount(player.id);
-    while (turmoil.getAvailableDelegateCount(player.id) > 0) {
-      turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+    const totalAvailableDelegates = turmoil.getAvailableDelegateCount(player);
+    while (turmoil.getAvailableDelegateCount(player) > 0) {
+      turmoil.sendDelegateToParty(player, PartyName.REDS, game);
     }
     // If we dont do this player will not get the bonus for POLITICAN Awards
     player.totalDelegatesPlaced += totalAvailableDelegates;

--- a/src/server/cards/community/LeadershipSummit.ts
+++ b/src/server/cards/community/LeadershipSummit.ts
@@ -22,7 +22,7 @@ export class LeadershipSummit extends GlobalEvent implements IGlobalEvent {
   }
   public resolve(game: IGame, turmoil: Turmoil) {
     game.getPlayersInGenerationOrder().forEach((player) => {
-      const partyLeaderCount = turmoil.parties.filter((party) => party.partyLeader === player.id).length;
+      const partyLeaderCount = turmoil.parties.filter((party) => party.partyLeader === player).length;
       player.drawCard(Math.min(5, partyLeaderCount) + turmoil.getPlayerInfluence(player));
     });
   }

--- a/src/server/cards/moon/TempestConsultancy.ts
+++ b/src/server/cards/moon/TempestConsultancy.ts
@@ -46,13 +46,13 @@ export class TempestConsultancy extends Card implements ICorporationCard {
   }
 
   public canAct(player: IPlayer) {
-    return player.tags.count(Tag.MOON) >= 5 && Turmoil.getTurmoil(player.game).getAvailableDelegateCount(player.id) > 0;
+    return player.tags.count(Tag.MOON) >= 5 && Turmoil.getTurmoil(player.game).getAvailableDelegateCount(player) > 0;
   }
 
   public action(player: IPlayer) {
     let count = Math.floor(player.tags.count(Tag.MOON) / 5);
     count = Math.min(count, 3);
-    count = Math.min(count, Turmoil.getTurmoil(player.game).getAvailableDelegateCount(player.id));
+    count = Math.min(count, Turmoil.getTurmoil(player.game).getAvailableDelegateCount(player));
     if (count > 0) {
       player.game.defer(new SendDelegateToArea(
         player,

--- a/src/server/cards/pathfinders/MindSetMars.ts
+++ b/src/server/cards/pathfinders/MindSetMars.ts
@@ -52,7 +52,7 @@ export class MindSetMars extends Card implements ICorporationCard {
 
   private canAddDelegate(player: IPlayer) {
     const turmoil = Turmoil.getTurmoil(player.game);
-    return this.resourceCount >= 2 && turmoil.getAvailableDelegateCount(player.id) > 0;
+    return this.resourceCount >= 2 && turmoil.getAvailableDelegateCount(player) > 0;
   }
 
   private canAddCity(player: IPlayer) {

--- a/src/server/cards/requirements/ChairmanRequirement.ts
+++ b/src/server/cards/requirements/ChairmanRequirement.ts
@@ -9,6 +9,6 @@ export class ChairmanRequirement extends CardRequirement {
     super({count: 1});
   }
   public satisfies(player: IPlayer) : boolean {
-    return Turmoil.getTurmoil(player.game).chairman === player.id;
+    return Turmoil.getTurmoil(player.game).chairman === player;
   }
 }

--- a/src/server/cards/requirements/PartyLeadersRequirement.ts
+++ b/src/server/cards/requirements/PartyLeadersRequirement.ts
@@ -7,6 +7,6 @@ export class PartyLeadersRequirement extends InequalityRequirement {
   public readonly type = RequirementType.PARTY_LEADERS;
   public override getScore(player: IPlayer): number {
     const turmoil = Turmoil.getTurmoil(player.game);
-    return turmoil.parties.filter((party) => party.partyLeader === player.id).length;
+    return turmoil.parties.filter((party) => party.partyLeader === player).length;
   }
 }

--- a/src/server/cards/turmoil/BannedDelegate.ts
+++ b/src/server/cards/turmoil/BannedDelegate.ts
@@ -3,7 +3,6 @@ import {Card} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
 import {IPlayer} from '../../IPlayer';
-import {Delegate} from '../../turmoil/Turmoil';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectDelegate} from '../../inputs/SelectDelegate';
 import {IParty} from '../../turmoil/parties/IParty';
@@ -49,20 +48,14 @@ export class BannedDelegate extends Card implements IProjectCard {
           if (entry[0] === 'NEUTRAL') {
             players.push('NEUTRAL');
           } else {
-            players.push(player.game.getPlayerById(entry[0]));
+            players.push(entry[0]);
           }
         }
 
         if (players.length > 0) {
           const selectDelegate = new SelectDelegate(players, 'Select player delegate to remove from ' + party.name + ' party')
             .andThen((selectedPlayer) => {
-              let playerToRemove: Delegate;
-              if (selectedPlayer === 'NEUTRAL') {
-                playerToRemove = 'NEUTRAL';
-              } else {
-                playerToRemove = selectedPlayer.id;
-              }
-              turmoil.removeDelegateFromParty(playerToRemove, party.name, player.game);
+              turmoil.removeDelegateFromParty(selectedPlayer, party.name, player.game);
               this.log(player, party, selectedPlayer);
               return undefined;
             });

--- a/src/server/cards/turmoil/CulturalMetropolis.ts
+++ b/src/server/cards/turmoil/CulturalMetropolis.ts
@@ -38,7 +38,7 @@ export class CulturalMetropolis extends Card implements IProjectCard {
 
   public override bespokeCanPlay(player: IPlayer): boolean {
     const turmoil = Turmoil.getTurmoil(player.game);
-    return turmoil.getAvailableDelegateCount(player.id) >= 2 && player.game.board.getAvailableSpacesForCity(player).length > 0;
+    return turmoil.getAvailableDelegateCount(player) >= 2 && player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
 
   public override bespokePlay(player: IPlayer) {

--- a/src/server/cards/turmoil/Recruitment.ts
+++ b/src/server/cards/turmoil/Recruitment.ts
@@ -27,7 +27,7 @@ export class Recruitment extends Card implements IProjectCard {
 
   public override bespokeCanPlay(player: IPlayer): boolean {
     const turmoil = Turmoil.getTurmoil(player.game);
-    if (turmoil.hasDelegatesInReserve(player.id) === false) {
+    if (turmoil.hasDelegatesInReserve(player) === false) {
       return false;
     }
 

--- a/src/server/cards/turmoil/SeptumTribus.ts
+++ b/src/server/cards/turmoil/SeptumTribus.ts
@@ -39,7 +39,7 @@ export class SeptumTribus extends Card implements IActionCard, ICorporationCard 
 
   public action(player: IPlayer) {
     const turmoil = Turmoil.getTurmoil(player.game);
-    const partiesWithPresence = turmoil.parties.filter((party) => party.delegates.has(player.id));
+    const partiesWithPresence = turmoil.parties.filter((party) => party.delegates.has(player));
     player.stock.add(Resource.MEGACREDITS, partiesWithPresence.length * 2, {log: true});
 
     return undefined;

--- a/src/server/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/server/cards/turmoil/VoteOfNoConfidence.ts
@@ -33,15 +33,15 @@ export class VoteOfNoConfidence extends Card implements IProjectCard {
 
   public override bespokeCanPlay(player: IPlayer): boolean {
     const turmoil = Turmoil.getTurmoil(player.game);
-    if (!turmoil.hasDelegatesInReserve(player.id)) return false;
+    if (!turmoil.hasDelegatesInReserve(player)) return false;
 
     return turmoil.chairman === 'NEUTRAL';
   }
 
   public override bespokePlay(player: IPlayer) {
     const turmoil = Turmoil.getTurmoil(player.game);
-    turmoil.delegateReserve.remove(player.id);
-    turmoil.setNewChairman(player.id, player.game, /* setAgenda */ false);
+    turmoil.delegateReserve.remove(player);
+    turmoil.setNewChairman(player, player.game, /* setAgenda */ false);
     return undefined;
   }
 }

--- a/src/server/colonies/Colony.ts
+++ b/src/server/colonies/Colony.ts
@@ -266,7 +266,7 @@ export abstract class Colony implements IColony {
 
     case ColonyBenefit.PLACE_DELEGATES:
       Turmoil.ifTurmoil(game, (turmoil) => {
-        const availablePlayerDelegates = turmoil.getAvailableDelegateCount(player.id);
+        const availablePlayerDelegates = turmoil.getAvailableDelegateCount(player);
         const qty = Math.min(quantity, availablePlayerDelegates);
         for (let i = 0; i < qty; i++) {
           game.defer(new SendDelegateToArea(player));
@@ -276,7 +276,7 @@ export abstract class Colony implements IColony {
 
     case ColonyBenefit.GIVE_MC_PER_DELEGATE:
       Turmoil.ifTurmoil(game, (turmoil) => {
-        const partyDelegateCount = sum(turmoil.parties.map((party) => party.delegates.get(player.id)));
+        const partyDelegateCount = sum(turmoil.parties.map((party) => party.delegates.get(player)));
         player.stock.add(Resource.MEGACREDITS, partyDelegateCount, {log: true});
       });
       break;

--- a/src/server/deferredActions/SendDelegateToArea.ts
+++ b/src/server/deferredActions/SendDelegateToArea.ts
@@ -59,14 +59,14 @@ export class SendDelegateToArea extends DeferredAction {
 
         for (let i = 0; i < numDelegateToSend; i++) {
           if (this.options.replace) {
-            this.turmoil.replaceDelegateFromParty(this.options.replace, this.player.id, partyName, this.player.game);
+            this.turmoil.replaceDelegateFromParty(this.options.replace, this.player, partyName, this.player.game);
           } else {
-            this.turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game);
+            this.turmoil.sendDelegateToParty(this.player, partyName, this.player.game);
           }
         }
 
         if (this.options?.freeStandardAction === true) {
-          this.turmoil.usedFreeDelegateAction.add(this.player.id);
+          this.turmoil.usedFreeDelegateAction.add(this.player);
         }
         this.player.totalDelegatesPlaced += numDelegateToSend;
         this.player.game.log('${0} sent ${1} delegate(s) in ${2} area', (b) => b.player(this.player).number(numDelegateToSend).partyName(partyName));

--- a/src/server/models/TurmoilModel.ts
+++ b/src/server/models/TurmoilModel.ts
@@ -3,7 +3,7 @@ import {PartyName} from '../../common/turmoil/PartyName';
 import {IGame} from '../IGame';
 import {PoliticalAgendas} from '../turmoil/PoliticalAgendas';
 import {IGlobalEvent} from '../turmoil/globalEvents/IGlobalEvent';
-import {Turmoil} from '../turmoil/Turmoil';
+import {Delegate, Turmoil} from '../turmoil/Turmoil';
 import {DelegatesModel, GlobalEventModel, PartyModel, PoliticalAgendasModel, TurmoilModel} from '../../common/models/TurmoilModel';
 
 export function getTurmoilModel(game: IGame): TurmoilModel | undefined {
@@ -12,26 +12,25 @@ export function getTurmoilModel(game: IGame): TurmoilModel | undefined {
     let chairman: Color | undefined;
 
     if (turmoil.chairman) {
-      if (turmoil.chairman === 'NEUTRAL') {
-        chairman = Color.NEUTRAL;
-      } else {
-        chairman = game.getPlayerById(turmoil.chairman).color;
-      }
+      chairman = delegateColor(turmoil.chairman);
     }
     const dominant = turmoil.dominantParty.name;
     const ruling = turmoil.rulingParty.name;
 
     const reserve: Array<DelegatesModel> = [];
     const lobby: Array<Color> = [];
-    turmoil.delegateReserve.forEachMultiplicity((count, playerId) => {
-      const color = playerId === 'NEUTRAL' ? Color.NEUTRAL : game.getPlayerById(playerId).color;
-      if (playerId !== 'NEUTRAL') {
-        if (!turmoil.usedFreeDelegateAction.has(playerId)) {
+    turmoil.delegateReserve.forEachMultiplicity((count, delegate) => {
+      const color = delegateColor(delegate);
+      if (delegate !== 'NEUTRAL') {
+        if (!turmoil.usedFreeDelegateAction.has(delegate)) {
           count--;
           lobby.push(color);
         }
       }
-      reserve.push({color, number: count});
+      reserve.push({
+        color: color,
+        number: count,
+      });
     });
 
     const distant = globalEventToModel(turmoil.distantGlobalEvent);
@@ -93,17 +92,12 @@ function getParties(game: IGame): Array<PartyModel> {
         const delegates: Array<DelegatesModel> = [];
         for (const player of party.delegates.keys()) {
           const number = party.delegates.count(player);
-          const color = player === 'NEUTRAL' ? Color.NEUTRAL : game.getPlayerById(player).color;
-          delegates.push({color, number});
+          delegates.push({
+            color: delegateColor(player),
+            number,
+          });
         }
-        let partyLeader;
-        if (party.partyLeader) {
-          if (party.partyLeader === 'NEUTRAL') {
-            partyLeader = Color.NEUTRAL;
-          } else {
-            partyLeader = game.getPlayerById(party.partyLeader).color;
-          }
-        }
+        const partyLeader = party.partyLeader === undefined ? undefined : delegateColor(party.partyLeader);
         return {
           name: party.name,
           partyLeader: partyLeader,
@@ -112,4 +106,8 @@ function getParties(game: IGame): Array<PartyModel> {
       });
     },
     () => []);
+}
+
+function delegateColor(delegate: Delegate) {
+  return delegate === 'NEUTRAL' ? Color.NEUTRAL : delegate.color;
 }

--- a/src/server/pathfinders/PathfindersExpansion.ts
+++ b/src/server/pathfinders/PathfindersExpansion.ts
@@ -164,7 +164,7 @@ export class PathfindersExpansion {
     case 'delegate':
       Turmoil.ifTurmoilElse(game,
         (turmoil) => {
-          if (turmoil.hasDelegatesInReserve(player.id)) {
+          if (turmoil.hasDelegatesInReserve(player)) {
             game.defer(new SendDelegateToArea(player));
           }
         },

--- a/src/server/turmoil/PoliticalAgendas.ts
+++ b/src/server/turmoil/PoliticalAgendas.ts
@@ -74,7 +74,7 @@ export class PoliticalAgendas {
     if (politicalAgendasData.agendaStyle === AgendaStyle.CHAIRMAN && chairman !== 'NEUTRAL') {
       const agenda = this.getAgenda(turmoil, rulingParty.name);
       game.defer(new ChoosePoliticalAgenda(
-        game.getPlayerById(chairman),
+        chairman,
         rulingParty,
         (bonusId) => {
           agenda.bonusId = bonusId;

--- a/src/server/turmoil/SerializedTurmoil.ts
+++ b/src/server/turmoil/SerializedTurmoil.ts
@@ -2,22 +2,23 @@ import {GlobalEventName} from '../../common/turmoil/globalEvents/GlobalEventName
 import {PartyName} from '../../common/turmoil/PartyName';
 import {SerializedGlobalEventDealer} from './globalEvents/SerializedGlobalEventDealer';
 import {SerializedPoliticalAgendasData} from './PoliticalAgendas';
-import {Delegate} from './Turmoil';
 import {PlayerId} from '../../common/Types';
 
 export type SerializedParty = {
     name: PartyName;
-    delegates: Array<Delegate>;
-    partyLeader: undefined | Delegate;
+    delegates: Array<SerializedDelegate>;
+    partyLeader?: SerializedDelegate;
 }
 
+export type SerializedDelegate = PlayerId | 'NEUTRAL';
+
 export type SerializedTurmoil = {
-    chairman: undefined | Delegate;
+    chairman: undefined | SerializedDelegate;
     rulingParty: PartyName;
     dominantParty: PartyName;
     lobby?: Array<PlayerId>;
-    usedFreeDelegateAction?: Array<PlayerId>;
-    delegateReserve: Array<Delegate>;
+    usedFreeDelegateAction: Array<PlayerId>;
+    delegateReserve: Array<SerializedDelegate>;
     parties: Array<SerializedParty>;
     playersInfluenceBonus: Array<[string, number]>;
     globalEventDealer: SerializedGlobalEventDealer;

--- a/src/server/turmoil/Turmoil.ts
+++ b/src/server/turmoil/Turmoil.ts
@@ -6,11 +6,10 @@ import {Unity} from './parties/Unity';
 import {Kelvinists} from './parties/Kelvinists';
 import {Reds} from './parties/Reds';
 import {Greens} from './parties/Greens';
-import {PlayerId} from '../../common/Types';
 import {IGame} from '../IGame';
 import {GlobalEventDealer, getGlobalEventByName} from './globalEvents/GlobalEventDealer';
 import {IGlobalEvent} from './globalEvents/IGlobalEvent';
-import {SerializedTurmoil} from './SerializedTurmoil';
+import {SerializedDelegate, SerializedTurmoil} from './SerializedTurmoil';
 import {DELEGATES_FOR_NEUTRAL_PLAYER, DELEGATES_PER_PLAYER} from '../../common/constants';
 import {PoliticalAgendasData, PoliticalAgendas} from './PoliticalAgendas';
 import {AgendaStyle} from '../../common/turmoil/Types';
@@ -23,9 +22,10 @@ import {IPlayer} from '../IPlayer';
 import {SendDelegateToArea} from '../deferredActions/SendDelegateToArea';
 import {SelectParty} from '../inputs/SelectParty';
 import {Policy, PolicyId, policyDescription} from './Policy';
+import {PlayerId} from '@/common/Types';
 
 export type NeutralPlayer = 'NEUTRAL';
-export type Delegate = PlayerId | NeutralPlayer;
+export type Delegate = IPlayer | NeutralPlayer;
 
 export type PartyFactory = new() => IParty;
 
@@ -51,7 +51,7 @@ export class Turmoil {
   public chairman: undefined | Delegate = undefined;
   public rulingParty: IParty;
   public dominantParty: IParty;
-  public usedFreeDelegateAction = new Set<PlayerId>();
+  public usedFreeDelegateAction = new Set<IPlayer>();
   public delegateReserve = new MultiSet<Delegate>();
   public parties = createParties();
   public playersInfluenceBonus = new Map<string, number>();
@@ -85,7 +85,7 @@ export class Turmoil {
     turmoil.parties = createParties();
 
     game.getPlayersInGenerationOrder().forEach((player) => {
-      turmoil.delegateReserve.add(player.id, DELEGATES_PER_PLAYER);
+      turmoil.delegateReserve.add(player, DELEGATES_PER_PLAYER);
     });
     // One Neutral delegate is already Chairman
     turmoil.delegateReserve.add('NEUTRAL', DELEGATES_FOR_NEUTRAL_PLAYER - 1);
@@ -354,18 +354,18 @@ export class Turmoil {
 
     // Finally, award Chairman benefits
     if (this.chairman !== 'NEUTRAL') {
-      const player = game.getPlayerById(this.chairman);
+      const chairman = this.chairman;
       let steps = gainTR ? 1 : 0;
       // Tempest Consultancy Hook (gains an additional TR when they become chairman)
-      if (player.isCorporation(CardName.TEMPEST_CONSULTANCY)) steps += 1;
+      if (chairman.isCorporation(CardName.TEMPEST_CONSULTANCY)) steps += 1;
 
       // Raise TR
-      game.defer(new SimpleDeferredAction(player, () => {
+      game.defer(new SimpleDeferredAction(chairman, () => {
         if (steps > 0) {
-          player.increaseTerraformRating(steps);
-          game.log('${0} is the new chairman and gains ${1} TR', (b) => b.player(player).number(steps));
+          chairman.increaseTerraformRating(steps);
+          game.log('${0} is the new chairman and gains ${1} TR', (b) => b.player(chairman).number(steps));
         } else {
-          game.log('${0} is the new chairman', (b) => b.player(player));
+          game.log('${0} is the new chairman', (b) => b.player(chairman));
         }
         return undefined;
       }));
@@ -414,11 +414,11 @@ export class Turmoil {
 
   public getPlayerInfluence(player: IPlayer) {
     let influence = 0;
-    if (this.chairman !== undefined && this.chairman === player.id) influence++;
+    if (this.chairman !== undefined && this.chairman === player) influence++;
 
     const dominantParty : IParty = this.dominantParty;
-    const isPartyLeader = dominantParty.partyLeader === player.id;
-    const delegateCount = dominantParty.delegates.get(player.id);
+    const isPartyLeader = dominantParty.partyLeader === player;
+    const delegateCount = dominantParty.delegates.get(player);
 
     if (isPartyLeader) {
       influence++;
@@ -466,7 +466,7 @@ export class Turmoil {
     }
 
     const party = this.getPartyByName(partyName);
-    return party.delegates.count(player.id) >= 2;
+    return party.delegates.count(player) >= 2;
   }
 
   /** Return the number of delegates for `delegate` in the reserve. */
@@ -491,9 +491,9 @@ export class Turmoil {
    */
   public getPlayerVictoryPoints(player: IPlayer): number {
     let victory = 0;
-    if (this.chairman === player.id) victory++;
+    if (this.chairman === player) victory++;
     this.parties.forEach((party) => {
-      if (party.partyLeader === player.id) {
+      if (party.partyLeader === player) {
         victory++;
       }
     });
@@ -501,9 +501,9 @@ export class Turmoil {
   }
 
   public getSendDelegateInput(player: IPlayer): SelectParty | undefined {
-    if (this.hasDelegatesInReserve(player.id)) {
+    if (this.hasDelegatesInReserve(player)) {
       let sendDelegate;
-      if (!this.usedFreeDelegateAction.has(player.id)) {
+      if (!this.usedFreeDelegateAction.has(player)) {
         sendDelegate = new SendDelegateToArea(player, 'Send a delegate in an area (from lobby)', {freeStandardAction: true});
       } else if (player.isCorporation(CardName.INCITE) && player.canAfford(3)) {
         sendDelegate = new SendDelegateToArea(player, 'Send a delegate in an area (3 M€)', {cost: 3});
@@ -519,16 +519,16 @@ export class Turmoil {
 
   public serialize(): SerializedTurmoil {
     const result: SerializedTurmoil = {
-      chairman: this.chairman,
+      chairman: serializeDelegateOrUndefined(this.chairman),
       rulingParty: this.rulingParty.name,
       dominantParty: this.dominantParty.name,
-      usedFreeDelegateAction: Array.from(this.usedFreeDelegateAction),
-      delegateReserve: Array.from(this.delegateReserve.values()),
+      usedFreeDelegateAction: Array.from(this.usedFreeDelegateAction).map((p) => p.id),
+      delegateReserve: Array.from(this.delegateReserve.values()).map(serializeDelegate),
       parties: this.parties.map((p) => {
         return {
           name: p.name,
-          delegates: Array.from(p.delegates.values()),
-          partyLeader: p.partyLeader,
+          delegates: Array.from(p.delegates.values()).map(serializeDelegate),
+          partyLeader: serializeDelegateOrUndefined(p.partyLeader),
         };
       }),
       playersInfluenceBonus: Array.from(this.playersInfluenceBonus.entries()),
@@ -543,22 +543,23 @@ export class Turmoil {
     return result;
   }
 
-  public static deserialize(d: SerializedTurmoil, playerIds: Array<IPlayer>): Turmoil {
+  public static deserialize(d: SerializedTurmoil, players: Array<IPlayer>): Turmoil {
     const dealer = GlobalEventDealer.deserialize(d.globalEventDealer);
-    const turmoil = new Turmoil(d.rulingParty, d.chairman || 'NEUTRAL', d.dominantParty, dealer);
+    const chairman = deserializeDelegateOrUndefined(d.chairman, players);
+    const turmoil = new Turmoil(d.rulingParty, chairman || 'NEUTRAL', d.dominantParty, dealer);
 
-    turmoil.usedFreeDelegateAction = new Set(d.usedFreeDelegateAction);
+    turmoil.usedFreeDelegateAction = new Set(d.usedFreeDelegateAction.map((p) => deserializePlayerId(p, players)));
 
-    turmoil.delegateReserve = MultiSet.from(d.delegateReserve);
+    turmoil.delegateReserve = MultiSet.from(d.delegateReserve.map((p) => deserializeDelegate(p, players)));
 
     if (d.lobby !== undefined) {
       turmoil.usedFreeDelegateAction.clear();
       const legacyLobby = new Set(d.lobby);
-      for (const player of playerIds) {
+      for (const player of players) {
         if (legacyLobby.has(player.id)) {
-          turmoil.delegateReserve.add(player.id);
+          turmoil.delegateReserve.add(player);
         } else {
-          turmoil.usedFreeDelegateAction.add(player.id);
+          turmoil.usedFreeDelegateAction.add(player);
         }
       }
     }
@@ -567,8 +568,8 @@ export class Turmoil {
 
     d.parties.forEach((sp) => {
       const tp = turmoil.getPartyByName(sp.name);
-      tp.delegates = MultiSet.from(sp.delegates);
-      tp.partyLeader = sp.partyLeader;
+      tp.delegates = MultiSet.from(sp.delegates.map((p) => deserializeDelegate(p, players)));
+      tp.partyLeader = deserializeDelegateOrUndefined(sp.partyLeader, players);
     });
 
     turmoil.playersInfluenceBonus = new Map<string, number>(d.playersInfluenceBonus);
@@ -585,4 +586,37 @@ export class Turmoil {
 
     return turmoil;
   }
+}
+
+function serializeDelegate(delegate: Delegate): SerializedDelegate {
+  return delegate === 'NEUTRAL' ? 'NEUTRAL' : delegate.id;
+}
+
+function serializeDelegateOrUndefined(delegate: Delegate | undefined): SerializedDelegate | undefined {
+  if (delegate === undefined) {
+    return undefined;
+  }
+  return serializeDelegate(delegate);
+}
+
+function deserializePlayerId(playerId: PlayerId, players: Array<IPlayer>): IPlayer {
+  const player = players.find((p) => p.id === playerId);
+  if (player === undefined) {
+    throw new Error('Delegate not found');
+  }
+  return player;
+}
+
+function deserializeDelegate(serializedDelegate: SerializedDelegate, players: Array<IPlayer>): Delegate {
+  if (serializedDelegate === 'NEUTRAL') {
+    return 'NEUTRAL';
+  }
+  return deserializePlayerId(serializedDelegate, players);
+}
+
+function deserializeDelegateOrUndefined(serializedDelegate: SerializedDelegate | undefined, players: Array<IPlayer>): Delegate | undefined {
+  if (serializedDelegate === undefined) {
+    return undefined;
+  }
+  return deserializeDelegate(serializedDelegate, players);
 }

--- a/src/server/turmoil/parties/Party.ts
+++ b/src/server/turmoil/parties/Party.ts
@@ -31,7 +31,7 @@ export abstract class Party {
         if (this.partyLeader === 'NEUTRAL') {
           currentIndex = players.indexOf(game.getPlayerById(game.activePlayer));
         } else {
-          currentIndex = players.indexOf(game.getPlayerById(this.partyLeader));
+          currentIndex = players.indexOf(this.partyLeader);
         }
 
         let playersToCheck: Array<IPlayer | NeutralPlayer> = [];
@@ -52,14 +52,8 @@ export abstract class Party {
         playersToCheck.push('NEUTRAL');
 
         playersToCheck.some((nextPlayer) => {
-          let nextPlayerId: Delegate;
-          if (nextPlayer === 'NEUTRAL') {
-            nextPlayerId = 'NEUTRAL';
-          } else {
-            nextPlayerId = nextPlayer.id;
-          }
-          if (this.delegates.get(nextPlayerId) === max) {
-            this.partyLeader = nextPlayerId;
+          if (this.delegates.get(nextPlayer) === max) {
+            this.partyLeader = nextPlayer;
             return true;
           }
           return false;

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -696,6 +696,7 @@ describe('Game', () => {
     game.moonData = undefined;
     game.pathfindersData = undefined;
     const serialized = game.serialize();
+    assertIsJSON(serialized);
     const serializedKeys = Object.keys(serialized);
 
     const unserializedFieldsInGame: Array<keyof Game> = [
@@ -873,3 +874,17 @@ describe('Game', () => {
     expect(deserialized.discardedColonies.map(toName)).has.members(discardedColonyNames);
   });
 });
+
+function assertIsJSON(serialized: any) {
+  for (const field in serialized) {
+    if (serialized.hasOwnProperty(field)) {
+      const val = serialized[field];
+      const type = typeof(val);
+      if (type === 'object') {
+        assertIsJSON(val);
+      } else if (type === 'function') {
+        throw new Error(field + ' is invalid');
+      }
+    }
+  }
+}

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -372,21 +372,21 @@ describe('Player', function() {
 
     const turmoil = game.turmoil!;
 
-    expect(turmoil.usedFreeDelegateAction.has(player.id)).is.false;
+    expect(turmoil.usedFreeDelegateAction.has(player)).is.false;
 
     const freeLobbyAction = cast(getSendADelegateOption(player), SelectParty);
 
     expect(freeLobbyAction.title).eq('Send a delegate in an area (from lobby)');
-    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player.id)).eq(0);
+    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player)).eq(0);
 
     freeLobbyAction.cb(PartyName.KELVINISTS);
     runAllActions(game);
 
-    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player.id)).eq(1);
+    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player)).eq(1);
 
     // Now the free lobby action is used, only the 5MC option is available.
     player.megaCredits = 4;
-    expect(turmoil.usedFreeDelegateAction.has(player.id)).is.true;
+    expect(turmoil.usedFreeDelegateAction.has(player)).is.true;
     expect(getSendADelegateOption(player)).is.undefined;
 
     player.megaCredits = 5;
@@ -398,7 +398,7 @@ describe('Player', function() {
     runAllActions(game);
 
     expect(player.megaCredits).eq(0);
-    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player.id)).eq(2);
+    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player)).eq(2);
   });
 
   it('Prelude action cycle', () => {

--- a/tests/cards/ceo/Greta.spec.ts
+++ b/tests/cards/ceo/Greta.spec.ts
@@ -91,12 +91,12 @@ describe('Greta', function() {
     player.setTerraformRating(20);
     player2.setTerraformRating(20);
     player.megaCredits = 0;
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
 
     card.action();
     turmoil.endGeneration(game);
     runAllActions(game);
-    expect(turmoil.chairman).to.eq(player.id);
+    expect(turmoil.chairman).to.eq(player);
     expect(player.getTerraformRating()).to.eq(20);
     expect(player.megaCredits).to.eq(0);
     expect(player2.getTerraformRating()).to.eq(19);

--- a/tests/cards/ceo/Oscar.spec.ts
+++ b/tests/cards/ceo/Oscar.spec.ts
@@ -30,12 +30,12 @@ describe('Oscar', function() {
 
   it('Takes OPG action', function() {
     turmoil.chairman = 'NEUTRAL';
-    const preActionDelegates = turmoil.delegateReserve.get(player.id);
+    const preActionDelegates = turmoil.delegateReserve.get(player);
     card.action(player);
     runAllActions(game);
-    expect(turmoil.chairman).eq(player.id);
+    expect(turmoil.chairman).eq(player);
     // Delegates in reserve decreases
-    expect(turmoil.delegateReserve.get(player.id)).is.eq(preActionDelegates - 1);
+    expect(turmoil.delegateReserve.get(player)).is.eq(preActionDelegates - 1);
   });
 
   it('Can only act once per game', function() {
@@ -48,12 +48,12 @@ describe('Oscar', function() {
   });
 
   it('Previous Chairman player gets their delegate back to reserve after Oscar OPG', function() {
-    turmoil.chairman = player2.id;
-    const prePlayer2Delegates = turmoil.delegateReserve.get(player2.id);
+    turmoil.chairman = player2;
+    const prePlayer2Delegates = turmoil.delegateReserve.get(player2);
     card.action(player);
     runAllActions(game);
-    expect(turmoil.chairman).eq(player.id);
-    expect(turmoil.delegateReserve.get(player2.id)).is.eq(prePlayer2Delegates + 1);
+    expect(turmoil.chairman).eq(player);
+    expect(turmoil.delegateReserve.get(player2)).is.eq(prePlayer2Delegates + 1);
   });
 
   it('Cannot take OPG if no delegates in reserve', function() {
@@ -64,7 +64,7 @@ describe('Oscar', function() {
 
   it('Cannot take OPG if already chairman', function() {
     expect(card.canAct(player)).is.true;
-    turmoil.chairman = player.id;
+    turmoil.chairman = player;
     expect(card.canAct(player)).is.false;
   });
 
@@ -72,7 +72,7 @@ describe('Oscar', function() {
     const tr = player.getTerraformRating();
     card.action(player);
     runAllActions(game);
-    expect(turmoil.chairman).eq(player.id);
+    expect(turmoil.chairman).eq(player);
     expect(player.getTerraformRating()).is.eq(tr);
   });
 
@@ -83,7 +83,7 @@ describe('Oscar', function() {
     card.action(player);
     runAllActions(game);
 
-    expect(turmoil.chairman).eq(player.id);
+    expect(turmoil.chairman).eq(player);
     expect(player.getTerraformRating()).is.eq(tr+1);
   });
 

--- a/tests/cards/ceo/Petra.spec.ts
+++ b/tests/cards/ceo/Petra.spec.ts
@@ -78,21 +78,21 @@ describe('Petra', function() {
     // Replace 4 delegates + chairman
     card.action(player);
 
-    expect(scientists.delegates.count(player.id)).eq(2);
-    expect(scientists.partyLeader).eq(player.id);
+    expect(scientists.delegates.count(player)).eq(2);
+    expect(scientists.partyLeader).eq(player);
 
-    expect(greens.delegates.count(player.id)).eq(1);
-    expect(greens.partyLeader).eq(player.id);
+    expect(greens.delegates.count(player)).eq(1);
+    expect(greens.partyLeader).eq(player);
 
-    expect(reds.delegates.count(player.id)).eq(1);
-    expect(reds.partyLeader).eq(player.id);
+    expect(reds.delegates.count(player)).eq(1);
+    expect(reds.partyLeader).eq(player);
 
     expect(player.megaCredits).to.eq(15);
 
     // Make sure that the player has the correct amount of spare delegates
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(2); // 1 Reserve + 1 Lobby
-    expect(turmoil.delegateReserve.has(player.id)).is.true;
-    expect(turmoil.chairman).eq(player.id);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(2); // 1 Reserve + 1 Lobby
+    expect(turmoil.delegateReserve.has(player)).is.true;
+    expect(turmoil.chairman).eq(player);
 
 
     // Send 3 Neutral delegates
@@ -116,18 +116,18 @@ describe('Petra', function() {
 
     // Replace 6 delegates + chairman
     card.action(player);
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(0);
-    expect(turmoil.delegateReserve.has(player.id)).is.false;
-    expect(turmoil.chairman).eq(player.id);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(0);
+    expect(turmoil.delegateReserve.has(player)).is.false;
+    expect(turmoil.chairman).eq(player);
 
-    expect(scientists.delegates.count(player.id)).eq(4);
-    expect(scientists.partyLeader).eq(player.id);
+    expect(scientists.delegates.count(player)).eq(4);
+    expect(scientists.partyLeader).eq(player);
 
-    expect(greens.delegates.count(player.id)).eq(1);
-    expect(greens.partyLeader).eq(player.id);
+    expect(greens.delegates.count(player)).eq(1);
+    expect(greens.partyLeader).eq(player);
 
-    expect(reds.delegates.count(player.id)).eq(1);
-    expect(reds.partyLeader).eq(player.id);
+    expect(reds.delegates.count(player)).eq(1);
+    expect(reds.partyLeader).eq(player);
 
     // We should have been paid 3MC for every swap, 7*3 total
     expect(player.megaCredits).to.eq(21);

--- a/tests/cards/ceo/Zan.spec.ts
+++ b/tests/cards/ceo/Zan.spec.ts
@@ -39,17 +39,17 @@ describe('Zan', function() {
   it('Takes OPG action', function() {
     const turmoil = game.turmoil!;
     player.megaCredits = 0;
-    const expectedMegagredits = turmoil.getAvailableDelegateCount(player.id);
+    const expectedMegagredits = turmoil.getAvailableDelegateCount(player);
     card.action(player);
     while (game.deferredActions.length) {
       game.deferredActions.pop()!.execute();
     }
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(0);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(0);
     expect(player.megaCredits).eq(expectedMegagredits);
 
     expect(turmoil.dominantParty.name).eq(PartyName.REDS);
-    expect(turmoil.dominantParty.partyLeader).eq(player.id);
+    expect(turmoil.dominantParty.partyLeader).eq(player);
     expect(card.isDisabled).is.true;
   });
 

--- a/tests/cards/community/ExecutiveOrder.spec.ts
+++ b/tests/cards/community/ExecutiveOrder.spec.ts
@@ -33,6 +33,6 @@ describe('ExecutiveOrder', function() {
     const selectParty = cast(game.deferredActions.pop()!.execute(), SelectParty);
     selectParty.cb(PartyName.MARS);
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
-    expect(marsFirst.delegates.get(player.id)).eq(2);
+    expect(marsFirst.delegates.get(player)).eq(2);
   });
 });

--- a/tests/cards/community/Incite.spec.ts
+++ b/tests/cards/community/Incite.spec.ts
@@ -43,11 +43,11 @@ describe('Incite', function() {
     sendDelegate.cb(PartyName.MARS);
 
     const marsFirst = game.turmoil!.getPartyByName(PartyName.MARS);
-    expect(marsFirst.delegates.get(player.id)).eq(2);
+    expect(marsFirst.delegates.get(player)).eq(2);
   });
 
   it('Lobbying costs 3MC', () => {
-    turmoil.usedFreeDelegateAction.add(player.id);
+    turmoil.usedFreeDelegateAction.add(player);
 
     player.megaCredits = 2;
     expect(getSendADelegateOption(player)).is.undefined;
@@ -56,12 +56,12 @@ describe('Incite', function() {
     const selectParty = cast(getSendADelegateOption(player), SelectParty);
 
     expect(selectParty.title).eq('Send a delegate in an area (3 M€)');
-    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player.id)).eq(0);
+    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player)).eq(0);
 
     selectParty.cb(PartyName.KELVINISTS);
     runAllActions(game);
 
     expect(player.megaCredits).eq(0);
-    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player.id)).eq(1);
+    expect(turmoil.getPartyByName(PartyName.KELVINISTS).delegates.get(player)).eq(1);
   });
 });

--- a/tests/cards/community/LeadershipSummit.spec.ts
+++ b/tests/cards/community/LeadershipSummit.spec.ts
@@ -14,10 +14,10 @@ describe('LeadershipSummit', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.dominantParty = turmoil.getPartyByName(PartyName.REDS);
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player);
 
     card.resolve(game, turmoil);
     expect(player.cardsInHand).has.lengthOf(1);

--- a/tests/cards/community/Pallas.spec.ts
+++ b/tests/cards/community/Pallas.spec.ts
@@ -8,6 +8,7 @@ import {Turmoil} from '../../../src/server/turmoil/Turmoil';
 import {SelectParty} from '../../../src/server/inputs/SelectParty';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {IParty} from '../../../src/server/turmoil/parties/IParty';
+import {MultiSet} from 'mnemonist';
 
 describe('Pallas', function() {
   let pallas: Pallas;
@@ -55,7 +56,7 @@ describe('Pallas', function() {
 
     const selectParty = cast(player.popWaitingFor(), SelectParty);
     selectParty.cb(PartyName.GREENS);
-    expect(Array.from(greens.delegates.values())).deep.eq([player.id]);
+    expect(greens.delegates).deep.eq(MultiSet.from([player]));
     expect(scientists.delegates.size).eq(0);
 
     runAllActions(game);
@@ -63,8 +64,8 @@ describe('Pallas', function() {
     const selectParty2 = cast(player.popWaitingFor(), SelectParty);
     selectParty2.cb(PartyName.SCIENTISTS);
 
-    expect(Array.from(greens.delegates.values())).deep.eq([player.id]);
-    expect(Array.from(scientists.delegates.values())).deep.eq([player.id]);
+    expect(greens.delegates).deep.eq(MultiSet.from([player]));
+    expect(scientists.delegates).deep.eq(MultiSet.from([player]));
 
     runAllActions(game);
 
@@ -74,9 +75,9 @@ describe('Pallas', function() {
   it('Should give trade bonus', function() {
     pallas.addColony(player);
     player.megaCredits = 0;
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.SCIENTISTS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
     pallas.trade(player2); // player2 is trading. But player(1) is getting the MC
     runAllActions(game);
     const sendDelegates = cast(player2.popWaitingFor(), SelectParty);
@@ -90,9 +91,9 @@ describe('Pallas', function() {
     pallas.addColony(player);
     player.megaCredits = 0;
     pallas.trackPosition = 2; // Send 1 delegate
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.SCIENTISTS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
     pallas.trade(player); // player(1) is trading and gaining the mc.
     runAllActions(game);
     const sendDelegates = cast(player.popWaitingFor(), SelectParty);

--- a/tests/cards/community/PoliticalUprising.spec.ts
+++ b/tests/cards/community/PoliticalUprising.spec.ts
@@ -30,7 +30,7 @@ describe('PoliticalUprising', function() {
 
     const turmoil = game.turmoil!;
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
-    expect(marsFirst.delegates.get(player.id)).eq(4);
+    expect(marsFirst.delegates.get(player)).eq(4);
     expect(player.cardsInHand).has.lengthOf(1);
   });
 });

--- a/tests/cards/moon/AnOfferYouCantRefuse.spec.ts
+++ b/tests/cards/moon/AnOfferYouCantRefuse.spec.ts
@@ -33,57 +33,57 @@ describe('AnOfferYouCantRefuse', () => {
   });
 
   it('can play fails, only active player delegates', () => {
-    populateParty(parties.unity, player.id);
+    populateParty(parties.unity, player);
     expect(card.canPlay(player)).is.false;
   });
 
   it('can play fails, only available player is leader.', () => {
-    populateParty(parties.unity, redPlayer.id);
-    expect(parties.unity.partyLeader).eq(redPlayer.id);
+    populateParty(parties.unity, redPlayer);
+    expect(parties.unity.partyLeader).eq(redPlayer);
     expect(card.canPlay(player)).is.false;
   });
 
   it('can play succeeds', () => {
-    populateParty(parties.unity, redPlayer.id, yellowPlayer.id);
-    expect(parties.unity.partyLeader).eq(redPlayer.id);
+    populateParty(parties.unity, redPlayer, yellowPlayer);
+    expect(parties.unity.partyLeader).eq(redPlayer);
     expect(card.canPlay(player)).is.true;
   });
 
   it('Simple test - cannot exchange', () => {
-    assertCannotExchange([redPlayer.id]);
+    assertCannotExchange([redPlayer]);
     assertCannotExchange(['NEUTRAL']);
-    assertCannotExchange([redPlayer.id, player.id]);
+    assertCannotExchange([redPlayer, player]);
   });
 
   it('Can exchange - all one party', () => {
     assertExchanges(
-      [redPlayer.id, redPlayer.id, redPlayer.id],
-      redPlayer.id,
+      [redPlayer, redPlayer, redPlayer],
+      redPlayer,
       [redPlayer]);
   });
 
   it('Can exchange - green', () => {
     assertExchanges(
-      [redPlayer.id, yellowPlayer.id],
-      redPlayer.id,
+      [redPlayer, yellowPlayer],
+      redPlayer,
       [yellowPlayer]);
   });
 
   it('Can exchange - I am party leader', () => {
     assertExchanges(
-      [player.id, yellowPlayer.id],
-      player.id,
+      [player, yellowPlayer],
+      player,
       [yellowPlayer]);
   });
 
   it('Cannot exchange - I am the party leader and it is just me and neutral', () => {
-    assertCannotExchange([player.id, 'NEUTRAL']);
+    assertCannotExchange([player, 'NEUTRAL']);
   });
 
   it('play', () => {
-    populateParty(parties.unity, player.id, player.id, redPlayer.id, redPlayer.id, yellowPlayer.id);
-    expect(parties.unity.partyLeader).eq(player.id);
-    populateParty(parties.reds, 'NEUTRAL', redPlayer.id, 'NEUTRAL', redPlayer.id);
+    populateParty(parties.unity, player, player, redPlayer, redPlayer, yellowPlayer);
+    expect(parties.unity.partyLeader).eq(player);
+    populateParty(parties.reds, 'NEUTRAL', redPlayer, 'NEUTRAL', redPlayer);
     expect(parties.reds.partyLeader).eq('NEUTRAL');
 
     expect(card.canPlay(player)).is.true;
@@ -96,16 +96,16 @@ describe('AnOfferYouCantRefuse', () => {
 
     // Now do a delegate exchange
     // Swap with Reds / red
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
-    expect(turmoil.getAvailableDelegateCount(redPlayer.id)).eq(7);
-    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer.id, redPlayer.id);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
+    expect(turmoil.getAvailableDelegateCount(redPlayer)).eq(7);
+    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer, redPlayer);
 
     const switchParties = cast(orOptions.options[2].cb(), OrOptions);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(6);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(6);
     // TODO(kberg): rewrite this test, because it shouldn't be possible for red to have this many delegates.
-    expect(turmoil.getAvailableDelegateCount(redPlayer.id)).eq(8);
-    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer.id, player.id);
+    expect(turmoil.getAvailableDelegateCount(redPlayer)).eq(8);
+    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer, player);
 
     // Now player may switch parties.
     expect(switchParties.options.map((option) => option.title)).deep.eq(
@@ -119,21 +119,21 @@ describe('AnOfferYouCantRefuse', () => {
       ]);
 
     // This is a repeat assertion from above but it makes the test easier to read.
-    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer.id, player.id);
+    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer, player);
     expectDelegates(parties.scientists, ...[]);
     expect(parties.scientists.partyLeader).is.undefined;
 
     // Choose scientists
     switchParties.options[1].cb();
 
-    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer.id);
-    expectDelegates(parties.scientists, player.id);
-    expect(parties.scientists.partyLeader).eq(player.id);
+    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer);
+    expectDelegates(parties.scientists, player);
+    expect(parties.scientists.partyLeader).eq(player);
   });
 
   it('play, player chooses not to switch parties', () => {
-    populateParty(parties.unity, player.id, redPlayer.id, yellowPlayer.id);
-    populateParty(parties.reds, 'NEUTRAL', redPlayer.id, 'NEUTRAL', redPlayer.id);
+    populateParty(parties.unity, player, redPlayer, yellowPlayer);
+    populateParty(parties.reds, 'NEUTRAL', redPlayer, 'NEUTRAL', redPlayer);
 
     const options = cast(card.play(player), OrOptions);
     assertOptions(
@@ -144,14 +144,14 @@ describe('AnOfferYouCantRefuse', () => {
 
     // Now do a delegate exchange
     // Swap with Reds / red
-    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer.id, redPlayer.id);
+    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer, redPlayer);
     const switchParties = cast(options.options[2].cb(), OrOptions);
-    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer.id, player.id);
+    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer, player);
 
     // Do not move
     switchParties.options[4].cb();
 
-    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer.id, player.id);
+    expectDelegates(parties.reds, 'NEUTRAL', 'NEUTRAL', redPlayer, player);
   });
 
   function expectDelegates(party: IParty, ...delegates: Array<Delegate>) {

--- a/tests/cards/moon/LunaPoliticalInstitute.spec.ts
+++ b/tests/cards/moon/LunaPoliticalInstitute.spec.ts
@@ -36,7 +36,7 @@ describe('LunaPoliticalInstitute', () => {
 
   it('can act', () => {
     turmoil.delegateReserve.clear();
-    turmoil.delegateReserve.add(player.id);
+    turmoil.delegateReserve.add(player);
     expect(card.canAct(player)).is.true;
 
     turmoil.delegateReserve.clear();
@@ -50,12 +50,12 @@ describe('LunaPoliticalInstitute', () => {
     card.action(player);
     expect(game.deferredActions).has.lengthOf(1);
 
-    expect(marsFirst.delegates.get(player.id)).eq(0);
+    expect(marsFirst.delegates.get(player)).eq(0);
 
     const selectParty = cast(game.deferredActions.peek()!.execute(), SelectParty);
     selectParty.cb(PartyName.MARS);
 
-    expect(marsFirst.delegates.get(player.id)).eq(1);
+    expect(marsFirst.delegates.get(player)).eq(1);
   });
 });
 

--- a/tests/cards/moon/TempestConsultancy.spec.ts
+++ b/tests/cards/moon/TempestConsultancy.spec.ts
@@ -9,7 +9,6 @@ import {SelectParty} from '../../../src/server/inputs/SelectParty';
 import {Greens} from '../../../src/server/turmoil/parties/Greens';
 import {cast, runAllActions} from '../../TestingUtils';
 import {VoteOfNoConfidence} from '../../../src/server/cards/turmoil/VoteOfNoConfidence';
-import {isPlayerId, PlayerId} from '../../../src/common/Types';
 
 describe('TempestConsultancy', () => {
   let player: TestPlayer;
@@ -43,42 +42,42 @@ describe('TempestConsultancy', () => {
 
   it('action, 1 delegate', () => {
     player.tagsForTest = {moon: 5};
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
     // This test is brittle - it assumes mars first will be orOptions[0]. But OK.
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
-    expect(marsFirst.delegates.get(player.id)).eq(0);
+    expect(marsFirst.delegates.get(player)).eq(0);
     card.action(player);
-    const action = player.game.deferredActions.pop() as SendDelegateToArea;
+    const action = cast(player.game.deferredActions.pop(), SendDelegateToArea);
     const options = action.execute();
     options!.cb(marsFirst.name);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(6);
-    expect(marsFirst.delegates.get(player.id)).eq(1);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(6);
+    expect(marsFirst.delegates.get(player)).eq(1);
   });
 
   it('action, 3 delegates', () => {
     player.tagsForTest = {moon: 16};
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
     // This test is brittle - it assumes mars first will be orOptions[0]. But OK.
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
-    expect(marsFirst.delegates.get(player.id)).eq(0);
+    expect(marsFirst.delegates.get(player)).eq(0);
     card.action(player);
     const action = cast(player.game.deferredActions.pop(), SendDelegateToArea);
     const options = cast(action.execute(), SelectParty);
     options.cb(marsFirst.name);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(4);
-    expect(marsFirst.delegates.get(player.id)).eq(3);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(4);
+    expect(marsFirst.delegates.get(player)).eq(3);
   });
 
   it('action, 3 delegates, only 2 available', () => {
     player.tagsForTest = {moon: 16};
     turmoil.delegateReserve.clear();
-    turmoil.delegateReserve.add(player.id, 2);
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(2);
+    turmoil.delegateReserve.add(player, 2);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(2);
     // This test is brittle - it assumes mars first will be orOptions[0]. But OK.
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
-    expect(marsFirst.delegates.get(player.id)).eq(0);
+    expect(marsFirst.delegates.get(player)).eq(0);
 
     card.action(player);
 
@@ -86,20 +85,20 @@ describe('TempestConsultancy', () => {
     const options = cast(action.execute(), SelectParty);
     options.cb(marsFirst.name);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(0);
-    expect(marsFirst.delegates.get(player.id)).eq(2);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(0);
+    expect(marsFirst.delegates.get(player)).eq(2);
   });
 
   it('new chairman', () => {
     player.setCorporationForTest(card);
     turmoil.dominantParty = new Greens();
-    turmoil.dominantParty.partyLeader = player.id;
+    turmoil.dominantParty.partyLeader = player;
     expect(player.getTerraformRating()).eq(20);
 
     turmoil.setRulingParty(game);
     runAllActions(game);
 
-    expect(turmoil.chairman).eq(player.id);
+    expect(turmoil.chairman).eq(player);
     expect(player.getTerraformRating()).eq(22);
   });
 
@@ -108,15 +107,14 @@ describe('TempestConsultancy', () => {
     turmoil.chairman = 'NEUTRAL';
 
     const greens = turmoil.getPartyByName(PartyName.GREENS);
-    greens.partyLeader = player.id;
+    greens.partyLeader = player;
 
     expect(player.getTerraformRating()).to.eq(20);
 
     const voteOfNoConfidence = new VoteOfNoConfidence();
     voteOfNoConfidence.play(player);
 
-    expect(isPlayerId(turmoil.chairman)).is.true;
-    expect(game.getPlayerById(turmoil.chairman as PlayerId)).to.eq(player);
+    expect(turmoil.chairman).eq(player);
     runAllActions(game);
     // With Vote of No Confidence, player becomes chairman and gains 1 TR. Tempest gives player a second TR.
     expect(player.getTerraformRating()).to.eq(22);

--- a/tests/cards/pathfinders/BalancedDevelopment.spec.ts
+++ b/tests/cards/pathfinders/BalancedDevelopment.spec.ts
@@ -18,10 +18,10 @@ describe('BalancedDevelopment', function() {
     player2.playedCards.push(new PowerPlant());
     player2.playedCards.push(new PowerPlant());
 
-    turmoil.chairman = player2.id;
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.chairman = player2;
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
 

--- a/tests/cards/pathfinders/CommunicationBoom.spec.ts
+++ b/tests/cards/pathfinders/CommunicationBoom.spec.ts
@@ -31,12 +31,12 @@ describe('CommunicationBoom', function() {
     player2.megaCredits = 12;
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player.id);
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player);
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
 

--- a/tests/cards/pathfinders/ConstantStruggle.spec.ts
+++ b/tests/cards/pathfinders/ConstantStruggle.spec.ts
@@ -13,12 +13,12 @@ describe('ConstantStruggle', function() {
     player2.megaCredits = 12;
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player.id);
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player);
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     expect(game.pathfindersData).deep.eq({
       venus: -1,

--- a/tests/cards/pathfinders/DeclarationOfIndependence.spec.ts
+++ b/tests/cards/pathfinders/DeclarationOfIndependence.spec.ts
@@ -34,15 +34,15 @@ describe('DeclarationOfIndependence', function() {
 
 
   it('play', function() {
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
-    expect(marsFirst.delegates.get(player.id)).eq(0);
+    expect(marsFirst.delegates.get(player)).eq(0);
     card.play(player);
     runAllActions(player.game);
     const action = cast(player.getWaitingFor(), SelectParty);
     action.cb(marsFirst.name);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(5);
-    expect(marsFirst.delegates.get(player.id)).eq(2);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(5);
+    expect(marsFirst.delegates.get(player)).eq(2);
   });
 });

--- a/tests/cards/pathfinders/ExperiencedMartians.spec.ts
+++ b/tests/cards/pathfinders/ExperiencedMartians.spec.ts
@@ -36,20 +36,20 @@ describe('ExperiencedMartians', function() {
     expect(player.cardsInHand).has.members([a, c]);
     expect(player.production.asUnits()).deep.eq(Units.of({megacredits: 2}));
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
 
     expect(game.deferredActions.length).eq(1);
 
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
-    expect(marsFirst.delegates.get(player.id)).eq(0);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
+    expect(marsFirst.delegates.get(player)).eq(0);
 
     const action = cast(game.deferredActions.pop(), SendDelegateToArea);
     const options = cast(action.execute(), SelectParty);
     options.cb(marsFirst.name);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(6);
-    expect(marsFirst.delegates.get(player.id)).eq(1);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(6);
+    expect(marsFirst.delegates.get(player)).eq(1);
   });
 });

--- a/tests/cards/pathfinders/LobbyHalls.spec.ts
+++ b/tests/cards/pathfinders/LobbyHalls.spec.ts
@@ -38,7 +38,7 @@ describe('LobbyHalls', function() {
   });
 
   it('play, has a delegate', () => {
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
     expect(card.tags).deep.eq([Tag.CLONE, Tag.BUILDING]);
 
     card.play(player);
@@ -61,13 +61,13 @@ describe('LobbyHalls', function() {
   function assertAddDelegateAction(action: SendDelegateToArea) {
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
-    expect(marsFirst.delegates.get(player.id)).eq(0);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
+    expect(marsFirst.delegates.get(player)).eq(0);
 
     const options = cast(action.execute(), SelectParty);
     options.cb(marsFirst.name);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(6);
-    expect(marsFirst.delegates.get(player.id)).eq(1);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(6);
+    expect(marsFirst.delegates.get(player)).eq(1);
   }
 });

--- a/tests/cards/pathfinders/MindSetMars.spec.ts
+++ b/tests/cards/pathfinders/MindSetMars.spec.ts
@@ -62,7 +62,7 @@ describe('MindSetMars', function() {
     expect(game.deferredActions).is;
 
     turmoil.delegateReserve.clear();
-    turmoil.delegateReserve.add(player.id, 3);
+    turmoil.delegateReserve.add(player, 3);
     cast(card.action(player), SelectOption).cb(undefined);
     expect(game.deferredActions.length).eq(1);
     assertSendDelegateToArea(player, game.deferredActions.pop()!);
@@ -82,7 +82,7 @@ describe('MindSetMars', function() {
   it('both are available, place delegates', () => {
     card.resourceCount = 7;
 
-    turmoil.delegateReserve.add(player.id, 3);
+    turmoil.delegateReserve.add(player, 3);
     const options = cast(card.action(player), OrOptions);
     expect(options.options).has.length(2);
 
@@ -97,7 +97,7 @@ describe('MindSetMars', function() {
   it('both are available, place a city', () => {
     card.resourceCount = 7;
 
-    turmoil.delegateReserve.add(player.id, 3);
+    turmoil.delegateReserve.add(player, 3);
     const options = cast(card.action(player), OrOptions);
     expect(options.options).has.length(2);
 

--- a/tests/cards/pathfinders/Odyssey.spec.ts
+++ b/tests/cards/pathfinders/Odyssey.spec.ts
@@ -196,10 +196,10 @@ describe('Odyssey', () => {
 
     player.playedCards.push(new ThoriumRush()); // Event: Building, Moon
 
-    turmoil.chairman = player.id;
+    turmoil.chairman = player;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player.id;
-    turmoil.dominantParty.delegates.add(player.id);
+    turmoil.dominantParty.partyLeader = player;
+    turmoil.dominantParty.delegates.add(player);
 
     // Not enough tags, because the event does not count.
     diversity.resolve(game, turmoil);

--- a/tests/cards/pathfinders/SpaceRaceToMars.spec.ts
+++ b/tests/cards/pathfinders/SpaceRaceToMars.spec.ts
@@ -83,12 +83,12 @@ describe('SpaceRaceToMars', function() {
   });
 
   it('Energy bump', function() {
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player.id);
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player);
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
 

--- a/tests/cards/pathfinders/TiredEarth.spec.ts
+++ b/tests/cards/pathfinders/TiredEarth.spec.ts
@@ -21,10 +21,10 @@ describe('TiredEarth', function() {
     player.plants = 20;
     player2.plants = 20;
 
-    turmoil.chairman = player2.id;
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.chairman = player2;
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
 

--- a/tests/cards/pathfinders/assertions.ts
+++ b/tests/cards/pathfinders/assertions.ts
@@ -16,14 +16,14 @@ export function assertSendDelegateToArea(player: IPlayer, action: DeferredAction
   const turmoil = game.turmoil!;
   const marsFirst = turmoil.getPartyByName(PartyName.MARS);
 
-  const delegatesInReserve = turmoil.getAvailableDelegateCount(player.id);
-  const delegatesInParty = marsFirst.delegates.get(player.id);
+  const delegatesInReserve = turmoil.getAvailableDelegateCount(player);
+  const delegatesInParty = marsFirst.delegates.get(player);
 
   const options = cast(sendDelegate.execute(), SelectParty);
   options.cb(marsFirst.name);
 
-  expect(turmoil.getAvailableDelegateCount(player.id)).eq(delegatesInReserve - 1);
-  expect(marsFirst.delegates.get(player.id)).eq(delegatesInParty + 1);
+  expect(turmoil.getAvailableDelegateCount(player)).eq(delegatesInReserve - 1);
+  expect(marsFirst.delegates.get(player)).eq(delegatesInParty + 1);
 }
 
 export function assertPlaceCityTile(player: IPlayer, action: DeferredAction) {

--- a/tests/cards/requirements/CardRequirements.spec.ts
+++ b/tests/cards/requirements/CardRequirements.spec.ts
@@ -95,7 +95,7 @@ describe('CardRequirements', function() {
   it('satisfies properly for chairman', function() {
     const requirements = {chairman: true};
     expect(satisfies(requirements, player)).eq(false);
-    player.game.turmoil!.chairman = player.id;
+    player.game.turmoil!.chairman = player;
     expect(satisfies(requirements, player)).eq(true);
   });
 
@@ -160,7 +160,7 @@ describe('CardRequirements', function() {
     const requirements = {partyLeader: 1};
     expect(satisfies(requirements, player)).eq(false);
     const greens = player.game.turmoil!.getPartyByName(PartyName.GREENS);
-    greens.partyLeader = player.id;
+    greens.partyLeader = player;
     expect(satisfies(requirements, player)).eq(true);
   });
 
@@ -227,8 +227,8 @@ describe('CardRequirements', function() {
   it('satisfies properly for party', function() {
     const requirements = {party: PartyName.MARS};
     expect(satisfies(requirements, player)).eq(false);
-    player.game.turmoil!.sendDelegateToParty(player.id, PartyName.MARS, player.game);
-    player.game.turmoil!.sendDelegateToParty(player.id, PartyName.MARS, player.game);
+    player.game.turmoil!.sendDelegateToParty(player, PartyName.MARS, player.game);
+    player.game.turmoil!.sendDelegateToParty(player, PartyName.MARS, player.game);
     expect(satisfies(requirements, player)).eq(true);
   });
 

--- a/tests/cards/starwars/BeholdTheEmperor.spec.ts
+++ b/tests/cards/starwars/BeholdTheEmperor.spec.ts
@@ -26,11 +26,11 @@ describe('BeholdTheEmperor', () => {
 
     expect(card.canPlay(player)).is.false;
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
 
     expect(card.canPlay(player)).is.false;
 
-    turmoil.chairman = player.id;
+    turmoil.chairman = player;
 
     expect(card.canPlay(player)).is.true;
   });
@@ -46,16 +46,16 @@ describe('BeholdTheEmperor', () => {
       party.delegates.clear();
     });
 
-    turmoil.chairman = player.id;
+    turmoil.chairman = player;
     turmoil.rulingParty = kelvinists;
 
-    turmoil.sendDelegateToParty(player2.id, PartyName.REDS, game);
-    turmoil.sendDelegateToParty(player2.id, PartyName.REDS, game);
-    turmoil.sendDelegateToParty(player2.id, PartyName.REDS, game);
-    turmoil.sendDelegateToParty(player2.id, PartyName.REDS, game);
-    turmoil.sendDelegateToParty(player2.id, PartyName.REDS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player2, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player2, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player2, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player2, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player2, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
 
     card.play(player);
 
@@ -67,7 +67,7 @@ describe('BeholdTheEmperor', () => {
     turmoil.endGeneration(game);
     runAllActions(game);
 
-    expect(turmoil.chairman).to.eq(player.id);
+    expect(turmoil.chairman).to.eq(player);
     expect(player.getTerraformRating()).to.eq(20);
     expect(player2.getTerraformRating()).to.eq(19);
 

--- a/tests/cards/turmoil/AerialLenses.spec.ts
+++ b/tests/cards/turmoil/AerialLenses.spec.ts
@@ -24,7 +24,7 @@ describe('AerialLenses', function() {
     expect(player.simpleCanPlay(card)).is.not.true;
 
     const kelvinists = game.turmoil!.getPartyByName(PartyName.KELVINISTS);
-    kelvinists.delegates.add(player.id, 2);
+    kelvinists.delegates.add(player, 2);
     expect(player.simpleCanPlay(card)).is.true;
   });
 

--- a/tests/cards/turmoil/BannedDelegate.spec.ts
+++ b/tests/cards/turmoil/BannedDelegate.spec.ts
@@ -25,17 +25,17 @@ describe('Banned Delegate', function() {
   });
 
   it('Cannot play', function() {
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     expect(player.simpleCanPlay(card)).is.not.true;
   });
 
   it('Should play', function() {
-    turmoil.chairman = player.id;
+    turmoil.chairman = player;
     expect(player.simpleCanPlay(card)).is.true;
 
     const greens = turmoil.getPartyByName(PartyName.GREENS);
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
-    turmoil.sendDelegateToParty(player2.id, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player2, PartyName.GREENS, game);
 
     // This card returns OrOptions, or SelectDelegate. It's
     // By putting 2 delegates in the Reds party, Reds is a second option.
@@ -51,13 +51,13 @@ describe('Banned Delegate', function() {
   });
 
   it('Removes duplicates', function() {
-    turmoil.chairman = player.id;
+    turmoil.chairman = player;
     expect(player.simpleCanPlay(card)).is.true;
 
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
-    turmoil.sendDelegateToParty(player2.id, PartyName.GREENS, game);
-    turmoil.sendDelegateToParty(player2.id, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player2, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player2, PartyName.GREENS, game);
     turmoil.sendDelegateToParty('NEUTRAL', PartyName.GREENS, game);
     turmoil.sendDelegateToParty('NEUTRAL', PartyName.GREENS, game);
 

--- a/tests/cards/turmoil/CulturalMetropolis.spec.ts
+++ b/tests/cards/turmoil/CulturalMetropolis.spec.ts
@@ -26,8 +26,8 @@ describe('Cultural Metropolis', function() {
   });
 
   it('Can not play without energy production', function() {
-    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game);
+    turmoil.sendDelegateToParty(player, PartyName.UNITY, game);
+    turmoil.sendDelegateToParty(player, PartyName.UNITY, game);
     expect(card.canPlay(player)).is.not.true;
   });
 
@@ -39,21 +39,21 @@ describe('Cultural Metropolis', function() {
 
   it('Can not play without 2 delegates available', function() {
     player.production.add(Resource.ENERGY, 1);
-    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game);
-    while (turmoil.getAvailableDelegateCount(player.id) > 2) {
-      turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player, PartyName.UNITY, game);
+    turmoil.sendDelegateToParty(player, PartyName.UNITY, game);
+    while (turmoil.getAvailableDelegateCount(player) > 2) {
+      turmoil.sendDelegateToParty(player, PartyName.REDS, game);
     }
-    expect(turmoil.getAvailableDelegateCount(player.id)).to.equal(2);
+    expect(turmoil.getAvailableDelegateCount(player)).to.equal(2);
     expect(card.canPlay(player)).is.true;
-    turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player, PartyName.REDS, game);
     expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play without an available city space', () => {
     player.production.add(Resource.ENERGY, 1);
-    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game);
+    turmoil.sendDelegateToParty(player, PartyName.UNITY, game);
+    turmoil.sendDelegateToParty(player, PartyName.UNITY, game);
 
     const availableCitySpaces = [...game.board.getAvailableSpacesForCity(player)];
     const savedSpace = availableCitySpaces.pop()!;
@@ -73,11 +73,11 @@ describe('Cultural Metropolis', function() {
     const startingUnityDelegateCount = unity.delegates.size;
 
     player.production.add(Resource.ENERGY, 1);
-    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game);
+    turmoil.sendDelegateToParty(player, PartyName.UNITY, game);
+    turmoil.sendDelegateToParty(player, PartyName.UNITY, game);
 
     expect(unity.delegates.size).eq(startingUnityDelegateCount + 2);
-    expect(turmoil.getAvailableDelegateCount(player.id)).to.equal(5);
+    expect(turmoil.getAvailableDelegateCount(player)).to.equal(5);
     expect(card.canPlay(player)).is.true;
 
     card.play(player);

--- a/tests/cards/turmoil/DiasporaMovement.spec.ts
+++ b/tests/cards/turmoil/DiasporaMovement.spec.ts
@@ -27,13 +27,13 @@ describe('DiasporaMovement', function() {
   });
 
   it('Can not play', function() {
-    reds.sendDelegate(player.id, game);
+    reds.sendDelegate(player, game);
     expect(player.simpleCanPlay(card)).is.not.true;
   });
 
   it('Should play', function() {
-    reds.sendDelegate(player.id, game);
-    reds.sendDelegate(player.id, game);
+    reds.sendDelegate(player, game);
+    reds.sendDelegate(player, game);
     expect(player.simpleCanPlay(card)).is.true;
 
     player.playedCards.push(new ColonizerTrainingCamp());

--- a/tests/cards/turmoil/EventAnalysts.spec.ts
+++ b/tests/cards/turmoil/EventAnalysts.spec.ts
@@ -9,9 +9,9 @@ describe('EventAnalysts', function() {
     const [game, player] = testGame(1, {turmoilExtension: true});
     expect(player.simpleCanPlay(card)).is.not.true;
 
-    game.turmoil!.sendDelegateToParty(player.id, PartyName.SCIENTISTS, game);
-    game.turmoil!.sendDelegateToParty(player.id, PartyName.SCIENTISTS, game);
-    game.turmoil!.sendDelegateToParty(player.id, PartyName.SCIENTISTS, game);
+    game.turmoil!.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
+    game.turmoil!.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
+    game.turmoil!.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
     expect(player.simpleCanPlay(card)).is.true;
 
     card.play(player);

--- a/tests/cards/turmoil/GMOContract.spec.ts
+++ b/tests/cards/turmoil/GMOContract.spec.ts
@@ -12,7 +12,7 @@ describe('GMOContract', function() {
     turmoil.rulingParty = turmoil.getPartyByName(PartyName.REDS);
     expect(player.simpleCanPlay(card)).is.not.true;
     const greens = turmoil.getPartyByName(PartyName.GREENS);
-    greens.delegates.add(player.id, 2);
+    greens.delegates.add(player, 2);
     expect(player.simpleCanPlay(card)).is.true;
     card.play(player);
     card.onCardPlayed(player, card);

--- a/tests/cards/turmoil/MartianMediaCenter.spec.ts
+++ b/tests/cards/turmoil/MartianMediaCenter.spec.ts
@@ -11,7 +11,7 @@ describe('MartianMediaCenter', function() {
     expect(card.canPlay(player)).is.not.true;
 
     const mars = game.turmoil!.getPartyByName(PartyName.MARS);
-    mars.delegates.add(player.id, 2);
+    mars.delegates.add(player, 2);
     expect(card.canPlay(player)).is.true;
 
     card.play(player);

--- a/tests/cards/turmoil/PROffice.spec.ts
+++ b/tests/cards/turmoil/PROffice.spec.ts
@@ -15,7 +15,7 @@ describe('PROffice', function() {
     expect(player.simpleCanPlay(card)).is.not.true;
 
     const unity = game.turmoil!.getPartyByName(PartyName.UNITY);
-    unity.delegates.add(player.id, 2);
+    unity.delegates.add(player, 2);
     expect(player.simpleCanPlay(card)).is.true;
 
     player.playedCards.push(card2, card3);

--- a/tests/cards/turmoil/ParliamentHall.spec.ts
+++ b/tests/cards/turmoil/ParliamentHall.spec.ts
@@ -15,7 +15,7 @@ describe('ParliamentHall', function() {
     expect(player.simpleCanPlay(card)).is.not.true;
 
     const mars = game.turmoil!.getPartyByName(PartyName.MARS);
-    mars.delegates.add(player.id, 2);
+    mars.delegates.add(player, 2);
     expect(player.simpleCanPlay(card)).is.true;
 
     player.playedCards.push(card2, card3);

--- a/tests/cards/turmoil/PoliticalAlliance.spec.ts
+++ b/tests/cards/turmoil/PoliticalAlliance.spec.ts
@@ -21,15 +21,15 @@ describe('PoliticalAlliance', function() {
 
   it('Can not play', function() {
     const greens = turmoil.getPartyByName(PartyName.GREENS);
-    greens.partyLeader = player.id;
+    greens.partyLeader = player;
     expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     const greens = turmoil.getPartyByName(PartyName.GREENS);
     const reds = turmoil.getPartyByName(PartyName.REDS);
-    greens.partyLeader = player.id;
-    reds.partyLeader = player.id;
+    greens.partyLeader = player;
+    reds.partyLeader = player;
     expect(card.canPlay(player)).is.true;
 
     card.play(player);

--- a/tests/cards/turmoil/PublicCelebrations.spec.ts
+++ b/tests/cards/turmoil/PublicCelebrations.spec.ts
@@ -9,7 +9,7 @@ describe('PublicCelebrations', function() {
 
     expect(player.simpleCanPlay(card)).is.not.true;
 
-    game.turmoil!.chairman = player.id;
+    game.turmoil!.chairman = player;
     expect(player.simpleCanPlay(card)).is.true;
     card.play(player);
   });

--- a/tests/cards/turmoil/RedTourismWave.spec.ts
+++ b/tests/cards/turmoil/RedTourismWave.spec.ts
@@ -21,7 +21,7 @@ describe('RedTourismWave', function() {
     expect(player.simpleCanPlay(card)).is.not.true;
 
     const reds = game.turmoil!.getPartyByName(PartyName.REDS);
-    reds.delegates.add(player.id, 2);
+    reds.delegates.add(player, 2);
     expect(player.simpleCanPlay(card)).is.true;
   });
 

--- a/tests/cards/turmoil/SeptumTribus.spec.ts
+++ b/tests/cards/turmoil/SeptumTribus.spec.ts
@@ -14,14 +14,14 @@ describe('SeptumTribus', function() {
 
     const turmoil = game.turmoil!;
 
-    turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player, PartyName.REDS, game);
+    turmoil.sendDelegateToParty(player, PartyName.REDS, game);
     card.action(player);
     expect(player.megaCredits).to.eq(2);
 
     player.megaCredits = 0;
-    turmoil.sendDelegateToParty(player.id, PartyName.KELVINISTS, game);
-    turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+    turmoil.sendDelegateToParty(player, PartyName.KELVINISTS, game);
+    turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
     card.action(player);
     expect(player.megaCredits).to.eq(6);
   });

--- a/tests/cards/turmoil/SponsoredMohole.spec.ts
+++ b/tests/cards/turmoil/SponsoredMohole.spec.ts
@@ -10,7 +10,7 @@ describe('SponsoredMohole', function() {
     expect(card.canPlay(player)).is.not.true;
 
     const kelvinists = game.turmoil!.getPartyByName(PartyName.KELVINISTS);
-    kelvinists.delegates.add(player.id, 2);
+    kelvinists.delegates.add(player, 2);
     expect(card.canPlay(player)).is.true;
 
     card.play(player);

--- a/tests/cards/turmoil/SupportedResearch.spec.ts
+++ b/tests/cards/turmoil/SupportedResearch.spec.ts
@@ -10,7 +10,7 @@ describe('SupportedResearch', function() {
     expect(player.simpleCanPlay(card)).is.not.true;
 
     const scientists = game.turmoil!.getPartyByName(PartyName.SCIENTISTS);
-    scientists.delegates.add(player.id, 2);
+    scientists.delegates.add(player, 2);
     expect(player.simpleCanPlay(card)).is.true;
 
     card.play(player);

--- a/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
+++ b/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
@@ -2,7 +2,6 @@ import {expect} from 'chai';
 import {VoteOfNoConfidence} from '../../../src/server/cards/turmoil/VoteOfNoConfidence';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {runAllActions} from '../../TestingUtils';
-import {isPlayerId, PlayerId} from '../../../src/common/Types';
 import {testGame} from '../../TestGame';
 
 describe('VoteOfNoConfidence', function() {
@@ -16,12 +15,11 @@ describe('VoteOfNoConfidence', function() {
     expect(player.simpleCanPlay(card)).is.not.true;
 
     const greens = game.turmoil!.getPartyByName(PartyName.GREENS);
-    greens.partyLeader = player.id;
+    greens.partyLeader = player;
     expect(player.simpleCanPlay(card)).is.true;
 
     card.play(player);
-    expect(isPlayerId(turmoil.chairman)).is.true;
-    expect(game.getPlayerById(turmoil.chairman as PlayerId)).to.eq(player);
+    expect(turmoil.chairman).to.eq(player);
     runAllActions(game);
     expect(player.getTerraformRating()).to.eq(15);
   });
@@ -33,7 +31,7 @@ describe('VoteOfNoConfidence', function() {
     const neutralReserve = turmoil.getAvailableDelegateCount('NEUTRAL');
     turmoil.chairman = 'NEUTRAL';
     const greens = game.turmoil!.getPartyByName(PartyName.GREENS);
-    greens.partyLeader = player.id;
+    greens.partyLeader = player;
     card.play(player);
     runAllActions(game);
     expect(turmoil.getAvailableDelegateCount('NEUTRAL')).to.eq(neutralReserve+1);

--- a/tests/cards/turmoil/WildlifeDome.spec.ts
+++ b/tests/cards/turmoil/WildlifeDome.spec.ts
@@ -56,7 +56,7 @@ describe('WildlifeDome', function() {
     turmoil.rulingParty = reds;
     PoliticalAgendas.setNextAgenda(turmoil, game);
 
-    greens.delegates.add(player.id, 2);
+    greens.delegates.add(player, 2);
     expect(player.canPlay(card)).is.not.true;
 
     player.megaCredits = 17;

--- a/tests/cards/underworld/ElectionSponsorship.spec.ts
+++ b/tests/cards/underworld/ElectionSponsorship.spec.ts
@@ -17,18 +17,18 @@ describe('ElectionSponsorship', () => {
     cast(card.play(player), undefined);
     runAllActions(game);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
 
     const marsFirst = turmoil.getPartyByName(PartyName.MARS);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(7);
-    expect(marsFirst.delegates.get(player.id)).eq(0);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(7);
+    expect(marsFirst.delegates.get(player)).eq(0);
 
     const selectParty = cast(player.popWaitingFor(), SelectParty);
     selectParty.cb(marsFirst.name);
 
-    expect(turmoil.getAvailableDelegateCount(player.id)).eq(6);
-    expect(marsFirst.delegates.get(player.id)).eq(1);
+    expect(turmoil.getAvailableDelegateCount(player)).eq(6);
+    expect(marsFirst.delegates.get(player)).eq(1);
 
     expect(player.underworldData.corruption).eq(1);
   });

--- a/tests/globalEvents/AquiferReleasedByPublicCouncil.spec.ts
+++ b/tests/globalEvents/AquiferReleasedByPublicCouncil.spec.ts
@@ -14,12 +14,12 @@ describe('AquiferReleasedByPublicCouncil', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player.id);
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player);
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.steel).to.eq(1);

--- a/tests/globalEvents/AsteroidMining.spec.ts
+++ b/tests/globalEvents/AsteroidMining.spec.ts
@@ -19,11 +19,11 @@ describe('AsteroidMining', function() {
     player2.playedCards.push(new MethaneFromTitan());
     player2.playedCards.push(new MethaneFromTitan());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.titanium).to.eq(1);

--- a/tests/globalEvents/CelebrityLeaders.spec.ts
+++ b/tests/globalEvents/CelebrityLeaders.spec.ts
@@ -19,11 +19,11 @@ describe('CelebrityLeaders', function() {
     player2.playedCards.push(new Virus());
     player2.playedCards.push(new Virus());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     player.megaCredits = 10;
     player2.megaCredits = 10;

--- a/tests/globalEvents/CloudSocieties.spec.ts
+++ b/tests/globalEvents/CloudSocieties.spec.ts
@@ -13,10 +13,10 @@ describe('CloudSocieties', function() {
     const game = Game.newInstance('gameid', [player], player);
     const turmoil = Turmoil.newInstance(game);
     player.playedCards.push(new FloatingHabs());
-    turmoil.chairman = player.id;
+    turmoil.chairman = player;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player.id;
-    turmoil.dominantParty.delegates.add(player.id);
+    turmoil.dominantParty.partyLeader = player;
+    turmoil.dominantParty.delegates.add(player);
     card.resolve(game, turmoil);
     game.deferredActions.runNext();
     expect(player.playedCards[0].resourceCount).to.eq(3);

--- a/tests/globalEvents/CorrosiveRain.spec.ts
+++ b/tests/globalEvents/CorrosiveRain.spec.ts
@@ -27,11 +27,11 @@ describe('CorrosiveRain', function() {
   });
 
   it('resolve play', function() {
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     player.megaCredits = 15;
     player2.megaCredits = 15;

--- a/tests/globalEvents/Diversity.spec.ts
+++ b/tests/globalEvents/Diversity.spec.ts
@@ -18,10 +18,10 @@ describe('Diversity', function() {
     player2.playedCards.push(new EarlySettlement()); // Building, City
     player2.playedCards.push(new SolarWindPower()); // Science, Space, Power
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
 

--- a/tests/globalEvents/EcoSabotage.spec.ts
+++ b/tests/globalEvents/EcoSabotage.spec.ts
@@ -15,10 +15,10 @@ describe('EcoSabotage', function() {
 
     turmoil.initGlobalEvent(game);
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
 
     player.plants = 10;
     player2.plants = 10;

--- a/tests/globalEvents/Election.spec.ts
+++ b/tests/globalEvents/Election.spec.ts
@@ -16,10 +16,10 @@ describe('Election', function() {
     player2.playedCards.push(new StripMine());
     player2.playedCards.push(new StripMine());
     addCity(player3);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
 
     expect(card.getScore(player, turmoil, game)).eq(1);
     expect(card.getScore(player2, turmoil, game)).eq(4);

--- a/tests/globalEvents/GenerousFunding.spec.ts
+++ b/tests/globalEvents/GenerousFunding.spec.ts
@@ -14,11 +14,11 @@ describe('GenerousFunding', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     player.megaCredits = 10;
     player2.megaCredits = 10;
@@ -38,11 +38,11 @@ describe('GenerousFunding', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     player.megaCredits = 10;
     player2.megaCredits = 10;

--- a/tests/globalEvents/GlobalDustStorm.spec.ts
+++ b/tests/globalEvents/GlobalDustStorm.spec.ts
@@ -17,10 +17,10 @@ describe('GlobalDustStorm', function() {
     player.playedCards.push(new StripMine());
     player2.playedCards.push(new StripMine());
     player2.playedCards.push(new StripMine());
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
     player.megaCredits = 10;
     player2.megaCredits = 10;
     player.heat = 7;

--- a/tests/globalEvents/HomeworldSupport.spec.ts
+++ b/tests/globalEvents/HomeworldSupport.spec.ts
@@ -19,11 +19,11 @@ describe('HomeworldSupport', function() {
     player2.playedCards.push(new Sponsors());
     player2.playedCards.push(new Sponsors());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(2);

--- a/tests/globalEvents/ImprovedEnergyTemplates.spec.ts
+++ b/tests/globalEvents/ImprovedEnergyTemplates.spec.ts
@@ -17,10 +17,10 @@ describe('ImprovedEnergyTemplates', function() {
     player.playedCards.push(new SolarWindPower());
     player2.playedCards.push(new SolarWindPower());
     player2.playedCards.push(new SolarWindPower());
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
     card.resolve(game, turmoil);
     expect(player.production.energy).to.eq(0);
     expect(player2.production.energy).to.eq(2);

--- a/tests/globalEvents/InterplanetaryTrade.spec.ts
+++ b/tests/globalEvents/InterplanetaryTrade.spec.ts
@@ -19,11 +19,11 @@ describe('InterplanetaryTrade', function() {
     player2.playedCards.push(new MethaneFromTitan());
     player2.playedCards.push(new MethaneFromTitan());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(2);

--- a/tests/globalEvents/JovianTaxRights.spec.ts
+++ b/tests/globalEvents/JovianTaxRights.spec.ts
@@ -22,11 +22,11 @@ describe('JovianTaxRights', function() {
     game.colonies.push(colony1);
     game.colonies.push(colony2);
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.titanium).to.eq(0);

--- a/tests/globalEvents/MicrogravityHealthProblems.spec.ts
+++ b/tests/globalEvents/MicrogravityHealthProblems.spec.ts
@@ -22,10 +22,10 @@ describe('MicrogravityHealthProblems', function() {
     colony2.colonies.push(player2.id);
     game.colonies.push(colony1);
     game.colonies.push(colony2);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
     player.megaCredits = 20;
     player2.megaCredits = 20;
     card.resolve(game, turmoil);

--- a/tests/globalEvents/MinersOnStrike.spec.ts
+++ b/tests/globalEvents/MinersOnStrike.spec.ts
@@ -20,10 +20,10 @@ describe('MinersOnStrike', function() {
     player.playedCards.push(new MethaneFromTitan());
     player2.playedCards.push(new MethaneFromTitan());
     player2.playedCards.push(new MethaneFromTitan());
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
     card.resolve(game, turmoil);
     expect(player.titanium).to.eq(4);
     expect(player2.titanium).to.eq(5);

--- a/tests/globalEvents/Pandemic.spec.ts
+++ b/tests/globalEvents/Pandemic.spec.ts
@@ -17,10 +17,10 @@ describe('Pandemic', function() {
     player.playedCards.push(new StripMine());
     player2.playedCards.push(new StripMine());
     player2.playedCards.push(new StripMine());
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
     player.megaCredits = 10;
     player2.megaCredits = 10;
     card.resolve(game, turmoil);

--- a/tests/globalEvents/ParadigmBreakdown.spec.ts
+++ b/tests/globalEvents/ParadigmBreakdown.spec.ts
@@ -16,12 +16,12 @@ describe('ParadigmBreakdown', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player.id);
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player);
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     const asteroid = new Asteroid();
     const dustSeals = new DustSeals();

--- a/tests/globalEvents/Productivity.spec.ts
+++ b/tests/globalEvents/Productivity.spec.ts
@@ -15,11 +15,11 @@ describe('Productivity', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     player.production.add(Resource.STEEL, 3);
     player2.production.add(Resource.STEEL, 3);

--- a/tests/globalEvents/RedInfluence.spec.ts
+++ b/tests/globalEvents/RedInfluence.spec.ts
@@ -17,11 +17,11 @@ describe('RedInfluence', function() {
     player.megaCredits = 10;
     player2.megaCredits = 10;
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(4);

--- a/tests/globalEvents/Revolution.spec.ts
+++ b/tests/globalEvents/Revolution.spec.ts
@@ -22,10 +22,10 @@ describe('Revolution', function() {
     turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
   });
 
   it('resolve play', function() {

--- a/tests/globalEvents/Sabotage.spec.ts
+++ b/tests/globalEvents/Sabotage.spec.ts
@@ -18,11 +18,11 @@ describe('Sabotage', function() {
     player.production.add(Resource.ENERGY, 1);
     player2.production.add(Resource.STEEL, 3);
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.steel).to.eq(0);

--- a/tests/globalEvents/ScientificCommunity.spec.ts
+++ b/tests/globalEvents/ScientificCommunity.spec.ts
@@ -18,11 +18,11 @@ describe('ScientificCommunity', function() {
     player.cardsInHand.push(new Ants());
     player2.cardsInHand.push(new SecurityFleet(), new Ants());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(1);

--- a/tests/globalEvents/SnowCover.spec.ts
+++ b/tests/globalEvents/SnowCover.spec.ts
@@ -20,11 +20,11 @@ describe('SnowCover', function() {
     [game, player, player2] = testGame(2);
 
     turmoil = Turmoil.newInstance(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
   });
 
   it('resolve play', function() {

--- a/tests/globalEvents/SolarFlare.spec.ts
+++ b/tests/globalEvents/SolarFlare.spec.ts
@@ -19,11 +19,11 @@ describe('SolarFlare', function() {
     player.megaCredits = 10;
     player2.megaCredits = 10;
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(7);

--- a/tests/globalEvents/SolarnetShutdown.spec.ts
+++ b/tests/globalEvents/SolarnetShutdown.spec.ts
@@ -21,11 +21,11 @@ describe('SolarnetShutdown', function() {
     player.megaCredits = 10;
     player2.megaCredits = 10;
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(7);

--- a/tests/globalEvents/SpinoffProducts.spec.ts
+++ b/tests/globalEvents/SpinoffProducts.spec.ts
@@ -27,11 +27,11 @@ describe('SpinoffProducts', function() {
     player2.playedCards.push(new Research());
     player2.playedCards.push(new Research());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(4);
@@ -42,11 +42,11 @@ describe('SpinoffProducts', function() {
     player.setCorporationForTest(new HabitatMarte());
     player.playedCards.push(new Research(), new DesignedOrganisms());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
 

--- a/tests/globalEvents/SponsoredProjects.spec.ts
+++ b/tests/globalEvents/SponsoredProjects.spec.ts
@@ -26,11 +26,11 @@ describe('SponsoredProjects', function() {
     }
     player2.playedCards.push(new Fish());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.playedCards[0].resourceCount).to.eq(2);

--- a/tests/globalEvents/StrongSociety.spec.ts
+++ b/tests/globalEvents/StrongSociety.spec.ts
@@ -15,11 +15,11 @@ describe('StrongSociety', function() {
     const turmoil = Turmoil.newInstance(game);
 
     addCity(player);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(2);

--- a/tests/globalEvents/SuccessfulOrganisms.spec.ts
+++ b/tests/globalEvents/SuccessfulOrganisms.spec.ts
@@ -15,11 +15,11 @@ describe('SuccessfulOrganisms', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     player.production.add(Resource.PLANTS, 3);
     player2.production.add(Resource.PLANTS, 3);

--- a/tests/globalEvents/VenusInfrastructure.spec.ts
+++ b/tests/globalEvents/VenusInfrastructure.spec.ts
@@ -17,11 +17,11 @@ describe('VenusInfrastructure', function() {
     player.playedCards.push(new CorroderSuits());
     player2.playedCards.push(new CorroderSuits(), new CorroderSuits(), new CorroderSuits());
 
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.megaCredits).to.eq(2);

--- a/tests/globalEvents/VolcanicEruptions.spec.ts
+++ b/tests/globalEvents/VolcanicEruptions.spec.ts
@@ -14,11 +14,11 @@ describe('VolcanicEruptions', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     card.resolve(game, turmoil);
     expect(player.production.heat).to.eq(0);

--- a/tests/globalEvents/WarOnEarth.spec.ts
+++ b/tests/globalEvents/WarOnEarth.spec.ts
@@ -14,11 +14,11 @@ describe('WarOnEarth', function() {
     const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
-    turmoil.chairman = player2.id;
+    turmoil.chairman = player2;
     turmoil.dominantParty = new Kelvinists();
-    turmoil.dominantParty.partyLeader = player2.id;
-    turmoil.dominantParty.delegates.add(player2.id);
-    turmoil.dominantParty.delegates.add(player2.id);
+    turmoil.dominantParty.partyLeader = player2;
+    turmoil.dominantParty.delegates.add(player2);
+    turmoil.dominantParty.delegates.add(player2);
 
     player.setTerraformRating(15);
     player2.setTerraformRating(15);

--- a/tests/turmoil/PoliticalAgendas.spec.ts
+++ b/tests/turmoil/PoliticalAgendas.spec.ts
@@ -39,7 +39,7 @@ describe('PoliticalAgendas', function() {
 
       const newParty = turmoil.getPartyByName(PartyName.KELVINISTS);
       turmoil.rulingParty = newParty;
-      turmoil.chairman = player2.id;
+      turmoil.chairman = player2;
       PoliticalAgendas.setNextAgenda(turmoil, game);
       runAllActions(game);
 
@@ -64,7 +64,7 @@ describe('PoliticalAgendas', function() {
 
       const newParty = turmoil.getPartyByName(PartyName.KELVINISTS);
       turmoil.rulingParty = newParty;
-      turmoil.chairman = newPlayer2.id;
+      turmoil.chairman = newPlayer2;
 
       PoliticalAgendas.setNextAgenda(turmoil, game);
       runAllActions(game);


### PR DESCRIPTION
This touches a fair bit of code, and tests, and complicates serialization, but simplifies everything else.