### PR TITLE
Few minor css changes

### DIFF
--- a/src/client/components/OtherPlayer.vue
+++ b/src/client/components/OtherPlayer.vue
@@ -53,32 +53,36 @@ export default Vue.extend({
 });
 </script>
 <template>
-  <div v-show="isVisible()" class="other_player_cont menu">
+  <div v-show="isVisible()">
+    <div :class="'player_translucent_bg_color_' + player.color" class="other_player_header">
+      <div class="player_name"> {{ player.name }} played cards </div>
       <AppButton size="big" type="close" @click="hideMe" :disableOnServerBusy="false" align="right" />
-      <div v-if="player.tableau.length > 0" class="player_home_block">
-          <span class="player_name" :class="'player_bg_color_' + player.color"> {{ player.name }} played cards </span>
-          <div>
-              <div v-for="card in getCardsByType(player.tableau, [CardType.CORPORATION])" :key="card.name" class="cardbox">
-                  <Card :card="card" :actionUsed="isCardActivated(card, player)"/>
-              </div>
-              <div v-for="card in getCardsByType(player.tableau, [CardType.CEO])" :key="card.name" class="cardbox">
-                  <Card :card="card" :actionUsed="isCardActivated(card, player)"/>
-              </div>
+    </div>
+    <div class="other_player_cont menu">
+        <div v-if="player.tableau.length > 0" class="player_home_block">
+            <div>
+                <div v-for="card in getCardsByType(player.tableau, [CardType.CORPORATION])" :key="card.name" class="cardbox">
+                    <Card :card="card" :actionUsed="isCardActivated(card, player)"/>
+                </div>
+                <div v-for="card in getCardsByType(player.tableau, [CardType.CEO])" :key="card.name" class="cardbox">
+                    <Card :card="card" :actionUsed="isCardActivated(card, player)"/>
+                </div>
 
-              <div v-for="card in sortActiveCards(getCardsByType(player.tableau, [CardType.ACTIVE]))" :key="card.name" class="cardbox">
-                  <Card :card="card" :actionUsed="isCardActivated(card, player)"/>
-              </div>
-              <stacked-cards :cards="getCardsByType(player.tableau, [CardType.AUTOMATED, CardType.PRELUDE])" :player="player"></stacked-cards>
-              <stacked-cards :cards="getCardsByType(player.tableau, [CardType.EVENT])" :player="player"></stacked-cards>
-          </div>
-      </div>
-      <div v-if="player.selfReplicatingRobotsCards.length > 0" class="player_home_block">
-          <span> Self-Replicating Robots cards </span>
-          <div>
-              <div v-for="card in getCardsByType(player.selfReplicatingRobotsCards, [CardType.ACTIVE])" :key="card.name" class="cardbox">
-                  <Card :card="card" />
-              </div>
-          </div>
-      </div>
+                <div v-for="card in sortActiveCards(getCardsByType(player.tableau, [CardType.ACTIVE]))" :key="card.name" class="cardbox">
+                    <Card :card="card" :actionUsed="isCardActivated(card, player)"/>
+                </div>
+                <stacked-cards :cards="getCardsByType(player.tableau, [CardType.AUTOMATED, CardType.PRELUDE])" :player="player"></stacked-cards>
+                <stacked-cards :cards="getCardsByType(player.tableau, [CardType.EVENT])" :player="player"></stacked-cards>
+            </div>
+        </div>
+        <div v-if="player.selfReplicatingRobotsCards.length > 0" class="player_home_block">
+            <span> Self-Replicating Robots cards </span>
+            <div>
+                <div v-for="card in getCardsByType(player.selfReplicatingRobotsCards, [CardType.ACTIVE])" :key="card.name" class="cardbox">
+                    <Card :card="card" />
+                </div>
+            </div>
+        </div>
+    </div>
   </div>
 </template>

--- a/src/client/components/overview/PlayerTags.vue
+++ b/src/client/components/overview/PlayerTags.vue
@@ -2,7 +2,7 @@
     <div class="player-tags">
         <div class="player-tags-main">
             <tag-count :tag="'vp'" :count="player.victoryPointsBreakdown.total" :size="'big'" :type="'main'" :hideCount="hideVpCount" />
-            <div v-if="isEscapeVelocityOn" class="tag-display" :class="tooltipCss" :data-tooltip="$t('Escape Velocity penalty')">
+            <div v-if="isEscapeVelocityOn" :class="tooltipCss" :data-tooltip="$t('Escape Velocity penalty')">
               <tag-count :tag="'escape'" :count="escapeVelocityPenalty" :size="'big'" :type="'main'"/>
             </div>
             <tag-count :tag="'tr'" :count="player.terraformRating" :size="'big'" :type="'main'"/>

--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -72,8 +72,8 @@
 
 .log-player {
     text-shadow:1px 1px 1px #222, -1px -1px 1px #666;
-    padding: 1px 5px;
-    border-radius: 4px;
+    padding: 2px 10px;
+    border-radius: 2px;
     font-weight: bold;
 }
 

--- a/src/styles/other_player.less
+++ b/src/styles/other_player.less
@@ -1,15 +1,21 @@
 .other_player_cont {
     display: inline-block;
-    padding: 10px;
-    background: #333;
+    width: 100%;
+    padding: 0 10px;
+    background: #222;
     max-height: 1200px;
-    max-width: 1170px;
     margin-right: 20px;
     overflow-y: auto;
-    border-radius: 4px;
-    box-shadow: 6px 6px 4px #111;
-    margin-top: 8px;
+    border-radius: 0px 0px 8px 8px;
     .other_player_close {
         float: right;
     }
+}
+
+.other_player_header {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 8px;
+    border-radius: 8px 8px 0px 0px;
+    margin-bottom: -4px;
 }

--- a/src/styles/other_player.less
+++ b/src/styles/other_player.less
@@ -1,7 +1,7 @@
 .other_player_cont {
     display: inline-block;
     width: 100%;
-    padding: 0 10px;
+    padding: 10px 0 0 25px;
     background: #222;
     max-height: 1200px;
     margin-right: 20px;

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -269,10 +269,9 @@
 }
 .tag-escape {
     background-image: url(./assets/expansion_icons/expansion_icon_escapeVelocity.png);
-    background-color: black;
-    background-size: 40px;
-    background-position: -3px;
-    border-radius: 20px;
+    background-size: 56px;
+    background-position: -8px;
+    border-radius: 18px;
 }
 .tag-city-count {
     background-image: url(./assets/tiles/city.png);
@@ -425,11 +424,9 @@
     }
 
     .player_name {
-        color: #ccc;
         text-shadow: 1px 1px 1px #222, -1px -1px 2px #666;
-        padding: 1px 5px;
+        padding: 2px 5px;
         border-radius: 4px;
-        font-weight: bold;
     }
 
     .tags_cont {


### PR DESCRIPTION
**AC**
- EV icon fix - double margin right has been removed and the width is proper now 
(top: current state, bottom: previous state)
![Untitled](https://github.com/terraforming-mars/terraforming-mars/assets/6917565/a5fcfa87-18dd-48ba-9876-16c29d542100)

- "other player cards" fixes:
-- on mobile and desktop the width matches the width of the player boards
-- player colour, label and close button are in a header - the backgroud colour and text colour now matches the colours of the player board
-- background colour is now 222 - identical to the background of the backlog
-- vertical scrolling now longer hides/scrolls away the close button 
![Untitled](https://github.com/terraforming-mars/terraforming-mars/assets/6917565/700c345b-11a7-498a-ac8a-acdc0a8cd107)
