### PR TITLE
Reflect modified global requirements limits in the UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "mnemonist": "^0.39.3",
         "prom-client": "^14.0.1",
         "spectre.css": "^0.5.8",
+        "ts-pattern": "^4.3.0",
         "vti": "^0.1.7",
         "vue": "2.6.10",
         "vue-template-compiler": "2.6.10",
@@ -7866,6 +7867,11 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ts-pattern": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.3.0.tgz",
+      "integrity": "sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg=="
+    },
     "node_modules/tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -14882,6 +14888,11 @@
           }
         }
       }
+    },
+    "ts-pattern": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.3.0.tgz",
+      "integrity": "sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg=="
     },
     "tsconfig": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mnemonist": "^0.39.3",
     "prom-client": "^14.0.1",
     "spectre.css": "^0.5.8",
+    "ts-pattern": "^4.3.0",
     "vti": "^0.1.7",
     "vue": "2.6.10",
     "vue-template-compiler": "2.6.10",

--- a/src/client/components/card/Card.vue
+++ b/src/client/components/card/Card.vue
@@ -7,7 +7,7 @@
               <CardTags :tags="getTags()" />
           </div>
           <CardTitle :title="card.name" :type="getCardType()"/>
-          <CardContent v-if="getCardMetadata() !== undefined" :metadata="getCardMetadata()" :requirements="getCardRequirements()" :isCorporation="isCorporationCard()" :padBottom="hasResourceType" />
+          <CardContent v-if="getCardMetadata() !== undefined" :metadata="getCardMetadata()" :requirements="getCardRequirements()" :isCorporation="isCorporationCard()" :padBottom="hasResourceType" :requirementsModifiers="getCardRequirementsModifiers()" />
       </div>
       <CardExpansion :expansion="getCardExpansion()" :isCorporation="isCorporationCard()"/>
       <CardResourceCounter v-if="hasResourceType" :amount="getResourceAmount()" :type="resourceType" />
@@ -37,6 +37,7 @@ import {CardResource} from '@/common/CardResource';
 import {getCardOrThrow} from '@/client/cards/ClientCardManifest';
 import {CardName} from '@/common/cards/CardName';
 import {CardRequirementDescriptor} from '@/common/cards/CardRequirementDescriptor';
