### PR TITLE
Remove simpleCanPlay.

### DIFF
--- a/src/server/IPlayer.ts
+++ b/src/server/IPlayer.ts
@@ -298,7 +298,6 @@ export interface IPlayer {
   takeActionForFinalGreenery(): void;
   getPlayableCards(): Array<PlayableCard>;
   canPlay(card: IProjectCard): boolean | YesAnd;
-  simpleCanPlay(card: IProjectCard, canAffordOptions?: CanAffordOptions): boolean | YesAnd;
   canSpend(payment: Payment, reserveUnits?: Units): boolean;
   payingAmount(payment: Payment, options?: Partial<PaymentOptions>): number;
   /**

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1345,7 +1345,7 @@ export class Player implements IPlayer {
     if (!canAfford.canAfford) {
       return false;
     }
-    const canPlay = this.simpleCanPlay(card, options);
+    const canPlay = card.canPlay(this, options);
     if (canPlay === false) {
       return false;
     }
@@ -1357,15 +1357,6 @@ export class Player implements IPlayer {
       }
     }
     return canPlay;
-  }
-
-  /**
-   * Verify if requirements for the card can be met, ignoring the project cost.
-   * Only made public for tests.
-   */
-  // TODO(kberg): use CanPlayResponse
-  public simpleCanPlay(card: IProjectCard, canAffordOptions?: CanAffordOptions): boolean | YesAnd {
-    return card.canPlay(this, canAffordOptions);
   }
 
   private maxSpendable(reserveUnits: Units = Units.EMPTY): Payment {

--- a/src/server/cards/Card.ts
+++ b/src/server/cards/Card.ts
@@ -87,7 +87,7 @@ const cardProperties = new Map<CardName, InternalProperties>();
  *    consumes very little memory.
  *
  * 2. It's key behavior is to provide a lot of the `canPlay` and `play` behavior currently
- *    in player.simpleCanPlay and player.simplePlay. These will eventually be removed and
+ *    in player.canPlay and player.play. These will eventually be removed and
  *    put right in here.
  *
  * In order to implement this default behavior, Card subclasses should ideally not

--- a/src/server/cards/community/Playwrights.ts
+++ b/src/server/cards/community/Playwrights.ts
@@ -117,7 +117,7 @@ export class Playwrights extends CorporationCard {
           };
           return card.type === CardType.EVENT &&
           // Can player.canPlay(card) replace this?
-          player.canAfford(canAffordOptions) && player.simpleCanPlay(card, canAffordOptions);
+          player.canAfford(canAffordOptions) && card.canPlay(player, canAffordOptions);
         }));
       });
     } finally {

--- a/tests/cards/ares/BioengineeringEnclosure.spec.ts
+++ b/tests/cards/ares/BioengineeringEnclosure.spec.ts
@@ -21,9 +21,9 @@ describe('BioengineeringEnclosure', function() {
   });
 
   it('Can not play without a science tag', () => {
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
     player.playCard(new AICentral());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Play', () => {

--- a/tests/cards/ares/EcologicalSurvey.spec.ts
+++ b/tests/cards/ares/EcologicalSurvey.spec.ts
@@ -31,13 +31,13 @@ describe('EcologicalSurvey', () => {
 
   it('Can play', () => {
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   // This doesn't test anything about this card, but about the behavior this card provides, from

--- a/tests/cards/ares/GeologicalSurvey.spec.ts
+++ b/tests/cards/ares/GeologicalSurvey.spec.ts
@@ -31,22 +31,22 @@ describe('GeologicalSurvey', () => {
 
   it('Can play', () => {
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     addGreenery(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
   });
 
   it('Works with Adjacency Bonuses', () => {

--- a/tests/cards/ares/MagneticFieldGeneratorsAres.spec.ts
+++ b/tests/cards/ares/MagneticFieldGeneratorsAres.spec.ts
@@ -21,7 +21,7 @@ describe('MagneticFieldGeneratorsAres', function() {
 
   it('Cannot play without enough energy production', function() {
     player.production.add(Resource.ENERGY, 3);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Play and Adjacency Bonus Grants', function() {
@@ -30,7 +30,7 @@ describe('MagneticFieldGeneratorsAres', function() {
     player.playedCards = [microbeCard, dataCard];
 
     player.production.add(Resource.ENERGY, 4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     runAllActions(game);

--- a/tests/cards/ares/OceanSanctuary.spec.ts
+++ b/tests/cards/ares/OceanSanctuary.spec.ts
@@ -23,19 +23,19 @@ describe('OceanSanctuary', function() {
 
   it('Can play', function() {
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Play', function() {

--- a/tests/cards/base/AdvancedEcosystems.spec.ts
+++ b/tests/cards/base/AdvancedEcosystems.spec.ts
@@ -17,14 +17,14 @@ describe('AdvancedEcosystems', function() {
   });
 
   it('Can not play if tag requirements is unmet', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.playedCards.push(new Tardigrades());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(card.getVictoryPoints(player)).to.eq(3);
@@ -32,6 +32,6 @@ describe('AdvancedEcosystems', function() {
 
   it('Can play with two wild tags', function() {
     player.playedCards.push(new ResearchCoordination());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 });

--- a/tests/cards/base/Algae.spec.ts
+++ b/tests/cards/base/Algae.spec.ts
@@ -16,7 +16,7 @@ describe('Algae', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
@@ -25,7 +25,7 @@ describe('Algae', function() {
       oceanSpaces[i].tile = {tileType: TileType.OCEAN};
     }
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.plants).to.eq(1);

--- a/tests/cards/base/AntiGravityTechnology.spec.ts
+++ b/tests/cards/base/AntiGravityTechnology.spec.ts
@@ -13,12 +13,12 @@ describe('AntiGravityTechnology', function() {
 
   it('Cannot play', function() {
     player.tagsForTest = {science: 6};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
     player.tagsForTest = {science: 7};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/Ants.spec.ts
+++ b/tests/cards/base/Ants.spec.ts
@@ -24,12 +24,12 @@ describe('Ants', function() {
 
   it('Can not play without oxygen', function() {
     setOxygenLevel(game, 3);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setOxygenLevel(game, 4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     card.resourceCount += 5;

--- a/tests/cards/base/ArchaeBacteria.spec.ts
+++ b/tests/cards/base/ArchaeBacteria.spec.ts
@@ -17,7 +17,7 @@ describe('ArchaeBacteria', function() {
 
   it('Can not play', function() {
     setTemperature(game, -12);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/ArcticAlgae.spec.ts
+++ b/tests/cards/base/ArcticAlgae.spec.ts
@@ -18,7 +18,7 @@ describe('ArcticAlgae', function() {
 
   it('Can not play', function() {
     setTemperature(game, -10);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/ArtificialLake.spec.ts
+++ b/tests/cards/base/ArtificialLake.spec.ts
@@ -21,7 +21,7 @@ describe('ArtificialLake', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
@@ -50,7 +50,7 @@ describe('ArtificialLake', function() {
     }
 
     // Card is still playable to get VPs...
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     // ...but an action to place ocean is not unavailable
     cast(card.play(player), undefined);
@@ -69,14 +69,14 @@ describe('ArtificialLake', function() {
     expect(game.board.getAvailableSpacesOnLand(player)).has.length(1);
 
     // Card is still playable.
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     // No spaces left?
     game.simpleAddTile(player, spaces[0], {tileType: TileType.GREENERY});
     expect(game.board.getAvailableSpacesOnLand(player)).has.length(0);
 
     // Cannot play.
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
   });
 
   it('Can still play if oceans are maxed but no land spaces are available', function() {
@@ -89,7 +89,7 @@ describe('ArtificialLake', function() {
       game.simpleAddTile(player, space, {tileType: TileType.GREENERY});
     });
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Works with reds', () => {

--- a/tests/cards/base/AsteroidMiningConsortium.spec.ts
+++ b/tests/cards/base/AsteroidMiningConsortium.spec.ts
@@ -19,12 +19,12 @@ describe('AsteroidMiningConsortium', function() {
   });
 
   it('Cannot play if no titanium production', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play if player has titanium production', function() {
     player.production.add(Resource.TITANIUM, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play - auto select if single target', function() {

--- a/tests/cards/base/BeamFromAThoriumAsteroid.spec.ts
+++ b/tests/cards/base/BeamFromAThoriumAsteroid.spec.ts
@@ -13,12 +13,12 @@ describe('BeamFromAThoriumAsteroid', function() {
   });
 
   it('Cannot play without a Jovian tag', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(card);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.heat).to.eq(3);

--- a/tests/cards/base/BiomassCombustors.spec.ts
+++ b/tests/cards/base/BiomassCombustors.spec.ts
@@ -19,24 +19,24 @@ describe('BiomassCombustors', function() {
 
   it('Cannot play if oxygen requirement not met', function() {
     player2.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Cannot play if no one has plant production', function() {
     setOxygenLevel(game, 6);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play in solo mode if oxygen requirement is met', function() {
     const game = Game.newInstance('gameid', [player], player);
     setOxygenLevel(game, 6);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {
     setOxygenLevel(game, 6);
     player2.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     runAllActions(game);

--- a/tests/cards/base/BreathingFilters.spec.ts
+++ b/tests/cards/base/BreathingFilters.spec.ts
@@ -16,12 +16,12 @@ describe('BreathingFilters', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setOxygenLevel(game, 7);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(card.getVictoryPoints(player)).to.eq(2);

--- a/tests/cards/base/Bushes.spec.ts
+++ b/tests/cards/base/Bushes.spec.ts
@@ -16,12 +16,12 @@ describe('Bushes', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -10);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.plants).to.eq(2);

--- a/tests/cards/base/CarbonateProcessing.spec.ts
+++ b/tests/cards/base/CarbonateProcessing.spec.ts
@@ -14,12 +14,12 @@ describe('CarbonateProcessing', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/CaretakerContract.spec.ts
+++ b/tests/cards/base/CaretakerContract.spec.ts
@@ -22,13 +22,13 @@ describe('CaretakerContract', function() {
   });
 
   it('Cannot play or act', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     expect(card.canAct(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, 0);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Cannot act', function() {

--- a/tests/cards/base/CloudSeeding.spec.ts
+++ b/tests/cards/base/CloudSeeding.spec.ts
@@ -21,32 +21,32 @@ describe('CloudSeeding', () => {
   it('Cannot play if cannot reduce M€ production', () => {
     maxOutOceans(player, 3);
     player.production.add(Resource.MEGACREDITS, -5);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Cannot play if ocean requirements not met', () => {
     maxOutOceans(player, 2);
     player.production.add(Resource.HEAT, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Cannot play if no one has heat production', () => {
     maxOutOceans(player, 3);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     maxOutOceans(player, 3);
     player.production.add(Resource.MEGACREDITS, -4);
     player.production.add(Resource.HEAT, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play - auto select if single target', () => {
     // Meet requirements
     player2.production.add(Resource.HEAT, 1);
     maxOutOceans(player, 3);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.megacredits).to.eq(-1);

--- a/tests/cards/base/ColonizerTrainingCamp.spec.ts
+++ b/tests/cards/base/ColonizerTrainingCamp.spec.ts
@@ -17,11 +17,11 @@ describe('ColonizerTrainingCamp', function() {
 
   it('Can not play', function() {
     setOxygenLevel(game, 6);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
   it('Should play', function() {
     setOxygenLevel(game, 5);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(card.getVictoryPoints(player)).to.eq(2);

--- a/tests/cards/base/Decomposers.spec.ts
+++ b/tests/cards/base/Decomposers.spec.ts
@@ -20,12 +20,12 @@ describe('Decomposers', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setOxygenLevel(game, 3);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     card.onCardPlayed(player, new Birds());
@@ -42,7 +42,7 @@ describe('Decomposers', function() {
     const ecoExpertCard = new EcologyExperts();
     game.phase = Phase.PRELUDES;
     player.playCard(ecoExpertCard);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     player.playCard(card);
     expect(card.resourceCount).to.eq(3);
   });

--- a/tests/cards/base/DesignedMicroOrganisms.spec.ts
+++ b/tests/cards/base/DesignedMicroOrganisms.spec.ts
@@ -17,17 +17,17 @@ describe('DesignedMicroOrganisms', function() {
 
   it('Cannot play', function() {
     setTemperature(game, -12);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
     setTemperature(game, -14);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -14);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
     expect(player.production.plants).to.eq(2);
   });

--- a/tests/cards/base/DomedCrater.spec.ts
+++ b/tests/cards/base/DomedCrater.spec.ts
@@ -18,13 +18,13 @@ describe('DomedCrater', function() {
   });
 
   it('Can not play without energy production', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if oxygen level too high', function() {
     player.production.add(Resource.ENERGY, 1);
     setOxygenLevel(game, 8);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/DustSeals.spec.ts
+++ b/tests/cards/base/DustSeals.spec.ts
@@ -15,11 +15,11 @@ describe('DustSeals', function() {
 
   it('Can not play', function() {
     maxOutOceans(player, 4);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });

--- a/tests/cards/base/EnergyTapping.spec.ts
+++ b/tests/cards/base/EnergyTapping.spec.ts
@@ -20,7 +20,7 @@ describe('EnergyTapping', function() {
 
   it('play - no targets', function() {
     player.playedCards.push(card, card);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     runAllActions(game);

--- a/tests/cards/base/ExtremeColdFungus.spec.ts
+++ b/tests/cards/base/ExtremeColdFungus.spec.ts
@@ -20,12 +20,12 @@ describe('ExtremeColdFungus', () => {
 
   it('Cannot play', () => {
     setTemperature(game, -8);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     setTemperature(game, -12);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {

--- a/tests/cards/base/Farming.spec.ts
+++ b/tests/cards/base/Farming.spec.ts
@@ -16,12 +16,12 @@ describe('Farming', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, 4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(player.production.megacredits).to.eq(2);

--- a/tests/cards/base/FoodFactory.spec.ts
+++ b/tests/cards/base/FoodFactory.spec.ts
@@ -14,12 +14,12 @@ describe('FoodFactory', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.plants).to.eq(0);

--- a/tests/cards/base/FuelFactory.spec.ts
+++ b/tests/cards/base/FuelFactory.spec.ts
@@ -14,12 +14,12 @@ describe('FuelFactory', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/FusionPower.spec.ts
+++ b/tests/cards/base/FusionPower.spec.ts
@@ -14,9 +14,9 @@ describe('FusionPower', function() {
 
   it('Can not play', function() {
     player.tagsForTest = {power: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     player.tagsForTest = {power: 2};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/GHGProducingBacteria.spec.ts
+++ b/tests/cards/base/GHGProducingBacteria.spec.ts
@@ -18,9 +18,9 @@ describe('GHGProducingBacteria', () => {
 
   it('Can play', () => {
     setOxygenLevel(game, 3);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     setOxygenLevel(game, 4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {

--- a/tests/cards/base/GeneRepair.spec.ts
+++ b/tests/cards/base/GeneRepair.spec.ts
@@ -14,12 +14,12 @@ describe('GeneRepair', function() {
 
   it('Can not play', function() {
     player.tagsForTest = {science: 2};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
     player.tagsForTest = {science: 3};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/Grass.spec.ts
+++ b/tests/cards/base/Grass.spec.ts
@@ -16,12 +16,12 @@ describe('Grass', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -16);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(player.production.plants).to.eq(1);

--- a/tests/cards/base/GreatEscarpmentConsortium.spec.ts
+++ b/tests/cards/base/GreatEscarpmentConsortium.spec.ts
@@ -19,12 +19,12 @@ describe('GreatEscarpmentConsortium', function() {
   });
 
   it('Cannot play without steel production', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play if player has steel production', function() {
     player.production.add(Resource.STEEL, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play - auto select if single target', function() {

--- a/tests/cards/base/Heather.spec.ts
+++ b/tests/cards/base/Heather.spec.ts
@@ -16,12 +16,12 @@ describe('Heather', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -14);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.plants).to.eq(1);

--- a/tests/cards/base/Herbivores.spec.ts
+++ b/tests/cards/base/Herbivores.spec.ts
@@ -20,19 +20,19 @@ describe('Herbivores', () => {
 
   it('Can not play if nobody has plant production', () => {
     setOxygenLevel(game, 8);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if oxygen level too low', () => {
     setOxygenLevel(game, 7);
     player2.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play - auto select if single target', () => {
     setOxygenLevel(game, 8);
     player2.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     runAllActions(game);
@@ -77,7 +77,7 @@ describe('Herbivores', () => {
     setOxygenLevel(game, 8);
     player.production.add(Resource.PLANTS, 1);
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
     expect(player.production.plants).to.eq(1); // should not decrease
   });

--- a/tests/cards/base/IceCapMelting.spec.ts
+++ b/tests/cards/base/IceCapMelting.spec.ts
@@ -16,12 +16,12 @@ describe('IceCapMelting', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(game.deferredActions).has.lengthOf(1);

--- a/tests/cards/base/Insects.spec.ts
+++ b/tests/cards/base/Insects.spec.ts
@@ -17,12 +17,12 @@ describe('Insects', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setOxygenLevel(game, 6);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.plants).to.eq(0);

--- a/tests/cards/base/InterstellarColonyShip.spec.ts
+++ b/tests/cards/base/InterstellarColonyShip.spec.ts
@@ -15,12 +15,12 @@ describe('InterstellarColonyShip', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new Research(), new Research(), new GeneRepair());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(card.getVictoryPoints(player)).to.eq(4);

--- a/tests/cards/base/KelpFarming.spec.ts
+++ b/tests/cards/base/KelpFarming.spec.ts
@@ -14,12 +14,12 @@ describe('KelpFarming', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     maxOutOceans(player, 6);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     const plantsCount = player.plants;
     card.play(player);

--- a/tests/cards/base/LakeMarineris.spec.ts
+++ b/tests/cards/base/LakeMarineris.spec.ts
@@ -17,12 +17,12 @@ describe('LakeMarineris', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -0);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(game.deferredActions).has.lengthOf(2);

--- a/tests/cards/base/Lichen.spec.ts
+++ b/tests/cards/base/Lichen.spec.ts
@@ -16,12 +16,12 @@ describe('Lichen', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -24);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.plants).to.eq(1);

--- a/tests/cards/base/LightningHarvest.spec.ts
+++ b/tests/cards/base/LightningHarvest.spec.ts
@@ -14,12 +14,12 @@ describe('LightningHarvest', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new GeneRepair(), new GeneRepair(), new GeneRepair());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(1);

--- a/tests/cards/base/Livestock.spec.ts
+++ b/tests/cards/base/Livestock.spec.ts
@@ -18,19 +18,19 @@ describe('Livestock', function() {
 
   it('Can not play without plant production', function() {
     setOxygenLevel(game, 9);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if oxygen level too low', function() {
     setOxygenLevel(game, 8);
     player.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.PLANTS, 1);
     setOxygenLevel(game, 9);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     player.playedCards.push(card);

--- a/tests/cards/base/MagneticFieldDome.spec.ts
+++ b/tests/cards/base/MagneticFieldDome.spec.ts
@@ -14,12 +14,12 @@ describe('MagneticFieldDome', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/MagneticFieldGenerators.spec.ts
+++ b/tests/cards/base/MagneticFieldGenerators.spec.ts
@@ -14,12 +14,12 @@ describe('MagneticFieldGenerators', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/Mangrove.spec.ts
+++ b/tests/cards/base/Mangrove.spec.ts
@@ -18,7 +18,7 @@ describe('Mangrove', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/MassConverter.spec.ts
+++ b/tests/cards/base/MassConverter.spec.ts
@@ -17,12 +17,12 @@ describe('MassConverter', function() {
 
   it('Can not play', function() {
     player.tagsForTest = {science: 4};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
     player.tagsForTest = {science: 5};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/MethaneFromTitan.spec.ts
+++ b/tests/cards/base/MethaneFromTitan.spec.ts
@@ -16,12 +16,12 @@ describe('MethaneFromTitan', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setOxygenLevel(game, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(player.production.heat).to.eq(2);

--- a/tests/cards/base/Moss.spec.ts
+++ b/tests/cards/base/Moss.spec.ts
@@ -17,19 +17,19 @@ describe('Moss', function() {
   it('Can not play without enough oceans', function() {
     maxOutOceans(player, 2);
     player.plants = 1;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if have no plants', function() {
     maxOutOceans(player, 3);
     player.plants = 0;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     maxOutOceans(player, 3);
     player.plants = 1;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.plants).to.eq(0);
@@ -42,7 +42,7 @@ describe('Moss', function() {
     player.playedCards.push(viralEnhancers);
     player.plants = 0;
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(player.plants).to.eq(-1);

--- a/tests/cards/base/NitrophilicMoss.spec.ts
+++ b/tests/cards/base/NitrophilicMoss.spec.ts
@@ -18,19 +18,19 @@ describe('NitrophilicMoss', function() {
   it('Can not play without enough oceans', function() {
     maxOutOceans(player, 2);
     player.plants = 2;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if not enough plants', function() {
     maxOutOceans(player, 3);
     player.plants = 1;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     maxOutOceans(player, 3);
     player.plants = 2;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.plants).to.eq(0);
@@ -44,7 +44,7 @@ describe('NitrophilicMoss', function() {
     maxOutOceans(player, 3);
     player.plants = 1;
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(player.plants).to.eq(-1);
@@ -56,6 +56,6 @@ describe('NitrophilicMoss', function() {
   it('Should play', function() {
     maxOutOceans(player, 3);
     player.setCorporationForTest(new Manutech());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 });

--- a/tests/cards/base/NoctisCity.spec.ts
+++ b/tests/cards/base/NoctisCity.spec.ts
@@ -21,7 +21,7 @@ describe('NoctisCity', function() {
   });
 
   it('Cannot play without energy production', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('All land spaces are available on Hellas', function() {
@@ -34,7 +34,7 @@ describe('NoctisCity', function() {
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/NoctisFarming.spec.ts
+++ b/tests/cards/base/NoctisFarming.spec.ts
@@ -21,7 +21,7 @@ describe('NoctisFarming', function() {
 
   it('Should play', function() {
     setTemperature(game, -20);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.megacredits).to.eq(1);

--- a/tests/cards/base/NuclearPower.spec.ts
+++ b/tests/cards/base/NuclearPower.spec.ts
@@ -15,11 +15,11 @@ describe('NuclearPower', function() {
 
   it('Can not play', function() {
     player.production.add(Resource.MEGACREDITS, -4);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
     expect(player.production.megacredits).to.eq(-2);
     expect(player.production.energy).to.eq(3);

--- a/tests/cards/base/PermafrostExtraction.spec.ts
+++ b/tests/cards/base/PermafrostExtraction.spec.ts
@@ -17,12 +17,12 @@ describe('PermafrostExtraction', function() {
   });
 
   it('Cannot play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -8);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
     runAllActions(game);

--- a/tests/cards/base/Plantation.spec.ts
+++ b/tests/cards/base/Plantation.spec.ts
@@ -18,12 +18,12 @@ describe('Plantation', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new InventorsGuild(), new InventorsGuild());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     expect(card.play(player)).is.undefined;
     runAllActions(game);

--- a/tests/cards/base/PowerSupplyConsortium.spec.ts
+++ b/tests/cards/base/PowerSupplyConsortium.spec.ts
@@ -20,16 +20,16 @@ describe('PowerSupplyConsortium', function() {
 
   it('Cannot play without power tags', function() {
     player.production.add(Resource.ENERGY, 3);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     player.tagsForTest = {power: 1};
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
     player.tagsForTest = {power: 2};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Can play - no targets', function() {
     player.tagsForTest = {power: 2};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     runAllActions(game);
@@ -47,7 +47,7 @@ describe('PowerSupplyConsortium', function() {
   it('Can play - single target', function() {
     player2.production.override({energy: 1});
     player.tagsForTest = {power: 2};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     runAllActions(game);

--- a/tests/cards/base/QuantumExtractor.spec.ts
+++ b/tests/cards/base/QuantumExtractor.spec.ts
@@ -16,12 +16,12 @@ describe('QuantumExtractor', function() {
 
   it('Can not play', function() {
     player.tagsForTest = {science: 3};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
     player.tagsForTest = {science: 4};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/RadSuits.spec.ts
+++ b/tests/cards/base/RadSuits.spec.ts
@@ -15,7 +15,7 @@ describe('RadSuits', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
@@ -23,7 +23,7 @@ describe('RadSuits', function() {
     game.addCity(player, lands[0]);
     game.addCity(player, lands[1]);
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(player.production.megacredits).to.eq(1);

--- a/tests/cards/base/Shuttles.spec.ts
+++ b/tests/cards/base/Shuttles.spec.ts
@@ -20,19 +20,19 @@ describe('Shuttles', function() {
 
   it('Can not play without energy production', function() {
     setOxygenLevel(game, 5);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if oxygen level too low', function() {
     player.production.add(Resource.ENERGY, 1);
     setOxygenLevel(game, 4);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setOxygenLevel(game, 5);
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/SmallAnimals.spec.ts
+++ b/tests/cards/base/SmallAnimals.spec.ts
@@ -20,12 +20,12 @@ describe('SmallAnimals', function() {
   it('Can not play if oxygen level too low', function() {
     player2.production.add(Resource.PLANTS, 1);
     setOxygenLevel(game, 5);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if no one has plant production', function() {
     setOxygenLevel(game, 6);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should act', function() {
@@ -38,7 +38,7 @@ describe('SmallAnimals', function() {
   it('Should play', function() {
     setOxygenLevel(game, 6);
     player2.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.playedCards.push(card);
     card.play(player);

--- a/tests/cards/base/StripMine.spec.ts
+++ b/tests/cards/base/StripMine.spec.ts
@@ -25,12 +25,12 @@ describe('StripMine', function() {
 
   it('Can not play', function() {
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/base/SymbioticFungus.spec.ts
+++ b/tests/cards/base/SymbioticFungus.spec.ts
@@ -19,12 +19,12 @@ describe('SymbioticFungus', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -14);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Can act without targets', function() {

--- a/tests/cards/base/Trees.spec.ts
+++ b/tests/cards/base/Trees.spec.ts
@@ -16,12 +16,12 @@ describe('Trees', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.plants).to.eq(3);

--- a/tests/cards/base/TundraFarming.spec.ts
+++ b/tests/cards/base/TundraFarming.spec.ts
@@ -16,12 +16,12 @@ describe('TundraFarming', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, -6);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.plants).to.eq(1);

--- a/tests/cards/base/UndergroundCity.spec.ts
+++ b/tests/cards/base/UndergroundCity.spec.ts
@@ -19,12 +19,12 @@ describe('UndergroundCity', function() {
 
   it('Can not play', function() {
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     expect(card.play(player)).is.undefined;
     runAllActions(player.game);

--- a/tests/cards/base/UrbanizedArea.spec.ts
+++ b/tests/cards/base/UrbanizedArea.spec.ts
@@ -25,13 +25,13 @@ describe('UrbanizedArea', function() {
   });
 
   it('Can not play without energy production', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play without available space between two cities', function() {
     game.addCity(player, lands[0]);
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
@@ -39,7 +39,7 @@ describe('UrbanizedArea', function() {
     game.addCity(player, lands[1]);
 
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     const action = cast(card.play(player), SelectSpace);
     expect(action.spaces).has.lengthOf(1);

--- a/tests/cards/base/WaterSplittingPlant.spec.ts
+++ b/tests/cards/base/WaterSplittingPlant.spec.ts
@@ -16,12 +16,12 @@ describe('WaterSplittingPlant', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
     maxOutOceans(player, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Can not act', function() {

--- a/tests/cards/base/WavePower.spec.ts
+++ b/tests/cards/base/WavePower.spec.ts
@@ -15,12 +15,12 @@ describe('WavePower', function() {
 
   it('Can not play', function() {
     maxOutOceans(player, 2);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     maxOutOceans(player, 3);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(1);

--- a/tests/cards/base/Worms.spec.ts
+++ b/tests/cards/base/Worms.spec.ts
@@ -18,12 +18,12 @@ describe('Worms', function() {
 
   it('Can not play', function() {
     setOxygenLevel(game, 3);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setOxygenLevel(game, 4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     const tardigrades = new Tardigrades();
     player.playedCards.push(tardigrades);
 

--- a/tests/cards/base/Zeppelins.spec.ts
+++ b/tests/cards/base/Zeppelins.spec.ts
@@ -17,11 +17,11 @@ describe('Zeppelins', function() {
 
   it('Can not play', function() {
     setOxygenLevel(game, 4);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
   it('Should play', function() {
     setOxygenLevel(game, 5);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     const lands = game.board.getAvailableSpacesOnLand(player);
     game.addCity(player, lands[0]);

--- a/tests/cards/colonies/CoronaExtractor.spec.ts
+++ b/tests/cards/colonies/CoronaExtractor.spec.ts
@@ -7,7 +7,7 @@ describe('CoronaExtractor', function() {
   it('Should play', function() {
     const card = new CoronaExtractor();
     const [/* game */, player] = testGame(1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(4);
   });

--- a/tests/cards/colonies/HeavyTaxation.spec.ts
+++ b/tests/cards/colonies/HeavyTaxation.spec.ts
@@ -7,7 +7,7 @@ describe('HeavyTaxation', function() {
   it('Should play', function() {
     const card = new HeavyTaxation();
     const [/* game */, player] = testGame(1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);
     expect(player.megaCredits).to.eq(4);

--- a/tests/cards/colonies/LunaGovernor.spec.ts
+++ b/tests/cards/colonies/LunaGovernor.spec.ts
@@ -7,7 +7,7 @@ describe('LunaGovernor', function() {
   it('Should play', function() {
     const card = new LunaGovernor();
     const [/* game */, player] = testGame(1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);
   });

--- a/tests/cards/colonies/MartianZoo.spec.ts
+++ b/tests/cards/colonies/MartianZoo.spec.ts
@@ -15,14 +15,14 @@ describe('MartianZoo', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     const lands = player.game.board.getAvailableSpacesOnLand(player);
     player.game.addCity(player, lands[0]);
     player.game.addCity(player, lands[1]);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
   });

--- a/tests/cards/colonies/MinorityRefuge.spec.ts
+++ b/tests/cards/colonies/MinorityRefuge.spec.ts
@@ -35,9 +35,9 @@ describe('MinorityRefuge', function() {
 
   it('canPlay', () => {
     player.production.override(Units.of({megacredits: -4}));
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
     player.production.override(Units.of({megacredits: -3}));
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play)', () => {
@@ -61,9 +61,9 @@ describe('MinorityRefuge', function() {
   it('can play with low MC production when Luna is in play', () => {
     const luna = new Luna();
     player.production.override(Units.of({megacredits: -4}));
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
     game.colonies[0] = luna;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     const selectColony = cast(churnPlay(card, player), SelectColony);
 
     // Gain plant production

--- a/tests/cards/colonies/RedSpotObservatory.spec.ts
+++ b/tests/cards/colonies/RedSpotObservatory.spec.ts
@@ -16,12 +16,12 @@ describe('RedSpotObservatory', function() {
 
   it('Can not play', function() {
     player.tagsForTest = {science: 2};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
     player.tagsForTest = {science: 3};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/colonies/SkyDocks.spec.ts
+++ b/tests/cards/colonies/SkyDocks.spec.ts
@@ -7,7 +7,7 @@ describe('SkyDocks', function() {
   it('Should play', function() {
     const card = new SkyDocks();
     const player = TestPlayer.BLUE.newPlayer();
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     cast(card.play(player), undefined);
     expect(player.colonies.getFleetSize()).to.eq(2);
     expect(card.getCardDiscount()).to.eq(1);

--- a/tests/cards/colonies/SpacePort.spec.ts
+++ b/tests/cards/colonies/SpacePort.spec.ts
@@ -24,18 +24,18 @@ describe('SpacePort', function() {
 
   it('Can not play without colony', function() {
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play without energy production', function() {
     player.game.colonies[0].colonies.push(player.id);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 1);
     player.game.colonies[0].colonies.push(player.id);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     expect(card.play(player)).is.undefined;
     runAllActions(player.game);

--- a/tests/cards/colonies/SubZeroSaltFish.spec.ts
+++ b/tests/cards/colonies/SubZeroSaltFish.spec.ts
@@ -19,18 +19,18 @@ describe('SubZeroSaltFish', function() {
 
   it('Can not play if no one has plant production', function() {
     setTemperature(game, 2);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if temperature requirement not met', function() {
     player2.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setTemperature(game, 2);
     player2.production.add(Resource.PLANTS, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     player.addResourceTo(card, 5);

--- a/tests/cards/colonies/WarpDrive.spec.ts
+++ b/tests/cards/colonies/WarpDrive.spec.ts
@@ -11,7 +11,7 @@ describe('WarpDrive', function() {
     const player = TestPlayer.BLUE.newPlayer();
     const player2 = TestPlayer.RED.newPlayer();
     Game.newInstance('gameid', [player, player2], player);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     cast(card.play(player), undefined);
     expect(card.getCardDiscount(player, new TollStation())).to.eq(4);
   });

--- a/tests/cards/community/Hygiea.spec.ts
+++ b/tests/cards/community/Hygiea.spec.ts
@@ -97,7 +97,7 @@ describe('Hygiea', () => {
     player.megaCredits = 10;
     player2.megaCredits = 10;
 
-    expect(player2.simpleCanPlay(lawSuit)).is.false;
+    expect(lawSuit.canPlay(player2)).is.false;
 
     hygiea.trade(player);
     runAllActions(game);
@@ -108,7 +108,7 @@ describe('Hygiea', () => {
     expect(player.megaCredits).to.eq(13);
     expect(player2.megaCredits).to.eq(7);
 
-    expect(player2.simpleCanPlay(lawSuit)).is.true;
+    expect(lawSuit.canPlay(player2)).is.true;
     const selectPlayer = cast(lawSuit.play(player2), SelectPlayer);
     selectPlayer.cb(player);
 

--- a/tests/cards/moon/EarthEmbassy.spec.ts
+++ b/tests/cards/moon/EarthEmbassy.spec.ts
@@ -38,7 +38,7 @@ describe('EarthEmbassy', () => {
     // Earth Embassy has an earth tag and a moon tag.
     // Business Contacts has an earth tag.
     player.playedCards.push(earthEmbassy, new BusinessNetwork());
-    expect(player.simpleCanPlay(lunaGovernor)).is.true;
+    expect(lunaGovernor.canPlay(player)).is.true;
   });
 
   it('Works for Martian Zoo', () => {

--- a/tests/cards/pathfinders/AgroDrones.spec.ts
+++ b/tests/cards/pathfinders/AgroDrones.spec.ts
@@ -18,10 +18,10 @@ describe('AgroDrones', function() {
 
   it('canPlay', function() {
     setTemperature(game, -20);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     setTemperature(game, -18);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Can act', function() {

--- a/tests/cards/pathfinders/BotanicalExperience.spec.ts
+++ b/tests/cards/pathfinders/BotanicalExperience.spec.ts
@@ -26,10 +26,10 @@ describe('BotanicalExperience', function() {
   });
 
   it('canPlay', () => {
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     game.addGreenery(otherPlayer, space);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('onTilePlaced', () => {

--- a/tests/cards/pathfinders/BreedingFarms.spec.ts
+++ b/tests/cards/pathfinders/BreedingFarms.spec.ts
@@ -21,16 +21,16 @@ describe('BreedingFarms', function() {
 
   it('canPlay', function() {
     player.tagsForTest = {};
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.tagsForTest = {science: 1};
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.tagsForTest = {animal: 1};
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.tagsForTest = {science: 1, animal: 1};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/FlatMarsTheory.spec.ts
+++ b/tests/cards/pathfinders/FlatMarsTheory.spec.ts
@@ -17,19 +17,19 @@ describe('FlatMarsTheory', function() {
 
   it('canPlay', function() {
     player.tagsForTest = {};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.tagsForTest = {science: 1};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.tagsForTest = {science: 2};
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.tagsForTest = {science: 1, wild: 1};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.tagsForTest = {wild: 2};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/HydrogenProcessingPlant.spec.ts
+++ b/tests/cards/pathfinders/HydrogenProcessingPlant.spec.ts
@@ -19,10 +19,10 @@ describe('HydrogenProcessingPlant', function() {
 
   it('canPlay', function() {
     setOxygenLevel(game, 2);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     setOxygenLevel(game, 3);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/LuxuryEstate.spec.ts
+++ b/tests/cards/pathfinders/LuxuryEstate.spec.ts
@@ -19,10 +19,10 @@ describe('LuxuryEstate', function() {
 
   it('canPlay', function() {
     setOxygenLevel(game, 6);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     setOxygenLevel(game, 7);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/MartianMonuments.spec.ts
+++ b/tests/cards/pathfinders/MartianMonuments.spec.ts
@@ -17,15 +17,15 @@ describe('MartianMonuments', function() {
   });
 
   it('can play', function() {
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
     addCity(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
-    expect(player2.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player2)).is.false;
 
     // Add a city in space, it shouldn't count.
     addCity(player2, SpaceName.GANYMEDE_COLONY);
-    expect(player2.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player2)).is.false;
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/NewVenice.spec.ts
+++ b/tests/cards/pathfinders/NewVenice.spec.ts
@@ -25,19 +25,19 @@ describe('NewVenice', function() {
 
   it('Can play', function() {
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     addOcean(player);
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.plants = 1;
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.plants = 2;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/PrefabricationofHumanHabitats.spec.ts
+++ b/tests/cards/pathfinders/PrefabricationofHumanHabitats.spec.ts
@@ -17,13 +17,13 @@ describe('PrefabricationofHumanHabitats', function() {
   });
 
   it('canPlay', function() {
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.production.override({steel: 0});
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.production.override({steel: 1});
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('City tag discount ', function() {

--- a/tests/cards/pathfinders/SpaceDebrisCleaningOperation.spec.ts
+++ b/tests/cards/pathfinders/SpaceDebrisCleaningOperation.spec.ts
@@ -23,19 +23,19 @@ describe('SpaceDebrisCleaningOperation', function() {
 
   it('canPlay', function() {
     player.tagsForTest = {space: 3};
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.tagsForTest = {space: 4};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('canPlay, any 4 tags', function() {
     player2.tagsForTest = {space: 3};
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
 
     player.tagsForTest = {space: 4};
-    expect(player.simpleCanPlay(card)).is.true;
-    expect(player2.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {

--- a/tests/cards/pathfinders/SpecializedSettlement.spec.ts
+++ b/tests/cards/pathfinders/SpecializedSettlement.spec.ts
@@ -28,9 +28,9 @@ describe('SpecializedSettlement', function() {
 
   it('Can play', () => {
     player.production.override({energy: 0});
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
     player.production.override({energy: 1});
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {

--- a/tests/cards/prelude/LavaTubeSettlement.spec.ts
+++ b/tests/cards/prelude/LavaTubeSettlement.spec.ts
@@ -21,7 +21,7 @@ describe('LavaTubeSettlement', function() {
   });
 
   it('Cannot play without energy production', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Cannot play if no volcanic spaces left', function() {
@@ -33,12 +33,12 @@ describe('LavaTubeSettlement', function() {
     const anotherPlayer = TestPlayer.RED.newPlayer();
     game.board.getSpace(SpaceName.ASCRAEUS_MONS).player = anotherPlayer; // land claim
 
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     runAllActions(game);

--- a/tests/cards/prelude/MartianSurvey.spec.ts
+++ b/tests/cards/prelude/MartianSurvey.spec.ts
@@ -17,15 +17,15 @@ describe('MartianSurvey', function() {
 
   it('Cannot play', () => {
     setOxygenLevel(game, 5);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
   it('Can play', () => {
     setOxygenLevel(game, 4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
 
     expect(card.getVictoryPoints(player)).to.eq(1);

--- a/tests/cards/prelude/Psychrophiles.spec.ts
+++ b/tests/cards/prelude/Psychrophiles.spec.ts
@@ -17,16 +17,16 @@ describe('Psychrophiles', () => {
 
   it('Cannot play', () => {
     setTemperature(game, -18);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     setTemperature(game, -20);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     cast(card.play(player), undefined);
   });
 

--- a/tests/cards/prelude/SpaceHotels.spec.ts
+++ b/tests/cards/prelude/SpaceHotels.spec.ts
@@ -14,12 +14,12 @@ describe('SpaceHotels', function() {
 
   it('Can not play', function() {
     player.tagsForTest = {earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
     player.tagsForTest = {earth: 2};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/promo/CrashSiteCleanup.spec.ts
+++ b/tests/cards/promo/CrashSiteCleanup.spec.ts
@@ -17,7 +17,7 @@ describe('CrashSiteCleanup', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play if removed plants from another player this generation', function() {
@@ -31,7 +31,7 @@ describe('CrashSiteCleanup', function() {
     const orOptions = cast(player.game.deferredActions.peek()!.execute(), OrOptions);
     orOptions.options[0].cb([player2]);
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     expect(player.game.someoneHasRemovedOtherPlayersPlants).is.true;
 
     const action = cast(card.play(player), OrOptions);
@@ -50,7 +50,7 @@ describe('CrashSiteCleanup', function() {
     expect(player.game.deferredActions).has.lengthOf(1);
     player.game.deferredActions.peek()!.execute();
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     expect(player.game.someoneHasRemovedOtherPlayersPlants).is.true;
   });
 });

--- a/tests/cards/promo/DiversitySupport.spec.ts
+++ b/tests/cards/promo/DiversitySupport.spec.ts
@@ -16,7 +16,7 @@ describe('DiversitySupport', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', function() {
@@ -28,7 +28,7 @@ describe('DiversitySupport', function() {
     dirigibles.resourceCount = 4;
     fish.resourceCount = 3;
     ants.resourceCount = 2;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     // 6 standard resources
     player.megaCredits = 10;
@@ -38,7 +38,7 @@ describe('DiversitySupport', function() {
     player.energy = 1;
     player.heat = 3;
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
     expect(player.getTerraformRating()).to.eq(21);
   });

--- a/tests/cards/promo/DuskLaserMining.spec.ts
+++ b/tests/cards/promo/DuskLaserMining.spec.ts
@@ -16,18 +16,18 @@ describe('DuskLaserMining', function() {
 
   it('Can not play if not enough science tags', function() {
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if no energy production', function() {
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new Research());
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/promo/GreatDamPromo.spec.ts
+++ b/tests/cards/promo/GreatDamPromo.spec.ts
@@ -16,7 +16,7 @@ describe('GreatDamPromo', function() {
   });
 
   it('Can not play without meeting requirements', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {

--- a/tests/cards/promo/Harvest.spec.ts
+++ b/tests/cards/promo/Harvest.spec.ts
@@ -18,13 +18,13 @@ describe('Harvest', function() {
   });
 
   it('Cannot play', function() {
-    expect(player.simpleCanPlay(card)).is.false;
+    expect(card.canPlay(player)).is.false;
   });
 
   it('Should play', function() {
     const landSpace = game.board.getAvailableSpacesOnLand(player)[0];
     game.addGreenery(player, landSpace);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.megaCredits).to.eq(12);

--- a/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
+++ b/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
@@ -19,12 +19,12 @@ describe('MagneticFieldGeneratorsPromo', function() {
 
   it('Cannot play without enough energy production', function() {
     player.production.add(Resource.ENERGY, 3);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 4);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     runAllActions(game);

--- a/tests/cards/promo/MagneticShield.spec.ts
+++ b/tests/cards/promo/MagneticShield.spec.ts
@@ -14,14 +14,14 @@ describe('MagneticShield', function() {
   });
 
   it('Can not play if not enough power tags available', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new PowerPlant());
     player.playedCards.push(new PowerPlant());
     player.playedCards.push(new PowerPlant());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.getTerraformRating()).to.eq(24);

--- a/tests/cards/promo/MercurianAlloys.spec.ts
+++ b/tests/cards/promo/MercurianAlloys.spec.ts
@@ -15,12 +15,12 @@ describe('MercurianAlloys', function() {
   });
 
   it('Can not play if not enough science tags available', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.getTitaniumValue()).to.eq(4);

--- a/tests/cards/promo/OrbitalCleanup.spec.ts
+++ b/tests/cards/promo/OrbitalCleanup.spec.ts
@@ -50,10 +50,10 @@ describe('OrbitalCleanup', function() {
 
     // Sanity check that Science Ruling Policy is working as intended:
     const bioengineeringEnclosure = new BioengineeringEnclosure(); // Requires 1 science tag
-    expect(player.simpleCanPlay(bioengineeringEnclosure)).is.false;
+    expect(bioengineeringEnclosure.canPlay(player)).is.false;
     setRulingParty(game, PartyName.SCIENTISTS, SCIENTISTS_POLICY_4.id); // Reduce science tag requirements by 1
     SCIENTISTS_POLICY_4.onPolicyStart(game);
-    expect(player.simpleCanPlay(bioengineeringEnclosure)).is.true;
+    expect(bioengineeringEnclosure.canPlay(player)).is.true;
 
     // Make sure that we do not get 1MC for the Science Ruling Policy
     player.playedCards.push(new Research());

--- a/tests/cards/promo/Penguins.spec.ts
+++ b/tests/cards/promo/Penguins.spec.ts
@@ -17,12 +17,12 @@ describe('Penguins', function() {
 
   it('Cannot play', function() {
     maxOutOceans(player, 7);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     maxOutOceans(player, 8);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should act', function() {

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -138,7 +138,7 @@ describe('PharmacyUnion', function() {
     const advancedEcosystems = new AdvancedEcosystems();
     player.playedCards.push(new Fish());
     player.playedCards.push(new Lichen());
-    expect(player.simpleCanPlay(advancedEcosystems)).is.true;
+    expect(advancedEcosystems.canPlay(player)).is.true;
 
     card.resourceCount = 0;
     card.onCardPlayed(player, new SearchForLife());
@@ -147,7 +147,7 @@ describe('PharmacyUnion', function() {
     orOptions.options[0].cb();
     expect(card.isDisabled).is.true;
     expect(player.tags.count(Tag.MICROBE)).to.eq(0);
-    expect(player.simpleCanPlay(advancedEcosystems)).is.not.true;
+    expect(advancedEcosystems.canPlay(player)).is.not.true;
   });
 
   it('Edge Case - Let player pick the tag resolution order', function() {

--- a/tests/cards/promo/RobotPollinators.spec.ts
+++ b/tests/cards/promo/RobotPollinators.spec.ts
@@ -19,9 +19,9 @@ describe('Robot Pollinators', function() {
 
   it('Can not play if oxygen level too low', function() {
     setOxygenLevel(game, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     setOxygenLevel(game, 10);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Play, No tags', function() {

--- a/tests/cards/promo/SelfReplicatingRobots.spec.ts
+++ b/tests/cards/promo/SelfReplicatingRobots.spec.ts
@@ -21,12 +21,12 @@ describe('SelfReplicatingRobots', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should act', function() {

--- a/tests/cards/promo/SnowAlgae.spec.ts
+++ b/tests/cards/promo/SnowAlgae.spec.ts
@@ -16,12 +16,12 @@ describe('SnowAlgae', function() {
 
   it('Can not play', function() {
     maxOutOceans(player, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     maxOutOceans(player, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.plants).to.eq(1);

--- a/tests/cards/promo/SubCrustMeasurements.spec.ts
+++ b/tests/cards/promo/SubCrustMeasurements.spec.ts
@@ -14,12 +14,12 @@ describe('SubCrustMeasurements', function() {
   });
 
   it('Can not play if not enough science tags', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(card.getVictoryPoints(player)).to.eq(2);

--- a/tests/cards/turmoil/AerialLenses.spec.ts
+++ b/tests/cards/turmoil/AerialLenses.spec.ts
@@ -21,11 +21,11 @@ describe('AerialLenses', function() {
   });
 
   it('Can play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     const kelvinists = game.turmoil!.getPartyByName(PartyName.KELVINISTS);
     kelvinists.delegates.add(player, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play without plants', function() {

--- a/tests/cards/turmoil/BannedDelegate.spec.ts
+++ b/tests/cards/turmoil/BannedDelegate.spec.ts
@@ -26,12 +26,12 @@ describe('Banned Delegate', function() {
 
   it('Cannot play', function() {
     turmoil.chairman = player2;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     turmoil.chairman = player;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     const greens = turmoil.getPartyByName(PartyName.GREENS);
     turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
@@ -52,7 +52,7 @@ describe('Banned Delegate', function() {
 
   it('Removes duplicates', function() {
     turmoil.chairman = player;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
     turmoil.sendDelegateToParty(player, PartyName.GREENS, game);

--- a/tests/cards/turmoil/DiasporaMovement.spec.ts
+++ b/tests/cards/turmoil/DiasporaMovement.spec.ts
@@ -28,13 +28,13 @@ describe('DiasporaMovement', function() {
 
   it('Can not play', function() {
     reds.sendDelegate(player, game);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     reds.sendDelegate(player, game);
     reds.sendDelegate(player, game);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.playedCards.push(new ColonizerTrainingCamp());
     player2.playedCards.push(new MethaneFromTitan());

--- a/tests/cards/turmoil/EventAnalysts.spec.ts
+++ b/tests/cards/turmoil/EventAnalysts.spec.ts
@@ -7,12 +7,12 @@ describe('EventAnalysts', function() {
   it('Should play', function() {
     const card = new EventAnalysts();
     const [game, player] = testGame(1, {turmoilExtension: true});
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     game.turmoil!.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
     game.turmoil!.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
     game.turmoil!.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(game.turmoil!.getPlayerInfluence(player)).to.eq(3);

--- a/tests/cards/turmoil/GMOContract.spec.ts
+++ b/tests/cards/turmoil/GMOContract.spec.ts
@@ -10,10 +10,10 @@ describe('GMOContract', function() {
     const turmoil = game.turmoil!;
 
     turmoil.rulingParty = turmoil.getPartyByName(PartyName.REDS);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     const greens = turmoil.getPartyByName(PartyName.GREENS);
     greens.delegates.add(player, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
     card.onCardPlayed(player, card);
     game.deferredActions.runNext();

--- a/tests/cards/turmoil/PROffice.spec.ts
+++ b/tests/cards/turmoil/PROffice.spec.ts
@@ -12,11 +12,11 @@ describe('PROffice', function() {
     const card3 = new AcquiredCompany();
     const [game, player] = testGame(1, {turmoilExtension: true});
 
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     const unity = game.turmoil!.getPartyByName(PartyName.UNITY);
     unity.delegates.add(player, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.playedCards.push(card2, card3);
     card.play(player);

--- a/tests/cards/turmoil/ParliamentHall.spec.ts
+++ b/tests/cards/turmoil/ParliamentHall.spec.ts
@@ -12,11 +12,11 @@ describe('ParliamentHall', function() {
     const card3 = new MartianRails();
     const [game, player] = testGame(1, {turmoilExtension: true});
 
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     const mars = game.turmoil!.getPartyByName(PartyName.MARS);
     mars.delegates.add(player, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.playedCards.push(card2, card3);
     card.play(player);

--- a/tests/cards/turmoil/PublicCelebrations.spec.ts
+++ b/tests/cards/turmoil/PublicCelebrations.spec.ts
@@ -7,10 +7,10 @@ describe('PublicCelebrations', function() {
     const card = new PublicCelebrations();
     const [game, player] = testGame(1, {turmoilExtension: true});
 
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     game.turmoil!.chairman = player;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
   });
 });

--- a/tests/cards/turmoil/RedTourismWave.spec.ts
+++ b/tests/cards/turmoil/RedTourismWave.spec.ts
@@ -18,11 +18,11 @@ describe('RedTourismWave', function() {
   });
 
   it('Can play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     const reds = game.turmoil!.getPartyByName(PartyName.REDS);
     reds.delegates.add(player, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('play', function() {

--- a/tests/cards/turmoil/SupportedResearch.spec.ts
+++ b/tests/cards/turmoil/SupportedResearch.spec.ts
@@ -7,11 +7,11 @@ describe('SupportedResearch', function() {
   it('Should play', function() {
     const card = new SupportedResearch();
     const [game, player] = testGame(2, {turmoilExtension: true});
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     const scientists = game.turmoil!.getPartyByName(PartyName.SCIENTISTS);
     scientists.delegates.add(player, 2);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.cardsInHand).has.lengthOf(2);

--- a/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
+++ b/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
@@ -9,14 +9,14 @@ describe('VoteOfNoConfidence', function() {
     const card = new VoteOfNoConfidence();
     const [game, player] = testGame(1, {turmoilExtension: true});
     const turmoil = game.turmoil!;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     turmoil.chairman = 'NEUTRAL';
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     const greens = game.turmoil!.getPartyByName(PartyName.GREENS);
     greens.partyLeader = player;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(turmoil.chairman).to.eq(player);

--- a/tests/cards/turmoil/WildlifeDome.spec.ts
+++ b/tests/cards/turmoil/WildlifeDome.spec.ts
@@ -32,7 +32,7 @@ describe('WildlifeDome', function() {
   it('Should play: reds', function() {
     turmoil.rulingParty = reds;
     PoliticalAgendas.setNextAgenda(turmoil, game);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Play when greens are in power', function() {

--- a/tests/cards/venusNext/AerosportTournament.spec.ts
+++ b/tests/cards/venusNext/AerosportTournament.spec.ts
@@ -19,9 +19,9 @@ describe('AerosportTournament', function() {
     const [/* game */, player] = testGame(2);
     player.setCorporationForTest(corp);
     corp.resourceCount = 4;
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     corp.resourceCount = 5;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
   it('Play', function() {
     addCity(player, '03');

--- a/tests/cards/venusNext/AtalantaPlanitiaLab.spec.ts
+++ b/tests/cards/venusNext/AtalantaPlanitiaLab.spec.ts
@@ -7,7 +7,7 @@ describe('AtalantaPlanitiaLab', function() {
   it('Should play', function() {
     const card = new AtalantaPlanitiaLab();
     const [/* game */, player] = testGame(2);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     cast(card.play(player), undefined);
     expect(player.cardsInHand).has.lengthOf(2);
     expect(card.getVictoryPoints(player)).to.eq(2);

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -30,12 +30,12 @@ describe('Atmoscoop', function() {
 
   it('Cannot play', function() {
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play - no targets', function() {
     player.playedCards.push(new Research(), new SearchForLife());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     const action = cast(card.play(player), OrOptions);
 

--- a/tests/cards/venusNext/DawnCity.spec.ts
+++ b/tests/cards/venusNext/DawnCity.spec.ts
@@ -9,7 +9,7 @@ describe('DawnCity', function() {
     const card = new DawnCity();
     const [/* game */, player] = testGame(2, {venusNextExtension: true});
     player.production.add(Resource.ENERGY, 1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     cast(card.play(player), undefined);
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/venusNext/Extremophiles.spec.ts
+++ b/tests/cards/venusNext/Extremophiles.spec.ts
@@ -19,12 +19,12 @@ describe('Extremophiles', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     cast(card.play(player), undefined);
   });
 

--- a/tests/cards/venusNext/FloatingHabs.spec.ts
+++ b/tests/cards/venusNext/FloatingHabs.spec.ts
@@ -19,12 +19,12 @@ describe('FloatingHabs', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     cast(card.play(player), undefined);
   });
 

--- a/tests/cards/venusNext/FreyjaBiodomes.spec.ts
+++ b/tests/cards/venusNext/FreyjaBiodomes.spec.ts
@@ -22,13 +22,13 @@ describe('FreyjaBiodomes', function() {
 
   it('Can not play without energy production', function() {
     setVenusScaleLevel(game, 10);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if Venus requirement not met', function() {
     player.production.add(Resource.ENERGY, 1);
     setVenusScaleLevel(game, 8);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play - single target', function() {
@@ -37,7 +37,7 @@ describe('FreyjaBiodomes', function() {
 
     player.production.add(Resource.ENERGY, 1);
     setVenusScaleLevel(game, 10);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     expect(card.play(player)).is.undefined;
     expect(player.production.energy).to.eq(0);

--- a/tests/cards/venusNext/IshtarMining.spec.ts
+++ b/tests/cards/venusNext/IshtarMining.spec.ts
@@ -8,10 +8,10 @@ describe('IshtarMining', function() {
     const card = new IshtarMining();
     const [game, player] = testGame(2);
     game.increaseVenusScaleLevel(player, 3);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     game.increaseVenusScaleLevel(player, 3);
     expect(game.getVenusScaleLevel()).to.eq(12);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     cast(card.play(player), undefined);
     expect(player.production.titanium).to.eq(1);
   });

--- a/tests/cards/venusNext/LuxuryFoods.spec.ts
+++ b/tests/cards/venusNext/LuxuryFoods.spec.ts
@@ -7,28 +7,28 @@ describe('LuxuryFoods', function() {
   it('Should play', function() {
     const card = new LuxuryFoods();
     const [/* game */, player] = testGame(1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {jovian: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {jovian: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, jovian: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, jovian: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(2);

--- a/tests/cards/venusNext/MaxwellBase.spec.ts
+++ b/tests/cards/venusNext/MaxwellBase.spec.ts
@@ -24,19 +24,19 @@ describe('MaxwellBase', function() {
 
   it('Can not play without energy production', function() {
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can not play if Venus requirement not met', function() {
     player.production.add(Resource.ENERGY, 1);
     setVenusScaleLevel(game, 10);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.production.add(Resource.ENERGY, 1);
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
     runAllActions(game);

--- a/tests/cards/venusNext/MorningStarInc.spec.ts
+++ b/tests/cards/venusNext/MorningStarInc.spec.ts
@@ -14,35 +14,35 @@ describe('MorningStarInc', function() {
     player.setCorporationForTest(corp);
 
     setVenusScaleLevel(game, 2);
-    expect(player.simpleCanPlay(min8Card)).is.false;
-    expect(player.simpleCanPlay(max10Card)).is.true;
+    expect(min8Card.canPlay(player)).is.false;
+    expect(max10Card.canPlay(player)).is.true;
 
     setVenusScaleLevel(game, 4);
-    expect(player.simpleCanPlay(min8Card)).is.true;
-    expect(player.simpleCanPlay(max10Card)).is.true;
+    expect(min8Card.canPlay(player)).is.true;
+    expect(max10Card.canPlay(player)).is.true;
 
     setVenusScaleLevel(game, 6);
-    expect(player.simpleCanPlay(min8Card)).is.true;
-    expect(player.simpleCanPlay(max10Card)).is.true;
+    expect(min8Card.canPlay(player)).is.true;
+    expect(max10Card.canPlay(player)).is.true;
 
     setVenusScaleLevel(game, 8);
-    expect(player.simpleCanPlay(min8Card)).is.true;
-    expect(player.simpleCanPlay(max10Card)).is.true;
+    expect(min8Card.canPlay(player)).is.true;
+    expect(max10Card.canPlay(player)).is.true;
 
     setVenusScaleLevel(game, 10);
-    expect(player.simpleCanPlay(min8Card)).is.true;
-    expect(player.simpleCanPlay(max10Card)).is.true;
+    expect(min8Card.canPlay(player)).is.true;
+    expect(max10Card.canPlay(player)).is.true;
 
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(min8Card)).is.true;
-    expect(player.simpleCanPlay(max10Card)).is.true;
+    expect(min8Card.canPlay(player)).is.true;
+    expect(max10Card.canPlay(player)).is.true;
 
     setVenusScaleLevel(game, 14);
-    expect(player.simpleCanPlay(min8Card)).is.true;
-    expect(player.simpleCanPlay(max10Card)).is.true;
+    expect(min8Card.canPlay(player)).is.true;
+    expect(max10Card.canPlay(player)).is.true;
 
     setVenusScaleLevel(game, 16);
-    expect(player.simpleCanPlay(min8Card)).is.true;
-    expect(player.simpleCanPlay(max10Card)).is.false;
+    expect(min8Card.canPlay(player)).is.true;
+    expect(max10Card.canPlay(player)).is.false;
   });
 });

--- a/tests/cards/venusNext/NeutralizerFactory.spec.ts
+++ b/tests/cards/venusNext/NeutralizerFactory.spec.ts
@@ -7,7 +7,7 @@ describe('NeutralizerFactory', function() {
   it('Should play', function() {
     const card = new NeutralizerFactory();
     const [game, player] = testGame(2);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     cast(card.play(player), undefined);
     expect(game.getVenusScaleLevel()).to.eq(2);
   });

--- a/tests/cards/venusNext/Omnicourt.spec.ts
+++ b/tests/cards/venusNext/Omnicourt.spec.ts
@@ -7,28 +7,28 @@ describe('Omnicourt', function() {
   it('Should play', function() {
     const card = new Omnicourt();
     const [/* game */, player] = testGame(2);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {jovian: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {jovian: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, jovian: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, jovian: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
     expect(player.getTerraformRating()).to.eq(22);

--- a/tests/cards/venusNext/RotatorImpacts.spec.ts
+++ b/tests/cards/venusNext/RotatorImpacts.spec.ts
@@ -20,16 +20,16 @@ describe('RotatorImpacts', () => {
 
   it('Cannot play', () => {
     setVenusScaleLevel(game, 16);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     setVenusScaleLevel(game, 14);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     cast(card.play(player), undefined);
   });
 
@@ -39,7 +39,7 @@ describe('RotatorImpacts', () => {
     player.setCorporationForTest(corp);
 
     setVenusScaleLevel(game, 18);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should act', () => {

--- a/tests/cards/venusNext/SisterPlanetSupport.spec.ts
+++ b/tests/cards/venusNext/SisterPlanetSupport.spec.ts
@@ -7,16 +7,16 @@ describe('SisterPlanetSupport', function() {
   it('Should play', function() {
     const card = new SisterPlanetSupport();
     const [/* game */, player] = testGame(1);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(3);

--- a/tests/cards/venusNext/Solarnet.spec.ts
+++ b/tests/cards/venusNext/Solarnet.spec.ts
@@ -7,28 +7,28 @@ describe('Solarnet', function() {
   it('Should play', function() {
     const card = new Solarnet();
     const [/* game */, player] = testGame(2);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {jovian: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {jovian: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, jovian: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
     player.tagsForTest = {venus: 1, jovian: 1, earth: 1};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
     expect(player.cardsInHand).has.lengthOf(2);

--- a/tests/cards/venusNext/SpinInducingAsteroid.spec.ts
+++ b/tests/cards/venusNext/SpinInducingAsteroid.spec.ts
@@ -18,11 +18,11 @@ describe('SpinInducingAsteroid', function() {
 
   it('Can not play', function() {
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     card.play(player);
     expect(game.getVenusScaleLevel()).to.eq(4);
   });
@@ -30,7 +30,7 @@ describe('SpinInducingAsteroid', function() {
   it('Should play with Morning Star', function() {
     player.setCorporationForTest(new MorningStarInc());
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(game.getVenusScaleLevel()).to.eq(16);

--- a/tests/cards/venusNext/SponsoredAcademies.spec.ts
+++ b/tests/cards/venusNext/SponsoredAcademies.spec.ts
@@ -31,7 +31,7 @@ describe('SponsoredAcademies', function() {
 
   it('Should play', function() {
     player.cardsInHand.push(housePrinting, tardigrades);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     player.playCard(card);
     const discardCard = cast(game.deferredActions.pop()!.execute(), SelectCard<IProjectCard>);

--- a/tests/cards/venusNext/Stratopolis.spec.ts
+++ b/tests/cards/venusNext/Stratopolis.spec.ts
@@ -19,12 +19,12 @@ describe('Stratopolis', function() {
   });
 
   it('Can not play', function() {
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     card.play(player);
     expect(player.production.megacredits).to.eq(2);

--- a/tests/cards/venusNext/StratosphericBirds.spec.ts
+++ b/tests/cards/venusNext/StratosphericBirds.spec.ts
@@ -30,26 +30,26 @@ describe('StratosphericBirds', () => {
     player.playedCards.push(deuteriumExport);
     player.addResourceTo(deuteriumExport, 1);
     setVenusScaleLevel(game, 10);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Cannot play if no floater', () => {
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     player.playedCards.push(deuteriumExport);
     player.addResourceTo(deuteriumExport, 1);
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
     player.playedCards.push(deuteriumExport);
     player.addResourceTo(deuteriumExport, 1);
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     player.playedCards.push(card);
 
     card.play(player);
@@ -92,7 +92,7 @@ describe('StratosphericBirds', () => {
     setVenusScaleLevel(game, 12);
     player.megaCredits = 12;
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     const selectProjectCardToPlay = new SelectProjectCardToPlay(player);
     selectProjectCardToPlay.payAndPlay(card, {...Payment.EMPTY, megaCredits: 12});
@@ -111,12 +111,12 @@ describe('StratosphericBirds', () => {
     player.megaCredits = 9;
 
     // 9 M€ + 1 Dirigibles floater: Cannot play
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
 
 
     // 12 M€ + 1 Dirigibles floater: Card is playable
     player.megaCredits = 12;
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     // Try to spend floater to pay for card: Throw an error
     expect(() => {
@@ -140,7 +140,7 @@ describe('StratosphericBirds', () => {
     setVenusScaleLevel(game, 12);
     player.megaCredits = 3;
 
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     // Spend all 3 floaters from Dirigibles to pay for the card
     const selectProjectCardToPlay = new SelectProjectCardToPlay(player);
@@ -161,6 +161,6 @@ describe('StratosphericBirds', () => {
     const indentured = new IndenturedWorkers();
     player.playCard(indentured);
     card.play(player);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 });

--- a/tests/cards/venusNext/SulphurEatingBacteria.spec.ts
+++ b/tests/cards/venusNext/SulphurEatingBacteria.spec.ts
@@ -18,12 +18,12 @@ describe('SulphurEatingBacteria', function() {
 
   it('Can not play', function() {
     setVenusScaleLevel(game, 4);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setVenusScaleLevel(game, 6);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     expect(card.play(player)).is.undefined;
   });
 

--- a/tests/cards/venusNext/TerraformingContract.spec.ts
+++ b/tests/cards/venusNext/TerraformingContract.spec.ts
@@ -9,9 +9,9 @@ describe('TerraformingContract', function() {
     const [/* game */, player] = testGame(1);
 
     player.setTerraformRating(24);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     player.setTerraformRating(25);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(4);

--- a/tests/cards/venusNext/Thermophiles.spec.ts
+++ b/tests/cards/venusNext/Thermophiles.spec.ts
@@ -20,12 +20,12 @@ describe('Thermophiles', function() {
 
   it('Can not play', function() {
     setVenusScaleLevel(game, 4);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setVenusScaleLevel(game, 6);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     cast(card.play(player), undefined);
   });
 

--- a/tests/cards/venusNext/VenusGovernor.spec.ts
+++ b/tests/cards/venusNext/VenusGovernor.spec.ts
@@ -9,9 +9,9 @@ describe('VenusGovernor', function() {
     const [/* game */, player] = testGame(1);
 
     player.tagsForTest = {venus: 1};
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
     player.tagsForTest = {venus: 2};
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
     expect(player.production.megacredits).to.eq(2);

--- a/tests/cards/venusNext/VenusMagnetizer.spec.ts
+++ b/tests/cards/venusNext/VenusMagnetizer.spec.ts
@@ -18,12 +18,12 @@ describe('VenusMagnetizer', function() {
 
   it('Can not play', function() {
     setVenusScaleLevel(game, 8);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setVenusScaleLevel(game, 10);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     expect(card.play(player)).is.undefined;
   });
 

--- a/tests/cards/venusNext/VenusianAnimals.spec.ts
+++ b/tests/cards/venusNext/VenusianAnimals.spec.ts
@@ -18,12 +18,12 @@ describe('VenusianAnimals', function() {
 
   it('Can not play', function() {
     setVenusScaleLevel(game, 16);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
     setVenusScaleLevel(game, 18);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     player.playedCards.push(card);
     card.play(player);
 

--- a/tests/cards/venusNext/VenusianInsects.spec.ts
+++ b/tests/cards/venusNext/VenusianInsects.spec.ts
@@ -17,17 +17,17 @@ describe('VenusianInsects', () => {
 
   it('Cannot play', () => {
     setVenusScaleLevel(game, 10);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can play', () => {
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
   });
 
   it('Should play', () => {
     setVenusScaleLevel(game, 12);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
     player.playedCards.push(card);
 
     cast(card.play(player), undefined);

--- a/tests/cards/venusNext/VenusianPlants.spec.ts
+++ b/tests/cards/venusNext/VenusianPlants.spec.ts
@@ -20,12 +20,12 @@ describe('VenusianPlants', function() {
 
   it('Can not play', function() {
     setVenusScaleLevel(game, 14);
-    expect(player.simpleCanPlay(card)).is.not.true;
+    expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play - multiple targets', function() {
     setVenusScaleLevel(game, 16);
-    expect(player.simpleCanPlay(card)).is.true;
+    expect(card.canPlay(player)).is.true;
 
     const card2 = new Thermophiles();
     const card3 = new VenusianAnimals();

--- a/tests/turmoil/parties/Scientists.spec.ts
+++ b/tests/turmoil/parties/Scientists.spec.ts
@@ -68,7 +68,7 @@ describe('Scientists', function() {
 
     const card = new SearchForLife();
     setOxygenLevel(game, 8);
-    expect(player.simpleCanPlay(card)).to.be.true;
+    expect(card.canPlay(player)).to.be.true;
   });
 
   it('Ruling policy 3: When you raise a global parameter, draw a card per step raised', function() {
@@ -87,12 +87,12 @@ describe('Scientists', function() {
     setRulingParty(game, PartyName.SCIENTISTS, SCIENTISTS_POLICY_4.id);
 
     const card = new GeneRepair();
-    expect(player.simpleCanPlay(card)).to.be.false;
+    expect(card.canPlay(player)).to.be.false;
 
     const scientistsPolicy = SCIENTISTS_POLICY_4;
     scientistsPolicy.onPolicyStart(game);
     player.playedCards.push(new Research());
-    expect(player.simpleCanPlay(card)).to.be.true;
+    expect(card.canPlay(player)).to.be.true;
   });
 
   it('Ruling policy 4: Cards with multiple tag requirements may be played with 1 less Science tag', function() {
@@ -100,13 +100,13 @@ describe('Scientists', function() {
     player.playedCards.push(new SpaceStation(), new Satellites());
     player.titanium = 2;
     const card = new PrideoftheEarthArkship();
-    expect(player.simpleCanPlay(card)).to.be.false;
+    expect(card.canPlay(player)).to.be.false;
 
     setRulingParty(game, PartyName.SCIENTISTS, SCIENTISTS_POLICY_4.id);
     const scientistsPolicy = SCIENTISTS_POLICY_4;
     scientistsPolicy.onPolicyStart(game);
-    expect(player.simpleCanPlay(card)).to.be.true;
+    expect(card.canPlay(player)).to.be.true;
     scientistsPolicy.onPolicyEnd(game);
-    expect(player.simpleCanPlay(card)).to.be.false;
+    expect(card.canPlay(player)).to.be.false;
   });
 });


### PR DESCRIPTION
It used to be helpful, but card.canPlay(player) is cleaner, better.