### PR TITLE
Update Public Sponsored Grants behavior to match printed card.

### DIFF
--- a/src/locales/cn/pathfinder_cards.json
+++ b/src/locales/cn/pathfinder_cards.json
@@ -79,7 +79,7 @@
   "(Requires 5 science tags. Increase your plant production 2 steps. Gain 3 plants. Add 3 microbes to ANY card. Add 1 animal to ANY card.)": "（需要5个自己的科学标志。将您的植物产能增加2。获得3个植物。将3个微生物添加到任意一张卡片中。将1个动物添加到任意一张卡片中。）",
   "(Requires 6% Oxygen.)": "（需要6％或更高的氧气含量。）",
   "(Requires Kelvinists are ruling or you have 2 delegates there. Increase your energy production 2 steps.)": "（需要执政党：开尔文主义者或2个以上自己的代表。将您的能源产能提高2个。）",
-  "(Requires Scientists are ruling or that you have 2 delegates there. All players lose 2M€. Choose a tag (NOT CITY, ? OR PLANETARY TRACK) and draw 2 cards with that tag.)": "（需要执政党：研究或2个以上的代表。其他所有玩家失去2M€。选择一个标志（除了木星，城市，小丑和行星），并抽取2张卡片。）",
+  "(Requires Scientists are ruling or that you have 2 delegates there. All other players lose 2M€. Choose a tag (NOT CITY, ? OR PLANETARY TRACK) and draw 2 cards with that tag.)": "（需要执政党：研究或2个以上的代表。其他所有玩家失去2M€。选择一个标志（除了木星，城市，小丑和行星），并抽取2张卡片。）",
   "(Requires any 2 Mars tags in play. 1 VP for every 2 data here.)": "（在游戏中需要2个火星标志。每2个此卡上的数据需要1个分。）",
   "(Requires at least 1 colony in play. Send one of your unused Trade Fleets to any colony tile. Collect the trade bonus and colony bonus for every colony on this tile. Other players do not get their colony bonuses from this action.)": "（游戏中需要1个殖民地。将您未使用的贸易舰队移动到任意（已被占领的）殖民地板块上。获得该地区殖民地和贸易奖励。其他玩家不获得奖励。）",
   "(Requires maximum 1 science tag. Increase your M€ production 1 step for every generation played so far.)": "（需要1个或更少的自己的科学标志。每代玩家的M€产能增加1，包括当前的。）",

--- a/src/locales/de/pathfinder_cards.json
+++ b/src/locales/de/pathfinder_cards.json
@@ -186,7 +186,7 @@
   "NO": "NICHT",
 
   "Public Sponsored Grant": "Öffentliche Subvention",
-  "(Requires Scientists are ruling or that you have 2 delegates there. All players lose 2M€. Choose a tag (NOT CITY, ? OR PLANETARY TRACK) and draw 2 cards with that tag.)": "(Benötigt Regierungspartei: FORSCHUNG oder 2+ eiegene Delegierte dort. Alle anderen Spieler verlieren 2 M€. Wähle ein Symbol (außer Jupiter, Stadt, Joker und Planet) und ziehe 2 Karten damit.)",
+  "(Requires Scientists are ruling or that you have 2 delegates there. All other players lose 2M€. Choose a tag (NOT CITY, ? OR PLANETARY TRACK) and draw 2 cards with that tag.)": "(Benötigt Regierungspartei: FORSCHUNG oder 2+ eiegene Delegierte dort. Alle anderen Spieler verlieren 2 M€. Wähle ein Symbol (außer Jupiter, Stadt, Joker und Planet) und ziehe 2 Karten damit.)",
 
   "Rare-Earth Elements": "Seltene-Erd-Elemente",
   "(Increase your M€ production by 1 for every special tile you own on Mars.)": "(Erhöhe deine M€-Produktion um 1 je eigenes Spezialplättchen.)",

--- a/src/locales/nl/pathfinder_cards.json
+++ b/src/locales/nl/pathfinder_cards.json
@@ -180,7 +180,7 @@
     "NO": "NIET",
 
     "Public Sponsored Grant": "Overheidssubsidie",
