### PR TITLE
Add safeCast to remove some obvious casts.

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -11,11 +11,11 @@ export function isPlayerId(object: any): object is PlayerId {
   return object?.charAt?.(0) === 'p';
 }
 
-export function isGameId(object: any): object is GameId {
+export function isGameId(object: string): object is GameId {
   return object?.charAt?.(0) === 'g';
 }
 
-export function isSpectatorId(object: any): object is SpectatorId {
+export function isSpectatorId(object: string): object is SpectatorId {
   return object?.charAt?.(0) === 's';
 }
 
@@ -23,10 +23,17 @@ export function isSpaceId(object: string): object is SpaceId {
   return /^m?[0-9][0-9]$/.test(object);
 }
 
+export function safeCast<T>(object: any, tester: (object: any) => object is T) {
+  if (tester(object)) {
+    return object;
+  }
+  throw new Error('failed cast: ' + tester.name);
+}
+
 /**
  * Very similar to `any` but only contains primitives, arrays of primitives, or dictionaries of primitives.
  *
- * An object of this type are guaranteed safe to serialize and deserialize.
+ * An object of this type is guaranteed safe to serialize and deserialize.
  */
 export type JSONValue =
     | undefined

--- a/src/server/GameSetup.ts
+++ b/src/server/GameSetup.ts
@@ -3,7 +3,7 @@ import {BoardName} from '../common/boards/BoardName';
 import {ElysiumBoard} from './boards/ElysiumBoard';
 import {IGame} from './IGame';
 import {GameOptions} from './game/GameOptions';
-import {GameId, PlayerId} from '../common/Types';
+import {GameId, isPlayerId, safeCast} from '../common/Types';
 import {HellasBoard} from './boards/HellasBoard';
 import {TharsisBoard} from './boards/TharsisBoard';
 import {IPlayer} from './IPlayer';
@@ -47,7 +47,7 @@ export class GameSetup {
   }
 
   public static neutralPlayerFor(gameId: GameId): IPlayer {
-    const playerId = 'p-' + gameId + '-neutral' as PlayerId;
+    const playerId = safeCast('p-' + gameId + '-neutral', isPlayerId);
     return new Player('neutral', Color.NEUTRAL, true, 0, playerId);
   }
 

--- a/src/server/boards/BoardBuilder.ts
+++ b/src/server/boards/BoardBuilder.ts
@@ -1,5 +1,5 @@
 import {Space, newSpace} from './Space';
-import {SpaceId} from '../../common/Types';
+import {SpaceId, isSpaceId, safeCast} from '../../common/Types';
 import {SpaceBonus} from '../../common/boards/SpaceBonus';
 import {SpaceName} from '../SpaceName';
 import {SpaceType} from '../../common/boards/SpaceType';
@@ -138,7 +138,6 @@ export class BoardBuilder {
     if (id < 10) {
       strId = '0'+strId;
     }
-    // OK to cast this.
-    return strId as SpaceId;
+    return safeCast(strId, isSpaceId);
   }
 }

--- a/src/server/database/PostgreSQL.ts
+++ b/src/server/database/PostgreSQL.ts
@@ -2,7 +2,7 @@ import type * as pg from 'pg';
 import {IDatabase} from './IDatabase';
 import {IGame, Score} from '../IGame';
 import {GameOptions} from '../game/GameOptions';
-import {GameId, ParticipantId} from '../../common/Types';
+import {GameId, ParticipantId, isGameId, safeCast} from '../../common/Types';
 import {SerializedGame} from '../SerializedGame';
 import {daysAgoToSeconds} from './utils';
 import {GameIdLedger} from './IDatabase';
@@ -274,7 +274,7 @@ export class PostgreSQL implements IDatabase {
   public async getParticipants(): Promise<Array<{gameId: GameId, participantIds: Array<ParticipantId>}>> {
     const res = await this.client.query('select game_id, participants from participants');
     return res.rows.map((row) => {
-      return {gameId: row.game_id as GameId, participantIds: row.participants as Array<ParticipantId>};
+      return {gameId: safeCast(row.game_id, isGameId), participantIds: row.participants as Array<ParticipantId>};
     });
   }
 

--- a/src/server/moon/MoonBoard.ts
+++ b/src/server/moon/MoonBoard.ts
@@ -5,7 +5,7 @@ import {IPlayer} from '../IPlayer';
 import {SpaceBonus} from '../../common/boards/SpaceBonus';
 import {SpaceType} from '../../common/boards/SpaceType';
 import {MoonSpaces} from '../../common/moon/MoonSpaces';
-import {SpaceId} from '../../common/Types';
+import {SpaceId, isSpaceId, safeCast} from '../../common/Types';
 
 function mineSpace(id: SpaceId, x: number, y: number, bonus: Array<SpaceBonus>): Space {
   return newSpace(id, SpaceType.LUNAR_MINE, x, y, bonus);
@@ -73,8 +73,7 @@ class Builder {
   public nextId(): SpaceId {
     this.idx++;
     const strId = this.idx.toString().padStart(2, '0');
-    // This cast is safe.
-    return 'm' + strId as SpaceId;
+    return safeCast('m' + strId, isSpaceId);
   }
 }
 

--- a/src/server/routes/Game.ts
+++ b/src/server/routes/Game.ts
@@ -12,7 +12,7 @@ import {Player} from '../Player';
 import {Server} from '../models/ServerModel';
 import {ServeAsset} from './ServeAsset';
 import {NewGameConfig} from '../../common/game/NewGameConfig';
-import {GameId, PlayerId, SpectatorId} from '../../common/Types';
+import {safeCast, isGameId, isSpectatorId, isPlayerId} from '../../common/Types';
 import {generateRandomId} from '../utils/server-ids';
 import {IGame} from '../IGame';
 import {Request} from '../Request';
@@ -99,15 +99,15 @@ export class GameHandler extends Handler {
       req.once('end', async () => {
         try {
           const gameReq: NewGameConfig = JSON.parse(body);
-          const gameId = generateRandomId('g') as GameId;
-          const spectatorId = generateRandomId('s') as SpectatorId;
+          const gameId = safeCast(generateRandomId('g'), isGameId);
+          const spectatorId = safeCast(generateRandomId('s'), isSpectatorId);
           const players = gameReq.players.map((obj: any) => {
             return new Player(
               obj.name,
               obj.color,
               obj.beginner,
               Number(obj.handicap), // For some reason handicap is coming up a string.
-              generateRandomId('p') as PlayerId,
+              safeCast(generateRandomId('p'), isPlayerId),
             );
           });
           let firstPlayerIdx = 0;
@@ -193,3 +193,4 @@ export class GameHandler extends Handler {
     });
   }
 }
+


### PR DESCRIPTION
This isn't meant to remove all uses of `as` but helps with some particularly obvious cases.