+import {RequirementType} from '@/common/cards/RequirementType';
 
 const CARDS_WITH_EXTERNAL_DOCUMENTATION = [
   CardName.BOTANICAL_EXPERIENCE,
@@ -130,6 +131,9 @@ export default Vue.extend({
     },
     getCardRequirements(): Array<CardRequirementDescriptor> {
       return this.cardInstance.requirements;
+    },
+    getCardRequirementsModifiers(): Map<RequirementType, number> {
+      return new Map(this.card.requirementsModifiers.map((rme) => [rme.type, rme.modifier]));
     },
     getResourceAmount(): number {
       return this.card.resources || this.robotCard?.resources || 0;

--- a/src/client/components/card/CardContent.vue
+++ b/src/client/components/card/CardContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="getClasses()">
-    <CardRequirementsComponent v-if="requirements.length > 0" :requirements="requirements"/>
+    <CardRequirementsComponent v-if="requirements.length > 0" :requirements="requirements" :requirementsModifiers="requirementsModifiers"/>
     <CardRenderData v-if="metadata.renderData" :renderData="metadata.renderData" />
     <CardDescription v-if="metadata.description" :item="metadata.description" />
     <CardVictoryPoints v-if="metadata.victoryPoints" :victoryPoints="metadata.victoryPoints" />
@@ -17,6 +17,7 @@ import CardVictoryPoints from './CardVictoryPoints.vue';
 import CardDescription from './CardDescription.vue';
 import CardRenderData from './CardRenderData.vue';
 import {CardRequirementDescriptor} from '@/common/cards/CardRequirementDescriptor';
+import {RequirementType} from '@/common/cards/RequirementType';
 
 export default Vue.extend({
   name: 'CardContent',
@@ -27,6 +28,9 @@ export default Vue.extend({
     },
     requirements: {
       type: Array<CardRequirementDescriptor>,
+    },
+    requirementsModifiers: {
+      type: Object as () => Map<RequirementType, number>,
     },
     isCorporation: {
       type: Boolean,

--- a/src/client/components/card/CardRequirementsComponent.vue
+++ b/src/client/components/card/CardRequirementsComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="getClasses">
     <div v-for="(req, idx) in requirements" :key="idx">
-      <card-requirement :requirement="req" :leftMargin="indentRight[idx]"/>
+      <card-requirement :requirement="req" :requirementsModifiers="requirementsModifiers" :leftMargin="indentRight[idx]"/>
     </div>
   </div>
 </template>
@@ -11,6 +11,7 @@
 import Vue from 'vue';
 import CardRequirementComponent from './CardRequirementComponent.vue';
 import {CardRequirementDescriptor} from '@/common/cards/CardRequirementDescriptor';
+import {RequirementType} from '@/common/cards/RequirementType';
 
 export default Vue.extend({
   name: 'CardRequirementsComponent',
@@ -18,6 +19,9 @@ export default Vue.extend({
     requirements: {
       type: Array<CardRequirementDescriptor>,
       required: true,
+    },
+    requirementsModifiers: {
+      type: Object as () => Map<RequirementType, number>,
     },
   },
   components: {

--- a/src/common/GlobalParameter.ts
+++ b/src/common/GlobalParameter.ts
@@ -1,3 +1,5 @@
+import {match} from 'ts-pattern';
+
 export enum GlobalParameter {
   OCEANS = 'oceans',
   OXYGEN = 'oxygen',
@@ -17,3 +19,35 @@ export const GLOBAL_PARAMETERS = [
   GlobalParameter.MOON_MINING_RATE,
   GlobalParameter.MOON_LOGISTICS_RATE,
 ] as const;
+
+export interface GlobalParameterLimits {
+  minimum: number,
+  maximum: number,
+  scale: number,
+}
+
+export function getGlobalParameterLimits(globalParameter: GlobalParameter): GlobalParameterLimits {
+  return match(globalParameter)
+    .with(GlobalParameter.OCEANS, () => {
+      return {minimum: 0, maximum: 9, scale: 1};
+    })
+    .with(GlobalParameter.OXYGEN, () => {
+      return {minimum: 0, maximum: 14, scale: 1};
+    })
+    .with(GlobalParameter.TEMPERATURE, () => {
+      return {minimum: -30, maximum: 8, scale: 2};
+    })
+    .with(GlobalParameter.VENUS, () => {
+      return {minimum: 0, maximum: 30, scale: 2};
+    })
+    .with(GlobalParameter.MOON_HABITAT_RATE, () => {
+      return {minimum: 0, maximum: 8, scale: 1};
+    })
+    .with(GlobalParameter.MOON_MINING_RATE, () => {
+      return {minimum: 0, maximum: 8, scale: 1};
+    })
+    .with(GlobalParameter.MOON_LOGISTICS_RATE, () => {
+      return {minimum: 0, maximum: 8, scale: 1};
+    })
+    .exhaustive();
+}

--- a/src/common/cards/RequirementType.ts
+++ b/src/common/cards/RequirementType.ts
@@ -1,3 +1,6 @@
+import {match} from 'ts-pattern';
+import {GlobalParameter} from '../GlobalParameter';
+
 export enum RequirementType {
     OXYGEN = 'O2',
     TEMPERATURE = 'C',
@@ -31,4 +34,35 @@ export enum RequirementType {
     // Underworld
     EXCAVATION = 'Excavation',
     CORRUPTION = 'Corruption',
+}
+
+export function requirementTypeFromGlobalParameter(globalParameter: GlobalParameter): RequirementType {
+  return match(globalParameter)
+    .with(GlobalParameter.OCEANS, () => RequirementType.OCEANS)
+    .with(GlobalParameter.OXYGEN, () => RequirementType.OXYGEN)
+    .with(GlobalParameter.TEMPERATURE, () => RequirementType.TEMPERATURE)
+    .with(GlobalParameter.VENUS, () => RequirementType.VENUS)
+    .with(GlobalParameter.MOON_HABITAT_RATE, () => RequirementType.HABITAT_RATE)
+    .with(GlobalParameter.MOON_MINING_RATE, () => RequirementType.MINING_RATE)
+    .with(GlobalParameter.MOON_LOGISTICS_RATE, () => RequirementType.LOGISTIC_RATE)
+    .exhaustive();
+}
+
+export function globalParameterForRequirementType(requirementType: RequirementType): GlobalParameter | null {
+  switch (requirementType) {
+  case RequirementType.TEMPERATURE:
+    return GlobalParameter.TEMPERATURE;
+  case RequirementType.OXYGEN:
+    return GlobalParameter.OXYGEN;
+  case RequirementType.VENUS:
+    return GlobalParameter.VENUS;
+  case RequirementType.HABITAT_RATE:
+    return GlobalParameter.MOON_HABITAT_RATE;
+  case RequirementType.MINING_RATE:
+    return GlobalParameter.MOON_MINING_RATE;
+  case RequirementType.LOGISTIC_RATE:
+    return GlobalParameter.MOON_LOGISTICS_RATE;
+  default:
+    return null;
+  }
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,4 @@
-import { GlobalParameter, getGlobalParameterLimits } from "./GlobalParameter";
+import {GlobalParameter, getGlobalParameterLimits} from './GlobalParameter';
 
 // Base constants
 export const CARD_COST = 3;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,3 +1,5 @@
+import { GlobalParameter, getGlobalParameterLimits } from "./GlobalParameter";
+
 // Base constants
 export const CARD_COST = 3;
 export const MILESTONE_COST = 8;
@@ -12,13 +14,13 @@ export const OCEAN_BONUS = 2;
 
 // Global parameters
 export const HEAT_FOR_TEMPERATURE = 8;
-export const MAX_OCEAN_TILES = 9;
-export const MAX_TEMPERATURE = 8;
-export const MAX_OXYGEN_LEVEL = 14;
-export const MIN_TEMPERATURE = -30;
-export const MIN_OXYGEN_LEVEL = 0;
-export const MIN_VENUS_SCALE = 0;
-export const MAX_VENUS_SCALE = 30;
+export const MAX_OCEAN_TILES = getGlobalParameterLimits(GlobalParameter.OCEANS).maximum;
+export const MAX_TEMPERATURE = getGlobalParameterLimits(GlobalParameter.TEMPERATURE).maximum;
+export const MAX_OXYGEN_LEVEL = getGlobalParameterLimits(GlobalParameter.OXYGEN).maximum;
+export const MIN_TEMPERATURE = getGlobalParameterLimits(GlobalParameter.TEMPERATURE).minimum;
+export const MIN_OXYGEN_LEVEL = getGlobalParameterLimits(GlobalParameter.OXYGEN).minimum;
+export const MIN_VENUS_SCALE = getGlobalParameterLimits(GlobalParameter.VENUS).minimum;
+export const MAX_VENUS_SCALE = getGlobalParameterLimits(GlobalParameter.VENUS).maximum;
 
 export const OXYGEN_LEVEL_FOR_TEMPERATURE_BONUS = 8;
 export const TEMPERATURE_FOR_OCEAN_BONUS = 0;

--- a/src/common/models/CardModel.ts
+++ b/src/common/models/CardModel.ts
@@ -3,7 +3,13 @@ import {Units} from '../Units';
 import {CardName} from '../cards/CardName';
 import {Resource} from '../Resource';
 import {CardDiscount} from '../cards/Types';
+import {RequirementType} from '../cards/RequirementType';
 import {Tag} from '../cards/Tag';
+
+export interface RequirementModifierEntry {
+    type: RequirementType;
+    modifier: number;
+}
 
 export interface CardModel {
     name: CardName;
@@ -11,6 +17,9 @@ export interface CardModel {
     calculatedCost?: number;
     isSelfReplicatingRobotsCard?: boolean,
     discount?: Array<CardDiscount>,
+    // TODO: Ideally this would be a Map<RequirementType, number> but Maps don't JSON serialize.
+    // We should probably polyfill a toJSON and fromJSON into Map rather than storing this as an Array.
+    requirementsModifiers: Array<RequirementModifierEntry>,
     isDisabled?: boolean; // Used with Pharmacy Union
     warning?: string | Message;
     reserveUnits?: Readonly<Units>; // Written for The Moon, but useful in other contexts.

--- a/src/server/cards/requirements/GlobalParameterRequirement.ts
+++ b/src/server/cards/requirements/GlobalParameterRequirement.ts
@@ -1,10 +1,9 @@
 import {IPlayer} from '../../IPlayer';
 import {InequalityRequirement} from './InequalityRequirement';
-import {GlobalParameter} from '../../../common/GlobalParameter';
+import {GlobalParameter, getGlobalParameterLimits} from '../../../common/GlobalParameter';
 import {YesAnd} from './CardRequirement';
 
 export abstract class GlobalParameterRequirement extends InequalityRequirement {
-  protected scale: number = 1;
   protected abstract parameter: GlobalParameter;
 
   public abstract getGlobalValue(player: IPlayer): number;
@@ -23,7 +22,7 @@ export abstract class GlobalParameterRequirement extends InequalityRequirement {
   }
 
   public getScore(player: IPlayer): number {
-    const playerRequirementsBonus = player.getGlobalParameterRequirementBonus(this.parameter) * this.scale;
+    const playerRequirementsBonus = player.getGlobalParameterRequirementBonus(this.parameter) * this.scale();
 
     const level = this.getGlobalValue(player);
 
@@ -35,6 +34,10 @@ export abstract class GlobalParameterRequirement extends InequalityRequirement {
   }
 
   public distance(player: IPlayer): number {
-    return Math.floor(Math.abs(this.getScore(player) - this.count) / this.scale);
+    return Math.floor(Math.abs(this.getScore(player) - this.count) / this.scale());
+  }
+
+  protected scale(): number {
+    return getGlobalParameterLimits(this.parameter).scale;
   }
 }

--- a/src/server/cards/requirements/OxygenRequirement.ts
+++ b/src/server/cards/requirements/OxygenRequirement.ts
@@ -8,7 +8,6 @@ import {MAX_OXYGEN_LEVEL, MIN_OXYGEN_LEVEL} from '../../../common/constants';
 export class OxygenRequirement extends GlobalParameterRequirement {
   public readonly type = RequirementType.OXYGEN;
   protected readonly parameter = GlobalParameter.OXYGEN;
-  protected override readonly scale = 1;
 
   constructor(options?: Partial<Options>) {
     const count = options?.count ?? 1;

--- a/src/server/cards/requirements/TemperatureRequirement.ts
+++ b/src/server/cards/requirements/TemperatureRequirement.ts
@@ -8,7 +8,6 @@ import {Options} from './CardRequirement';
 export class TemperatureRequirement extends GlobalParameterRequirement {
   public readonly type = RequirementType.TEMPERATURE;
   protected readonly parameter = GlobalParameter.TEMPERATURE;
-  protected override readonly scale = 2;
 
   constructor(options?: Partial<Options>) {
     const count = options?.count ?? 1;

--- a/src/server/cards/requirements/VenusRequirement.ts
+++ b/src/server/cards/requirements/VenusRequirement.ts
@@ -8,7 +8,6 @@ import {Options} from './CardRequirement';
 export class VenusRequirement extends GlobalParameterRequirement {
   public readonly type = RequirementType.VENUS;
   protected readonly parameter = GlobalParameter.VENUS;
-  protected override readonly scale = 2;
 
   constructor(options?: Partial<Options>) {
     const count = options?.count ?? 1;

--- a/src/server/models/ModelUtils.ts
+++ b/src/server/models/ModelUtils.ts
@@ -1,6 +1,7 @@
 import {CardModel} from '../../common/models/CardModel';
 import {ColonyModel} from '../../common/models/ColonyModel';
 import {Color} from '../../common/Color';
+import {GLOBAL_PARAMETERS} from '../../common/GlobalParameter';
 import {IGame} from '../IGame';
 import {ICard} from '../cards/ICard';
 import {isIProjectCard} from '../cards/IProjectCard';
@@ -11,6 +12,8 @@ import {IColony} from '../colonies/IColony';
 import {CardName} from '../../common/cards/CardName';
 import {Tag} from '../../common/cards/Tag';
 import {isICorporationCard} from '../cards/corporation/ICorporationCard';
+import {requirementTypeFromGlobalParameter} from '../../common/cards/RequirementType';
+import {RequirementModifierEntry} from '../../common/models/CardModel';
 
 export function cardsToModel(
   player: IPlayer,
@@ -24,6 +27,14 @@ export function cardsToModel(
 ): Array<CardModel> {
   return cards.map((card, index) => {
     let discount = card.cardDiscount === undefined ? undefined : (Array.isArray(card.cardDiscount) ? card.cardDiscount : [card.cardDiscount]);
+
+    const requirementsModifiers = GLOBAL_PARAMETERS.map((parameter) => {
+      const rme: RequirementModifierEntry = {
+        type: requirementTypeFromGlobalParameter(parameter),
+        modifier: player.getGlobalParameterRequirementBonus(parameter),
+      };
+      return rme;
+    });
 
     // Too bad this is hard-coded
     if (card.name === CardName.CRESCENT_RESEARCH_ASSOCIATION) {
@@ -51,6 +62,7 @@ export function cardsToModel(
       bonusResource: isIProjectCard(card) ? card.bonusResource : undefined,
       discount: discount,
       cloneTag: isICloneTagCard(card) ? card.cloneTag : undefined,
+      requirementsModifiers: requirementsModifiers,
     };
     const isDisabled = isICorporationCard(card) ? (card.isDisabled || false) : (options.enabled?.[index] === false);
     if (isDisabled === true) {

--- a/src/server/models/ServerModel.ts
+++ b/src/server/models/ServerModel.ts
@@ -32,6 +32,9 @@ import {SpaceId} from '../../common/Types';
 import {cardsToModel, coloniesToModel} from './ModelUtils';
 import {runId} from '../utils/server-ids';
 import {UnderworldExpansion} from '../underworld/UnderworldExpansion';
+import {GLOBAL_PARAMETERS} from '../../common/GlobalParameter';
+import {requirementTypeFromGlobalParameter} from '../../common/cards/RequirementType';
+import {RequirementModifierEntry} from '../../common/models/CardModel';
 
 export class Server {
   public static getSimpleGameModel(game: IGame): SimpleGameModel {
@@ -124,12 +127,21 @@ export class Server {
   }
 
   public static getSelfReplicatingRobotsTargetCards(player: IPlayer): Array<CardModel> {
+    const requirementsModifiers = GLOBAL_PARAMETERS.map((parameter) => {
+      const rme: RequirementModifierEntry = {
+        type: requirementTypeFromGlobalParameter(parameter),
+        modifier: player.getGlobalParameterRequirementBonus(parameter),
+      };
+      return rme;
+    });
+
     return player.getSelfReplicatingRobotsTargetCards().map((targetCard) => {
       const model: CardModel = {
         resources: targetCard.resourceCount,
         name: targetCard.card.name,
         calculatedCost: player.getCardCost(targetCard.card),
         isSelfReplicatingRobotsCard: true,
+        requirementsModifiers: requirementsModifiers,
       };
       return model;
     });


### PR DESCRIPTION
There are a couple of major questions/issues here:
1. Should we implement this generally like this (passing the
   requirements modifiers from the server to the client, and asking the
   client to compute the applicable modifications), or should the server
   pre-compute the relevant modifications and tell the client about
   them?
2. Assuming we pass the requirement modifications to the client, how
   should we do so? This is currently doing so with an ugly
   `Array<RequirementModifierEntry>` because `Map` doesn't
   JSON-serialize. Is this fine? Should we try to force `Map` to JSON
   serialize? Is there a different `Map`-like type we should be using
   which is more JSON friendly?

Fixes #6302