### PR TITLE
Allow players to include specific cards 

### DIFF
--- a/src/client/components/create/CardsFilter.vue
+++ b/src/client/components/create/CardsFilter.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="cards-filter">
-        <h2 v-i18n>Cards to exclude from the game</h2>
+        <h2 v-i18n>{{ title }}</h2>
         <div class="cards-filter-results-cont" v-if="selectedCardNames.length">
             <div class="cards-filter-result" v-for="cardName in selectedCardNames" v-bind:key="cardName">
                 <label>{{ cardName }}
@@ -51,7 +51,12 @@ interface CardsFilterModel {
 
 export default Vue.extend({
   name: 'CardsFilter',
-  props: {},
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+  },
   data(): CardsFilterModel {
     return {
       selectedCardNames: [],

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -288,6 +288,11 @@
                                 <span v-i18n>Exclude some cards</span>
                             </label>
 
+                            <input type="checkbox" v-model="showIncludedCards" id="includedCards-checkbox">
+                            <label for="includedCards-checkbox">
+                                <span v-i18n>Include some cards</span>
+                            </label>
+
                             <template v-if="colonies">
                                 <input type="checkbox" v-model="showColoniesList" id="customColonies-checkbox">
                                 <label for="customColonies-checkbox">
@@ -481,6 +486,15 @@
               <CardsFilter
                   ref="cardsFilter"
                   v-on:cards-list-changed="updateBannedCards"
+                  :title="'Cards to exclude from the game'"
+              ></CardsFilter>
+            </div>
+
+            <div class="create-game--block" v-if="showIncludedCards">
+              <CardsFilter
+                  ref="cardsFilter2"
+                  v-on:cards-list-changed="updateIncludedCards"
+                  :title="'Cards to include in the game'"
               ></CardsFilter>
             </div>
           <preferences-icon></preferences-icon>
@@ -522,6 +536,7 @@ type Refs = {
   corporationsFilter: InstanceType<typeof CorporationsFilter>,
   preludesFilter: InstanceType<typeof PreludesFilter>,
   cardsFilter: InstanceType<typeof CardsFilter>,
+  cardsFilter2: InstanceType<typeof CardsFilter>,
   file: HTMLInputElement,
 }
 
@@ -557,11 +572,13 @@ export default (Vue as WithRefs<Refs>).extend({
       showCorporationList: false,
       showPreludesList: false,
       showBannedCards: false,
+      showIncludedCards: false,
       turmoil: false,
       customColonies: [],
       customCorporations: [],
       customPreludes: [],
       bannedCards: [],
+      includedCards: [],
       board: BoardName.THARSIS,
       boards: [
         BoardName.THARSIS,
@@ -689,12 +706,14 @@ export default (Vue as WithRefs<Refs>).extend({
             const customCorporations = results[json_constants.CUSTOM_CORPORATIONS] || results[json_constants.OLD_CUSTOM_CORPORATIONS] || [];
             const customColonies = results[json_constants.CUSTOM_COLONIES] || results[json_constants.OLD_CUSTOM_COLONIES] || [];
             const bannedCards = results[json_constants.BANNED_CARDS] || results[json_constants.OLD_BANNED_CARDS] || [];
+            const includedCards = results[json_constants.INCLUDED_CARDS] || [];
             const customPreludes = results[json_constants.CUSTOM_PRELUDES] || [];
 
             component.playersCount = players.length;
             component.showCorporationList = customCorporations.length > 0;
             component.showColoniesList = customColonies.length > 0;
             component.showBannedCards = bannedCards.length > 0;
+            component.showIncludedCards = includedCards.length > 0;
             component.showPreludesList = customPreludes.length > 0;
 
             // Capture the solar phase option since several of the other results will change
@@ -708,6 +727,7 @@ export default (Vue as WithRefs<Refs>).extend({
               json_constants.OLD_CUSTOM_COLONIES,
               json_constants.CUSTOM_PRELUDES,
               json_constants.BANNED_CARDS,
+              json_constants.INCLUDED_CARDS,
               json_constants.OLD_BANNED_CARDS,
               'players',
               'solarPhaseOption',
@@ -731,6 +751,7 @@ export default (Vue as WithRefs<Refs>).extend({
                 if (component.showCorporationList) refs.corporationsFilter.selectedCorporations = customCorporations;
                 if (component.showPreludesList) refs.preludesFilter.updatePreludes(customPreludes);
                 if (component.showBannedCards) refs.cardsFilter.selectedCardNames = bannedCards;
+                if (component.showIncludedCards) refs.cardsFilter2.selectedCardNames = includedCards;
                 if (!component.seededGame) component.seed = Math.random();
                 // set to alter after any watched properties
                 component.solarPhaseOption = Boolean(capturedSolarPhaseOption);
@@ -765,6 +786,9 @@ export default (Vue as WithRefs<Refs>).extend({
     },
     updateBannedCards(bannedCards: Array<CardName>) {
       this.bannedCards = bannedCards;
+    },
+    updateIncludedCards(includedCards: Array<CardName>) {
+      this.includedCards = includedCards;
     },
     updatecustomColonies(customColonies: Array<ColonyName>) {
       this.customColonies = customColonies;
@@ -955,6 +979,7 @@ export default (Vue as WithRefs<Refs>).extend({
       const customCorporations = this.customCorporations;
       const customPreludes = this.customPreludes;
       const bannedCards = this.bannedCards;
+      const includedCards = this.includedCards;
       const board = this.board;
       const seed = this.seed;
       const promoCardsOption = this.promoCardsOption;
@@ -1115,6 +1140,7 @@ export default (Vue as WithRefs<Refs>).extend({
         customColoniesList: customColonies,
         customPreludes,
         bannedCards,
+        includedCards,
         board,
         seed,
         solarPhaseOption,

--- a/src/client/components/create/CreateGameModel.ts
+++ b/src/client/components/create/CreateGameModel.ts
@@ -22,10 +22,12 @@ export interface CreateGameModel {
   colonies: boolean;
   turmoil: boolean;
   bannedCards: Array<CardName>;
+  includedCards: Array<CardName>;
   customColonies: Array<ColonyName>;
   customCorporations: Array<CardName>;
   customPreludes: Array<CardName>;
   showBannedCards: boolean;
+  showIncludedCards: boolean;
   showCorporationList: boolean;
   showColoniesList: boolean;
   showPreludesList: boolean;

--- a/src/client/components/create/json.ts
+++ b/src/client/components/create/json.ts
@@ -4,4 +4,5 @@ export const CUSTOM_COLONIES = 'customColonies';
 export const OLD_CUSTOM_COLONIES = 'customColoniesList';
 export const CUSTOM_PRELUDES = 'customPreludes';
 export const BANNED_CARDS = 'bannedCards';
+export const INCLUDED_CARDS = 'includedCards';
 export const OLD_BANNED_CARDS = 'cardsBlackList';

--- a/src/common/game/NewGameConfig.ts
+++ b/src/common/game/NewGameConfig.ts
@@ -66,6 +66,7 @@ export interface NewGameConfig {
   soloTR: boolean; // Solo victory by getting TR 63 by game end
   customCorporationsList: Array<CardName>;
   bannedCards: Array<CardName>;
+  includedCards: Array<CardName>;
   customColoniesList: Array<ColonyName>;
   customPreludes: Array<CardName>;
   requiresMoonTrackCompletion: boolean; // Moon must be completed to end the game

--- a/src/common/models/GameOptionsModel.ts
+++ b/src/common/models/GameOptionsModel.ts
@@ -8,6 +8,7 @@ export type GameOptionsModel = {
   altVenusBoard: boolean,
   boardName: BoardName,
   bannedCards: Array<CardName>;
+  includedCards: Array<CardName>;
   ceoExtension: boolean,
   coloniesExtension: boolean,
   communityCardsOption: boolean,

--- a/src/server/GameCards.ts
+++ b/src/server/GameCards.ts
@@ -133,6 +133,7 @@ export class GameCards {
     }
 
     cards = this.filterBannedCards(cards);
+    cards = this.addCustomCards(cards, this.gameOptions.includedCards);
     cards = this.filterReplacedCards(cards);
     return cards;
   }

--- a/src/server/game/GameOptions.ts
+++ b/src/server/game/GameOptions.ts
@@ -48,6 +48,7 @@ export type GameOptions = {
   soloTR: boolean; // Solo victory by getting TR 63 by game end
   customCorporationsList: Array<CardName>;
   bannedCards: Array<CardName>;
+  includedCards: Array<CardName>;
   customColoniesList: Array<ColonyName>;
   customPreludes: Array<CardName>;
   customCeos: Array<CardName>;
@@ -70,6 +71,7 @@ export const DEFAULT_GAME_OPTIONS: GameOptions = {
   aresHazards: true,
   boardName: BoardName.THARSIS,
   bannedCards: [],
+  includedCards: [],
   ceoExtension: false,
   clonedGamedId: undefined,
   coloniesExtension: false,

--- a/src/server/models/ServerModel.ts
+++ b/src/server/models/ServerModel.ts
@@ -376,6 +376,7 @@ export class Server {
       aresExtension: options.aresExtension,
       boardName: options.boardName,
       bannedCards: options.bannedCards,
+      includedCards: options.includedCards,
       ceoExtension: options.ceoExtension,
       coloniesExtension: options.coloniesExtension,
       communityCardsOption: options.communityCardsOption,

--- a/src/server/routes/Game.ts
+++ b/src/server/routes/Game.ts
@@ -155,6 +155,7 @@ export class GameHandler extends Handler {
             soloTR: gameReq.soloTR,
             customCorporationsList: gameReq.customCorporationsList,
             bannedCards: gameReq.bannedCards,
+            includedCards: gameReq.includedCards,
             customColoniesList: gameReq.customColoniesList,
             customPreludes: gameReq.customPreludes,
             requiresVenusTrackCompletion: gameReq.requiresVenusTrackCompletion,

--- a/tests/GameCards.spec.ts
+++ b/tests/GameCards.spec.ts
@@ -76,7 +76,7 @@ describe('GameCards', function() {
     expect(ceoNames).not.to.contain(CardName.NEIL); // No Moon
   });
 
-  it('correctly removes banned cards', function () {
+  it('correctly removes banned cards', function() {
     const gameOptions: GameOptions = {
       ...DEFAULT_GAME_OPTIONS,
       corporateEra: true,
@@ -86,7 +86,7 @@ describe('GameCards', function() {
     expect(names).to.not.contain(CardName.SOLAR_WIND_POWER);
   });
 
-  it('correctly includes the included cards', function () {
+  it('correctly includes the included cards', function() {
     const gameOptions: GameOptions = {
       ...DEFAULT_GAME_OPTIONS,
       corporateEra: true,
@@ -95,6 +95,5 @@ describe('GameCards', function() {
     const names = new GameCards(gameOptions).getProjectCards().map((c) => c.name);
     expect(names).to.contain(CardName.VENUSIAN_INSECTS);
   });
-
 });
 

--- a/tests/GameCards.spec.ts
+++ b/tests/GameCards.spec.ts
@@ -75,5 +75,26 @@ describe('GameCards', function() {
     expect(ceoNames).to.contain(CardName.KAREN); // Yes Prelude
     expect(ceoNames).not.to.contain(CardName.NEIL); // No Moon
   });
+
+  it('correctly removes banned cards', function () {
+    const gameOptions: GameOptions = {
+      ...DEFAULT_GAME_OPTIONS,
+      corporateEra: true,
+      bannedCards: [CardName.SOLAR_WIND_POWER],
+    };
+    const names = new GameCards(gameOptions).getProjectCards().map((c) => c.name);
+    expect(names).to.not.contain(CardName.SOLAR_WIND_POWER);
+  });
+
+  it('correctly includes the included cards', function () {
+    const gameOptions: GameOptions = {
+      ...DEFAULT_GAME_OPTIONS,
+      corporateEra: true,
+      includedCards: [CardName.VENUSIAN_INSECTS],
+    };
+    const names = new GameCards(gameOptions).getProjectCards().map((c) => c.name);
+    expect(names).to.contain(CardName.VENUSIAN_INSECTS);
+  });
+
 });
 

--- a/tests/routes/ApiGame.spec.ts
+++ b/tests/routes/ApiGame.spec.ts
@@ -58,6 +58,7 @@ describe('ApiGame', () => {
           'aresExtension': false,
           'boardName': 'tharsis',
           'bannedCards': [],
+          'includedCards': [],
           'ceoExtension': false,
           'coloniesExtension': false,
           'communityCardsOption': false,


### PR DESCRIPTION
Intended as a mirror to the excluded cards feature. In my group we like to play without the actual expansions while still being able to include cards from all expansions. This feature allows for that.