### PR TITLE
[Bugfix] Comet for Venus and Warmonger award

### DIFF
--- a/src/server/cards/venusNext/CometForVenus.ts
+++ b/src/server/cards/venusNext/CometForVenus.ts
@@ -21,7 +21,7 @@ export class CometForVenus extends Card implements IProjectCard {
 
       behavior: {
         global: {venus: 1},
-        removeAnyPlants: 3
+        removeAnyPlants: 2
       },
 
       metadata: {

--- a/src/server/cards/venusNext/CometForVenus.ts
+++ b/src/server/cards/venusNext/CometForVenus.ts
@@ -21,6 +21,7 @@ export class CometForVenus extends Card implements IProjectCard {
 
       behavior: {
         global: {venus: 1},
+        removeAnyPlants: 3
       },
 
       metadata: {


### PR DESCRIPTION
This commit fixes a bug where the Comet for Venus card would not count as attack card for the Warmonger award.