### PR TITLE
Fix Underworld payment regression with Friends in High places.

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -846,7 +846,7 @@ export class Player implements IPlayer {
       auroraiData: card.type === CardType.STANDARD_PROJECT,
       graphene: card.tags.includes(Tag.CITY) || card.tags.includes(Tag.SPACE),
       kuiperAsteroids: card.name === CardName.AQUIFER_STANDARD_PROJECT || card.name === CardName.ASTEROID_STANDARD_PROJECT,
-      corruption: card.tags.includes(Tag.EARTH),
+      corruption: card.tags.includes(Tag.EARTH) && this.cardIsInEffect(CardName.FRIENDS_IN_HIGH_PLACES),
     };
   }
 

--- a/tests/cards/underworld/FriendsInHighPlaces.spec.ts
+++ b/tests/cards/underworld/FriendsInHighPlaces.spec.ts
@@ -57,4 +57,14 @@ describe('FriendsInHighPlaces', () => {
     player.underworldData.corruption = 1;
     expect(player.canPlay(protectedValley)).is.false;
   });
+
+  it('does not work without Friends in High Places', () => {
+    // Large Convoy costs 36.
+    const largeConvoy = new LargeConvoy();
+    player.megaCredits = 30;
+    player.underworldData.corruption = 1;
+    expect(player.canPlay(largeConvoy)).eq(true);
+    player.playedCards = [];
+    expect(player.canPlay(largeConvoy)).eq(false);
+  });
 });


### PR DESCRIPTION
Players were reporting finding that the UI was allowing them to play cards they couldn't afford without corruption and Friends in High Places. The cards were being deemed playable before sending them to the UI. Fortunately the UI prevented their purchases.