### PR TITLE
Make Neutrinograph playable even when all spaces are identified.

### DIFF
--- a/src/server/behavior/Executor.ts
+++ b/src/server/behavior/Executor.ts
@@ -35,6 +35,7 @@ import {SelectResource} from '../inputs/SelectResource';
 import {RemoveResourcesFromCard} from '../deferredActions/RemoveResourcesFromCard';
 import {isIProjectCard} from '../cards/IProjectCard';
 import {MAXIMUM_HABITAT_RATE, MAXIMUM_LOGISTICS_RATE, MAXIMUM_MINING_RATE, MAX_OCEAN_TILES, MAX_OXYGEN_LEVEL, MAX_TEMPERATURE, MAX_VENUS_SCALE} from '../../common/constants';
+import {CardName} from '../../common/cards/CardName';
 
 export class Executor implements BehaviorExecutor {
   public canExecute(behavior: Behavior, player: IPlayer, card: ICard, canAffordOptions?: CanAffordOptions) {
@@ -247,8 +248,15 @@ export class Executor implements BehaviorExecutor {
     if (behavior.underworld !== undefined) {
       const underworld = behavior.underworld;
       if (underworld.identify !== undefined) {
-        if (UnderworldExpansion.identifiableSpaces(player).length === 0) {
-          return false;
+        if (card.name === CardName.NEUTRINOGRAPH || player.cardIsInEffect(CardName.NEUTRINOGRAPH)) {
+          // Special case for Neutrinograph. Excavatable spaces are ones that are unidentified or reidentifiable.
+          if (UnderworldExpansion.excavatableSpaces(player).length === 0) {
+            return false;
+          }
+        } else {
+          if (UnderworldExpansion.identifiableSpaces(player).length === 0) {
+            return false;
+          }
         }
       }
     }

--- a/tests/cards/underworld/Neutrinograph.spec.ts
+++ b/tests/cards/underworld/Neutrinograph.spec.ts
@@ -16,8 +16,21 @@ describe('Neutrinograph', () => {
     expect(card.canPlay(player)).is.false;
     player.tagsForTest = {science: 4};
     expect(card.canPlay(player)).is.true;
+  });
 
+  it('canPlay while some spaces are excavatable', () => {
+    const card = new Neutrinograph();
+    const [/* game */, player] = testGame(2, {underworldExpansion: true});
+
+    player.tagsForTest = {science: 4};
+    const spaces = UnderworldExpansion.identifiableSpaces(player);
+    spaces.forEach((space) => space.undergroundResources = 'nothing');
+    spaces.slice(1).forEach((space) => space.excavator = player);
     cast(card.play(player), undefined);
+    expect(card.canPlay(player)).is.true;
+
+    spaces[0].excavator = player;
+    expect(card.canPlay(player)).is.false;
   });
 
   it('play', () => {


### PR DESCRIPTION
Fixes #6471