### PR TITLE
Standardize the luna colony warning.

### DIFF
--- a/src/client/components/WarningsComponent.vue
+++ b/src/client/components/WarningsComponent.vue
@@ -14,6 +14,7 @@ const descriptions: Record<Warning, string> = {
   'maxtemp': 'Note: the temperature is already at its goal.',
   'maxoceans': 'Note: all oceans are already on the board.',
   'maxvenus': 'Note: Venus scale is already at its goal.',
+  'buildOnLuna': 'You will only be able to build the colony on Luna.',
 };
 
 export default Vue.extend({

--- a/src/common/cards/ClientCard.ts
+++ b/src/common/cards/ClientCard.ts
@@ -1,4 +1,3 @@
-import {Message} from '../logs/Message';
 import {CardResource} from '../CardResource';
 import {Units} from '../Units';
 import {CardName} from './CardName';
@@ -21,7 +20,6 @@ export type ClientCard = {
   type: CardType;
   requirements: Array<CardRequirementDescriptor>;
   metadata: ICardMetadata;
-  warning?: string | Message;
   productionBox?: Units; // Replace with behavior?
   resourceType?: CardResource;
   startingMegaCredits?: number; // Corporation and Prelude

--- a/src/common/cards/Warning.ts
+++ b/src/common/cards/Warning.ts
@@ -1,4 +1,5 @@
 export type Warning =
  'maxtemp' |
  'maxoceans' |
- 'maxvenus';
+ 'maxvenus' |
+ 'buildOnLuna';

--- a/src/server/cards/Card.ts
+++ b/src/server/cards/Card.ts
@@ -99,7 +99,6 @@ const cardProperties = new Map<CardName, InternalProperties>();
 export abstract class Card {
   protected readonly properties: InternalProperties;
   public resourceCount = 0;
-  public warning?: string;
   public warnings: Array<Warning> = [];
 
   private internalize(external: StaticCardProperties): InternalProperties {

--- a/src/server/cards/ICard.ts
+++ b/src/server/cards/ICard.ts
@@ -1,7 +1,6 @@
 import {CardType} from '../../common/cards/CardType';
 import {IProjectCard} from './IProjectCard';
 import {Space} from '../boards/Space';
-import {Message} from '../../common/logs/Message';
 import {PlayerInput} from '../PlayerInput';
 import {IPlayer} from '../IPlayer';
 import {Tag} from '../../common/cards/Tag';
@@ -122,10 +121,8 @@ export interface ICard {
   requirements: Array<CardRequirementDescriptor>;
   metadata: ICardMetadata;
 
-  /** Per-instance message when choosing a card to play or act upon. */
-  warning?: string | Message;
   /**
-   * State-specific data about whether this card's action has other warnings.
+   * Per-instance state-specific warnings about this card's action.
    */
   warnings?: Array<Warning>;
 

--- a/src/server/cards/colonies/MinorityRefuge.ts
+++ b/src/server/cards/colonies/MinorityRefuge.ts
@@ -44,7 +44,7 @@ export class MinorityRefuge extends Card implements IProjectCard {
       if (lunaIsAvailable === false) {
         return false;
       }
-      this.warning = 'You will only be able to build the colony on Luna.';
+      this.warnings.push('buildOnLuna');
     }
 
     return true;

--- a/src/server/cards/colonies/PioneerSettlement.ts
+++ b/src/server/cards/colonies/PioneerSettlement.ts
@@ -62,7 +62,7 @@ export class PioneerSettlement extends Card implements IProjectCard {
       if (lunaIsAvailable === false) {
         return false;
       }
-      this.warning = 'You will only be able to build the colony on Luna.';
+      this.warnings.push('buildOnLuna');
     }
 
     return true;

--- a/src/server/models/ModelUtils.ts
+++ b/src/server/models/ModelUtils.ts
@@ -34,7 +34,7 @@ export function cardsToModel(
     }
 
 
-    let warning = card.warning;
+    let warning = undefined;
     const playCardMetadata = options?.extras?.get(card.name);
     if (typeof(playCardMetadata?.details) === 'object') {
       const thinkTankResources = playCardMetadata?.details.thinkTankResources;

--- a/src/server/tools/export_card_rendering.ts
+++ b/src/server/tools/export_card_rendering.ts
@@ -66,7 +66,6 @@ class CardProcessor {
       type: card.type,
       requirements: card.requirements ?? [],
       metadata: card.metadata,
-      warning: card.warning,
       productionBox: Units.isUnits(production) ? Units.of(production) : Units.EMPTY, // Dynamic units aren't used on on the client side.
       resourceType: card.resourceType,
       startingMegaCredits: startingMegaCredits,


### PR DESCRIPTION
Looks like a nice cleanup, actually. It removes `warning` from ICard and ClientCard.