### PR TITLE
Global events css polish

### DIFF
--- a/src/server/turmoil/globalEvents/CorrosiveRain.ts
+++ b/src/server/turmoil/globalEvents/CorrosiveRain.ts
@@ -8,7 +8,7 @@ import {CorrosiveRainDeferredAction} from '../../deferredActions/CorrosiveRainDe
 import {CardRenderer} from '../../cards/render/CardRenderer';
 
 const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().floaters(2).or().megacredits(-10).br.cards(1).slash().influence();
+  b.minus().floaters(2).or().megacredits(-10).nbsp.nbsp.cards(1).slash().influence();
 });
 
 export class CorrosiveRain extends GlobalEvent implements IGlobalEvent {

--- a/src/server/turmoil/globalEvents/Election.ts
+++ b/src/server/turmoil/globalEvents/Election.ts
@@ -12,7 +12,7 @@ import {played} from '../../cards/Options';
 import {Size} from '../../../common/cards/render/Size';
 
 const RENDER_DATA = CardRenderer.builder((b) => {
-  b.influence().plus().building(1, {played, size: Size.SMALL}).plus().city({size: Size.SMALL}).colon().br;
+  b.influence().plus().building(1, {played, size: Size.SMALL}).plus().city({size: Size.MEDIUM}).colon().br;
   b.text('1st:', Size.SMALL).tr(2, {size: Size.TINY}).nbsp.text('2nd:', Size.SMALL).tr(1, {size: Size.TINY});
 });
 

--- a/src/server/turmoil/globalEvents/GenerousFunding.ts
+++ b/src/server/turmoil/globalEvents/GenerousFunding.ts
@@ -9,7 +9,7 @@ import {CardRenderer} from '../../cards/render/CardRenderer';
 import {digit} from '../../cards/Options';
 
 const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().influence().plus().tr(5, {digit, over: 15}).br;
+  b.megacredits(2).slash().influence().plus().tr(5, {digit, over: 15}).br.br;
 });
 
 export class GenerousFunding extends GlobalEvent implements IGlobalEvent {

--- a/src/server/turmoil/globalEvents/RedInfluence.ts
+++ b/src/server/turmoil/globalEvents/RedInfluence.ts
@@ -9,7 +9,7 @@ import {CardRenderer} from '../../cards/render/CardRenderer';
 import {digit} from '../../cards/Options';
 
 const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(-3).slash().tr(5, {digit, over: 10}).nbsp.production((pb) => pb.megacredits(1)).slash().influence();
+  b.megacredits(-3).slash().tr(5, {digit, over: 10}).nbsp.production((pb) => pb.megacredits(1)).slash().influence().br;
 });
 
 

--- a/src/server/turmoil/globalEvents/Revolution.ts
+++ b/src/server/turmoil/globalEvents/Revolution.ts
@@ -12,8 +12,8 @@ import {Size} from '../../../common/cards/render/Size';
 
 const RENDER_DATA = CardRenderer.builder((b) => {
   b.earth(1, {played, size: Size.SMALL}).plus().influence().colon().br;
-  b.text('1st:', Size.SMALL).tr(2, {size: Size.TINY}).nbsp;
-  b.text('2nd:', Size.SMALL).tr(1, {size: Size.TINY});
+  b.text('1st:', Size.SMALL).minus().tr(2, {size: Size.TINY}).nbsp;
+  b.text('2nd:', Size.SMALL).minus().tr(1, {size: Size.TINY});
 });
 
 export class Revolution extends GlobalEvent implements IGlobalEvent {

--- a/src/styles/turmoil.less
+++ b/src/styles/turmoil.less
@@ -105,9 +105,7 @@
     justify-content: center;
     margin: 0 auto;
     top: 3px;
-    overflow-x: hidden;
-    justify-content: start;
-    scale: 0.9;
+    box-sizing: inherit;
 }
 
 .global-event-title {


### PR DESCRIPTION
**AC**
- css changes - removed the 0.9 scaling, the vertical scrolling and added vertical alignment
The "drawback" is that only 2 events ELECTION and REVOLUTION have iconography on two rows and slightly go off the desired borders
- minor events polish 

![events](https://github.com/terraforming-mars/terraforming-mars/assets/6917565/9ac11255-344b-4961-a52b-e7477b841578)
