### PR TITLE
Minimize Windows CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
       with:
         node-version: '18.x'
     - run: npm ci
-    - run: npm run lint
+    # - run: npm run lint
     - run: npm run build
-    - run: npm run build:tests
-    - run: npm test
+    # - run: npm run build:tests
+    # - run: npm test
 
   build-docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Windows is always slower than Linux, and adds no real value; running the tests twice is at best useful for finding non-determinstic tests, and possibly occasionally other things?