-    "(Requires Scientists are ruling or that you have 2 delegates there. All players lose 2M€. Choose a tag (NOT CITY, ? OR PLANETARY TRACK) and draw 2 cards with that tag.)": "(Vereist regerende partij: ONDERZOEK of 2+ eigen afgevaardigden daar. Alle andere spelers verliezen 2 M€. Kies een symbool (behalve Jupiter, Stad, Joker en Planeet) en trek er 2 kaarten met die tag.)",
+    "(Requires Scientists are ruling or that you have 2 delegates there. All other players lose 2M€. Choose a tag (NOT CITY, ? OR PLANETARY TRACK) and draw 2 cards with that tag.)": "(Vereist regerende partij: ONDERZOEK of 2+ eigen afgevaardigden daar. Alle andere spelers verliezen 2 M€. Kies een symbool (behalve Jupiter, Stad, Joker en Planeet) en trek er 2 kaarten met die tag.)",
 
     "Rare-Earth Elements": "Zeldzame aardelementen",
     "(Increase your M€ production by 1 for every special tile you own on Mars.)": "(Verhoog je M€-productie met 1 voor elke speciale tegel die je bezit.)",

--- a/src/locales/pl/pathfinder_cards.json
+++ b/src/locales/pl/pathfinder_cards.json
@@ -181,7 +181,7 @@
   "Opponents may not remove your basic resource production": "Efekt trwały: Przeciwnicy nie mogą obniżać twojej produkcji zasobów i M€.",
 
   "Public Sponsored Grant": "Publiczne Granty Badawcze",
-  "(Requires Scientists are ruling or that you have 2 delegates there. All players lose 2M€. Choose a tag (NOT CITY, ? OR PLANETARY TRACK) and draw 2 cards with that tag.)": "Naukowcy muszą być partią rządzącą lub musisz posiadać co najmniej 2 delegatów w tej partii. Każdy gracz traci 2 M€. Wybierz symbol (z wyjątkiem Miasta, Uniwersalnego i Planetarnego) i dobierz 2 karty z tym symbolem.",
+  "(Requires Scientists are ruling or that you have 2 delegates there. All other players lose 2M€. Choose a tag (NOT CITY, ? OR PLANETARY TRACK) and draw 2 cards with that tag.)": "Naukowcy muszą być partią rządzącą lub musisz posiadać co najmniej 2 delegatów w tej partii. Każdy pozostali gracz traci 2 M€. Wybierz symbol (z wyjątkiem Miasta, Uniwersalnego i Planetarnego) i dobierz 2 karty z tym symbolem.",
 
   "Rare-Earth Elements": "Metale Ziem Rzadkich",
   "(Increase your M€ production by 1 for every special tile you own on Mars.)": "Podnieś swoją produkcję M€ o 1 poziom za każdy posiadany obszar specjalny na planszy Marsa.",

--- a/src/server/cards/pathfinders/PublicSponsoredGrant.ts
+++ b/src/server/cards/pathfinders/PublicSponsoredGrant.ts
@@ -36,7 +36,7 @@ export class PublicSponsoredGrant extends Card implements IProjectCard {
   }
 
   public override bespokePlay(player: IPlayer) {
-    player.game.getPlayers().forEach((target) => {
+    player.getOpponents().forEach((target) => {
       target.maybeBlockAttack(player, (proceed) => {
         if (proceed) {
           target.stock.deduct(Resource.MEGACREDITS, Math.min(target.megaCredits, 2), {log: true, from: player});

--- a/tests/cards/pathfinders/PublicSponsoredGrant.spec.ts
+++ b/tests/cards/pathfinders/PublicSponsoredGrant.spec.ts
@@ -43,7 +43,7 @@ describe('PublicSponsoredGrant', function() {
 
     const options = cast(card.play(player), OrOptions);
 
-    expect(player.megaCredits).eq(2);
+    expect(player.megaCredits).eq(4);
     expect(player2.megaCredits).eq(0);
     expect(player3.megaCredits).eq(0);
 
@@ -74,7 +74,7 @@ describe('PublicSponsoredGrant', function() {
 
     // This is a great test, because player1 instigated the loss, so does not get an insurance
     // payout. Player 2 loses the payout and player 3 gets it.
-    expect(player.megaCredits).eq(8);
+    expect(player.megaCredits).eq(10);
     expect(player2.megaCredits).eq(5);
     expect(player3.megaCredits).eq(11);
   });


### PR DESCRIPTION
According to Google Translate, most of the translations already referenced "Every other player."