### PR TITLE
Added Mining Expedition as a valid attack card

### DIFF
--- a/src/server/awards/terraCimmeria/Warmonger.ts
+++ b/src/server/awards/terraCimmeria/Warmonger.ts
@@ -36,6 +36,7 @@ export class Warmonger implements IAward {
     CardName.GREAT_ESCARPMENT_CONSORTIUM,
     CardName.HACKERS,
     CardName.HIRED_RAIDERS,
+    CardName.MINING_EXPEDITION,
     CardName.POWER_SUPPLY_CONSORTIUM,
     CardName.PREDATORS,
     CardName.SABOTAGE,


### PR DESCRIPTION
This fixes the problem, that Warmonger didn't count Mining Expedition as a valid attack card.