### PR TITLE
Create new Deck.draw that returns undefined when draw pile is empty

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -330,22 +330,22 @@ export class Game implements IGame, Logger {
         gameOptions.initialDraftVariant ||
         gameOptions.ceoExtension) {
         for (let i = 0; i < gameOptions.startingCorporations; i++) {
-          player.dealtCorporationCards.push(corporationDeck.draw(game));
+          player.dealtCorporationCards.push(corporationDeck.drawLegacy(game));
         }
         if (gameOptions.initialDraftVariant === false) {
           for (let i = 0; i < 10; i++) {
-            player.dealtProjectCards.push(projectDeck.draw(game));
+            player.dealtProjectCards.push(projectDeck.drawLegacy(game));
           }
         }
         if (gameOptions.preludeExtension) {
           for (let i = 0; i < constants.PRELUDE_CARDS_DEALT_PER_PLAYER; i++) {
-            const prelude = preludeDeck.draw(game);
+            const prelude = preludeDeck.drawLegacy(game);
             player.dealtPreludeCards.push(prelude);
           }
         }
         if (gameOptions.ceoExtension) {
           for (let i = 0; i < gameOptions.startingCeos; i++) {
-            const ceoCard = ceoDeck.draw(game);
+            const ceoCard = ceoDeck.drawLegacy(game);
             player.dealtCeoCards.push(ceoCard);
           }
         }
@@ -1518,14 +1518,14 @@ export class Game implements IGame, Logger {
 
   public discardForCost(cardCount: 1 | 2, toPlace: TileType) {
     if (cardCount === 1) {
-      const card = this.projectDeck.draw(this);
+      const card = this.projectDeck.drawLegacy(this);
       this.projectDeck.discard(card);
       this.log('Drew and discarded ${0} to place a ${1}', (b) => b.card(card, {cost: true}).tileType(toPlace));
       return card.cost;
     } else {
-      const card1 = this.projectDeck.draw(this);
+      const card1 = this.projectDeck.drawLegacy(this);
       this.projectDeck.discard(card1);
-      const card2 = this.projectDeck.draw(this);
+      const card2 = this.projectDeck.drawLegacy(this);
       this.projectDeck.discard(card2);
       this.log('Drew and discarded ${0} and ${1} to place a ${2}', (b) => b.card(card1, {cost: true}).card(card2, {cost: true}).tileType(toPlace));
       return card1.cost + card2.cost;

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -709,7 +709,7 @@ export class Player implements IPlayer {
 
   public dealForDraft(quantity: number, cards: Array<IProjectCard>): void {
     for (let i = 0; i < quantity; i++) {
-      cards.push(this.game.projectDeck.draw(this.game, 'bottom'));
+      cards.push(this.game.projectDeck.drawLegacy(this.game, 'bottom'));
     }
   }
 

--- a/src/server/cards/Deck.ts
+++ b/src/server/cards/Deck.ts
@@ -57,6 +57,22 @@ export class Deck<T extends ICard> {
     }
   }
 
+  public draw(logger: Logger, source: 'top' | 'bottom' = 'top'): T | undefined {
+    if (this.drawPile.length === 0) {
+      logger.log(`The ${this.type} discard pile has been shuffled to form a new deck.`);
+      this.shuffle();
+    }
+
+    const card = source === 'top' ? this.drawPile.pop() : this.drawPile.shift();
+
+    if (this.drawPile.length === 0) {
+      logger.log(`The ${this.type} discard pile has been shuffled to form a new deck.`);
+      this.shuffle();
+    }
+
+    return card;
+  }
+
   public drawLegacy(logger: Logger, source: 'top' | 'bottom' = 'top'): T {
     return this.drawOrThrow(logger, source);
   }

--- a/src/server/cards/Deck.ts
+++ b/src/server/cards/Deck.ts
@@ -57,7 +57,11 @@ export class Deck<T extends ICard> {
     }
   }
 
-  public draw(logger: Logger, source: 'top' | 'bottom' = 'top'): T {
+  public drawLegacy(logger: Logger, source: 'top' | 'bottom' = 'top'): T {
+    return this.drawOrThrow(logger, source);
+  }
+
+  public drawOrThrow(logger: Logger, source: 'top' | 'bottom' = 'top'): T {
     const card = source === 'top' ? this.drawPile.pop() : this.drawPile.shift();
 
     if (card === undefined) {
@@ -81,7 +85,7 @@ export class Deck<T extends ICard> {
         logger.log(`discarded every ${this.type} card without a match`);
         break;
       }
-      const projectCard = this.draw(logger);
+      const projectCard = this.drawLegacy(logger);
       if (include(projectCard)) {
         result.push(projectCard);
       } else {

--- a/src/server/cards/base/SearchForLife.ts
+++ b/src/server/cards/base/SearchForLife.ts
@@ -50,7 +50,7 @@ export class SearchForLife extends Card implements IActionCard, IProjectCard {
   public action(player: IPlayer) {
     player.game.defer(new SelectPaymentDeferred(player, 1, {title: TITLES.payForCardAction(this.name)}))
       .andThen(() => {
-        const topCard = player.game.projectDeck.draw(player.game);
+        const topCard = player.game.projectDeck.drawLegacy(player.game);
         player.game.log('${0} revealed and discarded ${1}', (b) => b.player(player).card(topCard, {tags: true}));
         if (topCard.tags.includes(Tag.MICROBE)) {
           player.addResourceTo(this, 1);

--- a/src/server/cards/ceos/CoLeadership.ts
+++ b/src/server/cards/ceos/CoLeadership.ts
@@ -22,9 +22,9 @@ export class CoLeadership extends PreludeCard {
   public override bespokePlay(player: IPlayer) {
     const game = player.game;
     let ceosDrawn: Array<ICeoCard> = [
-      game.ceoDeck.draw(game),
-      game.ceoDeck.draw(game),
-      game.ceoDeck.draw(game),
+      game.ceoDeck.drawLegacy(game),
+      game.ceoDeck.drawLegacy(game),
+      game.ceoDeck.drawLegacy(game),
     ];
 
     // TODO(d-little): This is not being tested, but currently every CEO is always playable

--- a/src/server/cards/ceos/Karen.ts
+++ b/src/server/cards/ceos/Karen.ts
@@ -25,7 +25,7 @@ export class Karen extends CeoCard {
     const game = player.game;
     const cards: Array<IPreludeCard> = [];
     for (let i = 0; i < game.generation; i++) {
-      cards.push(game.preludeDeck.draw(game));
+      cards.push(game.preludeDeck.drawLegacy(game));
     }
     return PreludesExpansion.playPrelude(player, cards);
   }

--- a/src/server/cards/ceos/Lowell.ts
+++ b/src/server/cards/ceos/Lowell.ts
@@ -37,9 +37,9 @@ export class Lowell extends CeoCard {
     this.isDisabled = true;
     const game = player.game;
     let ceosDrawn: Array<ICeoCard> = [
-      game.ceoDeck.draw(game),
-      game.ceoDeck.draw(game),
-      game.ceoDeck.draw(game),
+      game.ceoDeck.drawLegacy(game),
+      game.ceoDeck.drawLegacy(game),
+      game.ceoDeck.drawLegacy(game),
     ];
 
     // TODO(d-little): This is not being tested, but currently every CEO is always playable

--- a/src/server/cards/community/JunkVentures.ts
+++ b/src/server/cards/community/JunkVentures.ts
@@ -32,7 +32,7 @@ export class JunkVentures extends CorporationCard {
     const discardedCards = new Set<CardName>();
 
     for (let i = 0; i < 3; i++) {
-      const card = player.game.projectDeck.draw(player.game);
+      const card = player.game.projectDeck.drawLegacy(player.game);
       player.game.projectDeck.discard(card);
       discardedCards.add(card.name);
     }

--- a/src/server/cards/pathfinders/OumuamuaTypeObjectSurvey.ts
+++ b/src/server/cards/pathfinders/OumuamuaTypeObjectSurvey.ts
@@ -60,7 +60,7 @@ export class OumuamuaTypeObjectSurvey extends Card implements IProjectCard {
     const game = player.game;
     // TODO(kberg): Make sure this action occurs after the card play, in case the played card has data.
     game.defer(new AddResourcesToCard(player, CardResource.DATA, {count: 2}));
-    const cards = [game.projectDeck.draw(player.game), game.projectDeck.draw(player.game)];
+    const cards = [game.projectDeck.drawLegacy(player.game), game.projectDeck.drawLegacy(player.game)];
 
     player.game.log('${0} revealed ${1} and ${2}', (b) => b.player(player).card(cards[0], {tags: true}).card(cards[1], {tags: true}));
     if (this.processCard(player, cards[0])) {

--- a/src/server/cards/prelude/ValleyTrust.ts
+++ b/src/server/cards/prelude/ValleyTrust.ts
@@ -40,9 +40,9 @@ export class ValleyTrust extends CorporationCard {
   public initialAction(player: IPlayer) {
     const game = player.game;
     const cards = [
-      game.preludeDeck.draw(game),
-      game.preludeDeck.draw(game),
-      game.preludeDeck.draw(game),
+      game.preludeDeck.drawLegacy(game),
+      game.preludeDeck.drawLegacy(game),
+      game.preludeDeck.drawLegacy(game),
     ];
     return PreludesExpansion.playPrelude(player, cards);
   }

--- a/src/server/cards/promo/AsteroidDeflectionSystem.ts
+++ b/src/server/cards/promo/AsteroidDeflectionSystem.ts
@@ -46,7 +46,7 @@ export class AsteroidDeflectionSystem extends Card implements IActionCard, IProj
   }
 
   public action(player: IPlayer) {
-    const topCard = player.game.projectDeck.draw(player.game);
+    const topCard = player.game.projectDeck.drawLegacy(player.game);
     player.game.log('${0} revealed and discarded ${1}', (b) => b.player(player).card(topCard, {tags: true}));
     if (topCard.tags.includes(Tag.SPACE)) {
       player.addResourceTo(this, {qty: 1, log: true});

--- a/src/server/cards/promo/Merger.ts
+++ b/src/server/cards/promo/Merger.ts
@@ -62,7 +62,7 @@ export class Merger extends PreludeCard {
     const cards: Array<ICorporationCard> = [];
     try {
       while (cards.length < 4) {
-        cards.push(corporationDeck.draw(player.game));
+        cards.push(corporationDeck.drawLegacy(player.game));
       }
     } catch (err) {
       // Error will only occur if the deck is empty. That won't happen, but here we'll just do our best.

--- a/src/server/cards/promo/NewPartner.ts
+++ b/src/server/cards/promo/NewPartner.ts
@@ -26,8 +26,8 @@ export class NewPartner extends PreludeCard {
 
   public override bespokePlay(player: IPlayer) {
     const cards: Array<IPreludeCard> = [
-      player.game.preludeDeck.draw(player.game),
-      player.game.preludeDeck.draw(player.game),
+      player.game.preludeDeck.drawLegacy(player.game),
+      player.game.preludeDeck.drawLegacy(player.game),
     ];
     return PreludesExpansion.playPrelude(player, cards);
   }

--- a/tests/cards/Deck.spec.ts
+++ b/tests/cards/Deck.spec.ts
@@ -1,10 +1,13 @@
 import {expect} from 'chai';
-import {PreludeDeck, CeoDeck} from '../../src/server/cards/Deck';
+import {PreludeDeck, CeoDeck, ProjectDeck} from '../../src/server/cards/Deck';
 import {GameCards} from '../../src/server/GameCards';
 import {DEFAULT_GAME_OPTIONS} from '../../src/server/game/GameOptions';
+import {ICard} from '../../src/server/cards/ICard';
+import {Game} from '../../src/server/Game';
+import {IProjectCard} from '../../src/server/cards/IProjectCard';
 import {CardName} from '../../src/common/cards/CardName';
 import {ConstRandom, UnseededRandom} from '../../src/common/utils/Random';
-import {ICard} from '../../src/server/cards/ICard';
+import {testGame} from '../TestGame';
 
 function name(card: ICard): CardName {
   return card.name;
@@ -109,5 +112,120 @@ describe('CeoDeck', function() {
 
     expect(deck.drawPile).to.deep.eq(deserialized.drawPile);
     expect(deck.discardPile).to.deep.eq(deserialized.discardPile);
+  });
+});
+
+describe('draw()', function() {
+  let deck: ProjectDeck;
+  let game: Game;
+  let drawnCard: IProjectCard | undefined;
+  let originalLength: number;
+  let topCard: IProjectCard | undefined;
+  let bottomCard: IProjectCard | undefined;
+
+  describe('with more than enough cards in the draw pile', function() {
+    beforeEach(function() {
+      [game] = testGame(2, {skipInitialCardSelection: true});
+      deck = game.projectDeck;
+      originalLength = game.projectDeck.drawPile.length;
+    });
+
+    describe('drawing from the top', function() {
+      beforeEach(function() {
+        topCard = deck.drawPile[originalLength - 1];
+        drawnCard = deck.draw(game);
+      });
+
+      it('should draw the top card', () => {
+        expect(drawnCard).to.equal(topCard);
+      });
+
+      it('should remove the card from the draw pile', () => {
+        expect(deck.drawPile.length).to.equal(originalLength - 1);
+      });
+    });
+
+    describe('drawing from the bottom', function() {
+      beforeEach(function() {
+        bottomCard = deck.drawPile[0];
+        drawnCard = deck.draw(game, 'bottom');
+      });
+
+      it('should draw the bottom card', () => {
+        expect(drawnCard).to.equal(bottomCard);
+      });
+
+      it('should remove the card from the draw pile', () => {
+        expect(deck.drawPile.length).to.equal(originalLength - 1);
+      });
+    });
+  });
+
+  describe('draw from the top with only 1 card left in the draw pile', function() {
+    beforeEach(function() {
+      [game] = testGame(2, {skipInitialCardSelection: true});
+      deck = game.projectDeck;
+      originalLength = game.projectDeck.drawPile.length;
+      bottomCard = deck.drawPile[0];
+
+      // move all cards in the draw pile except 1 into discard pile
+      const allExceptLast = deck.drawPile.splice(1);
+      deck.discardPile.push(...allExceptLast);
+
+      drawnCard = deck.draw(game);
+    });
+
+    it('should draw the top card', () => {
+      expect(drawnCard).to.equal(bottomCard);
+    });
+
+    it('should shuffle the discard pile back into the draw pile', () => {
+      expect(deck.drawPile.length).to.equal(originalLength - 1);
+      expect(deck.discardPile.length).to.equal(0);
+    });
+  });
+
+  describe('draw from the top with no cards left in the draw pile', function() {
+    let removedCards: IProjectCard[];
+
+    beforeEach(function() {
+      [game] = testGame(2, {skipInitialCardSelection: true});
+      deck = game.projectDeck;
+      originalLength = game.projectDeck.drawPile.length;
+      bottomCard = deck.drawPile[0];
+
+      // remove all draw pile cards
+      removedCards = deck.drawPile.splice(0);
+
+      drawnCard = deck.draw(game);
+    });
+
+    it('should have an empty discard pile', () => {
+      expect(deck.discardPile.length).to.equal(0);
+    });
+
+    it('the drawn card should be undefined', function() {
+      expect(drawnCard).to.equal(undefined);
+    });
+
+    describe('some cards are discarded before drawing from the top again', function() {
+      beforeEach(function() {
+        deck.discardPile = [...removedCards.splice(0, 11)];
+
+        drawnCard = deck.draw(game);
+      });
+
+      it('should draw the new top card', () => {
+        expect(drawnCard).to.not.equal(undefined);
+      });
+
+      it('should empty the discard pile', () => {
+        expect(deck.discardPile.length).to.equal(0);
+      });
+
+      it('should have the correct number of remaining cards in the draw pile', () => {
+        expect(deck.drawPile.length).to.equal(10);
+      });
+    });
   });
 });

--- a/tests/cards/Deck.spec.ts
+++ b/tests/cards/Deck.spec.ts
@@ -54,8 +54,8 @@ describe('PreludeDeck', function() {
       log: () => {},
     };
 
-    deck.discard(deck.draw(logger));
-    deck.discard(deck.draw(logger));
+    deck.discard(deck.drawLegacy(logger));
+    deck.discard(deck.drawLegacy(logger));
 
     expect(deck.drawPile).has.length(33);
     expect(deck.discardPile).has.length(2);
@@ -93,7 +93,7 @@ describe('CeoDeck', function() {
     const drawCardsCount = 3;
     const deckLength = deck.drawPile.length - drawCardsCount;
     for (let i = 0; i < drawCardsCount; i++) {
-      deck.discard(deck.draw(logger));
+      deck.discard(deck.drawLegacy(logger));
     }
 
     expect(deck.drawPile).has.length(deckLength);

--- a/tests/cards/community/JunkVentures.spec.ts
+++ b/tests/cards/community/JunkVentures.spec.ts
@@ -25,13 +25,13 @@ describe('JunkVentures', function() {
     expect(game.projectDeck.discardPile).is.empty;
     expect(card.canAct(player)).is.false;
 
-    game.projectDeck.discard(game.projectDeck.draw(game));
+    game.projectDeck.discard(game.projectDeck.drawLegacy(game));
     expect(card.canAct(player)).is.false;
 
-    game.projectDeck.discard(game.projectDeck.draw(game));
+    game.projectDeck.discard(game.projectDeck.drawLegacy(game));
     expect(card.canAct(player)).is.false;
 
-    game.projectDeck.discard(game.projectDeck.draw(game));
+    game.projectDeck.discard(game.projectDeck.drawLegacy(game));
     expect(card.canAct(player)).is.true;
   });
 

--- a/tests/cards/moon/LunarPlanningOffice.spec.ts
+++ b/tests/cards/moon/LunarPlanningOffice.spec.ts
@@ -42,7 +42,7 @@ describe('LunarPlanningOffice', () => {
     expect(game.projectDeck.discardPile.map((c) => c.name)).has.members([CardName.MICRO_MILLS]);
 
     // Robotic Workforce is at the top of the deck.
-    expect(game.projectDeck.draw(game).name).eq(CardName.ROBOTIC_WORKFORCE);
+    expect(game.projectDeck.drawLegacy(game).name).eq(CardName.ROBOTIC_WORKFORCE);
   });
 });
 


### PR DESCRIPTION
Renames existing `draw` method to `drawLegacy` while we switch references over to the new `draw` in stages.

The new `draw` returns undefined when the draw pile is empty, rather than throwing an error that's generally not handled properly.

~~Switches `AsteroidDeflectionSystem` and `SearchForLife` over to the new `draw` with some light refactoring to tidy them up a bit.~~
