### PR TITLE
Deprioritize robotic workforce and mars univeristy.

### DIFF
--- a/src/server/cards/base/RoboticWorkforce.ts
+++ b/src/server/cards/base/RoboticWorkforce.ts
@@ -6,6 +6,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {played} from '../Options';
 import {IPlayer} from '../../IPlayer';
+import {Priority} from '../../deferredActions/Priority';
 
 export class RoboticWorkforce extends RoboticWorkforceBase {
   constructor() {
@@ -27,6 +28,14 @@ export class RoboticWorkforce extends RoboticWorkforceBase {
   }
 
   public override bespokePlay(player: IPlayer) {
-    return this.selectBuildingCard(player, this.getPlayableBuildingCards(player), 'Select builder card to copy');
+    player.defer(
+      this.selectBuildingCard(
+        player,
+        this.getPlayableBuildingCards(player),
+        'Select builder card to copy',
+      ),
+      Priority.ROBOTIC_WORKFORCE,
+    );
+    return undefined;
   }
 }

--- a/src/server/cards/promo/CyberiaSystems.ts
+++ b/src/server/cards/promo/CyberiaSystems.ts
@@ -7,6 +7,7 @@ import {played} from '../Options';
 import {Size} from '../../../common/cards/render/Size';
 import {IPlayer} from '../../IPlayer';
 import {ICard} from '../ICard';
+import {Priority} from '../../deferredActions/Priority';
 
 export class CyberiaSystems extends RoboticWorkforceBase {
   constructor() {
@@ -37,10 +38,20 @@ export class CyberiaSystems extends RoboticWorkforceBase {
   }
 
   public override bespokePlay(player: IPlayer) {
-    const cards = this.getPlayableBuildingCards(player);
-    return this.selectBuildingCard(player, cards, 'Select first builder card to copy', (card) => {
-      const secondSet = this.getPlayableBuildingCards(player).filter((c) => c !== card);
-      return this.selectBuildingCard(player, secondSet, 'Select second card to copy');
-    });
+    const firstSet = this.getPlayableBuildingCards(player);
+    const selectFirstCard = this.selectBuildingCard(player, firstSet, 'Select first builder card to copy');
+    if (selectFirstCard === undefined) {
+      return undefined;
+    }
+
+    player.defer(
+      selectFirstCard.andThen(([card]) => {
+        const secondSet = this.getPlayableBuildingCards(player).filter((c) => c !== card);
+        player.defer(this.selectBuildingCard(player, secondSet, 'Select second card to copy'), Priority.ROBOTIC_WORKFORCE);
+        return undefined;
+      }),
+      Priority.ROBOTIC_WORKFORCE,
+    );
+    return undefined;
   }
 }

--- a/src/server/deferredActions/Priority.ts
+++ b/src/server/deferredActions/Priority.ts
@@ -10,8 +10,6 @@ export enum Priority {
 
   /** When you must discard before you can draw. Making a determination that Sponsored Academies should come before Mars U. */
   SPONSORED_ACADEMIES,
-  /** When you must discard before you can draw. Mars U, Ender (CEO). */
-  DISCARD_AND_DRAW,
   DRAW_CARDS,
   BUILD_COLONY,
   INCREASE_COLONY_TRACK,
@@ -21,6 +19,13 @@ export enum Priority {
 
   /** Anything that doesn't fit into another category. */
   DEFAULT,
+  /**
+   * When you must discard before you can draw. Mars U, Ender (CEO).
+   *
+   * Note: This used to be before DRAW_CARDS, and I don't know why it would be.
+   * Moving this just after DEFAULT. See #5488
+   */
+  DISCARD_AND_DRAW,
   /** Effects that make your opponents lose resources or production. */
   ATTACK_OPPONENT,
   /** Effects that make you lose resource or production "as much as possible". Pharmacy Union, Mons. */
@@ -29,5 +34,6 @@ export enum Priority {
   LOSE_RESOURCE_OR_PRODUCTION,
   DECREASE_COLONY_TRACK_AFTER_TRADE,
   DISCARD_CARDS,
+  ROBOTIC_WORKFORCE,
   BACK_OF_THE_LINE,
 }

--- a/tests/cards/base/MiningRights.spec.ts
+++ b/tests/cards/base/MiningRights.spec.ts
@@ -101,7 +101,9 @@ describe('MiningRights', () => {
     player.playedCards = [card];
 
     const roboticWorkforce = new RoboticWorkforce();
-    const selectCard = cast(roboticWorkforce.play(player), SelectCard);
+    cast(roboticWorkforce.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
     expect(selectCard.cards).deep.eq([card]);
     selectCard.cb([selectCard.cards[0]]);
     runAllActions(game);

--- a/tests/cards/base/RoboticWorkforce.spec.ts
+++ b/tests/cards/base/RoboticWorkforce.spec.ts
@@ -70,8 +70,10 @@ describe('RoboticWorkforce', () => {
     const noctisFarming = new NoctisFarming();
     player.playedCards.push(noctisFarming);
 
-    const action = cast(card.play(player), SelectCard);
-    action.cb([noctisFarming]);
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
+    selectCard.cb([noctisFarming]);
     expect(player.production.megacredits).to.eq(1);
   });
 
@@ -80,11 +82,15 @@ describe('RoboticWorkforce', () => {
     const venusgov = new VenusGovernor();
     player.playedCards.push(gyropolis, venusgov);
 
-    const action = card.play(player);
-    cast(action, undefined); // Not enough energy production for gyropolis, no other building card to copy
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    cast(player.popWaitingFor(), undefined); // Not enough energy production for gyropolis, no other building card to copy
 
     player.production.add(Resource.ENERGY, 2);
-    const selectCard = cast(card.play(player), SelectCard);
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
+
     selectCard.cb([gyropolis]);
     expect(player.production.energy).to.eq(0);
     expect(player.production.megacredits).to.eq(2);
@@ -94,11 +100,16 @@ describe('RoboticWorkforce', () => {
     const capital = new Capital();
     player.playedCards.push(capital);
 
-    const action = card.play(player);
-    cast(action, undefined); // Not enough energy production
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    cast(player.popWaitingFor(), undefined); // Not enough energy production
 
     player.production.add(Resource.ENERGY, 2);
-    const selectCard = cast(card.play(player), SelectCard);
+
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
+
     selectCard.cb([capital]);
     expect(player.production.energy).to.eq(0);
     expect(player.production.megacredits).to.eq(5);
@@ -109,11 +120,15 @@ describe('RoboticWorkforce', () => {
     const capitalAres = new CapitalAres();
     player.playedCards.push(capitalAres);
 
-    const action = card.play(player);
-    cast(action, undefined); // Not enough energy production
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    cast(player.popWaitingFor(), undefined); // Not enough energy production for gyropolis, no other building card to copy
 
     player.production.add(Resource.ENERGY, 2);
-    const selectCard = cast(card.play(player), SelectCard);
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
+
     selectCard.cb([capitalAres]);
     expect(player.production.energy).to.eq(0);
     expect(player.production.megacredits).to.eq(5);
@@ -129,14 +144,15 @@ describe('RoboticWorkforce', () => {
     expect(solarFarmSpace.bonus.every((b) => b === SpaceBonus.PLANT)).is.true;
 
     expect(player.production.energy).to.eq(0);
-    const action = cast(solarFarm.play(player), SelectSpace);
-    action.cb(solarFarmSpace);
+    const selectSpace = cast(solarFarm.play(player), SelectSpace);
+    selectSpace.cb(solarFarmSpace);
     expect(player.production.energy).to.eq(2);
 
     player.playedCards.push(solarFarm);
 
-    const selectCard = cast(card.play(player), SelectCard);
-    selectCard.cb([solarFarm]);
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    cast(player.popWaitingFor(), SelectCard).cb([solarFarm]);
     expect(player.production.energy).to.eq(4);
   });
 
@@ -144,11 +160,15 @@ describe('RoboticWorkforce', () => {
     const corporationCard = new UtopiaInvest();
     player.setCorporationForTest(corporationCard);
 
-    const action = cast(card.play(player), SelectCard);
+
+    cast(card.play(player), undefined);
+    runAllActions(game);
 
     expect(player.production.steel).to.eq(0);
     expect(player.production.titanium).to.eq(0);
-    action.cb([corporationCard as any]);
+
+    cast(player.popWaitingFor(), SelectCard).cb([corporationCard]);
+
     expect(player.production.steel).to.eq(1);
     expect(player.production.titanium).to.eq(1);
   });
@@ -170,11 +190,13 @@ describe('RoboticWorkforce', () => {
   it('Should work with Research Network', () => {
     const researchNetwork = new ResearchNetwork();
     player.playedCards.push(researchNetwork);
-    const action = cast(card.play(player), SelectCard);
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
 
-    expect(action.cards[0]).eq(researchNetwork);
+    expect(selectCard.cards[0]).eq(researchNetwork);
     expect(player.production.megacredits).to.eq(0);
-    action.cb([researchNetwork]);
+    selectCard.cb([researchNetwork]);
     expect(player.production.megacredits).to.eq(1);
   });
 
@@ -190,7 +212,9 @@ describe('RoboticWorkforce', () => {
 
     expect(card.canPlay(player)).is.true;
 
-    const selectCard = cast(card.play(player), SelectCard);
+    cast(card.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
 
     expect(selectCard.cards).deep.eq([heatTrappers]);
 

--- a/tests/cards/pathfinders/SpecializedSettlement.spec.ts
+++ b/tests/cards/pathfinders/SpecializedSettlement.spec.ts
@@ -126,10 +126,14 @@ describe('SpecializedSettlement', function() {
 
     const roboticWorkforce = new RoboticWorkforce();
     expect(roboticWorkforce.canPlay(player)).is.false;
-    expect(roboticWorkforce.play(player)).is.undefined;
 
     player.production.override(Units.of({energy: 1}));
-    const selectCard = cast(roboticWorkforce.play(player), SelectCard);
+
+    expect(roboticWorkforce.canPlay(player)).is.true;
+
+    cast(roboticWorkforce.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
     expect(selectCard.cards).deep.eq([card]);
     selectCard.cb([selectCard.cards[0]]);
     expect(player.production.asUnits()).deep.eq(Units.of({megacredits: 3, heat: 1}));

--- a/tests/cards/venusNext/Gyropolis.spec.ts
+++ b/tests/cards/venusNext/Gyropolis.spec.ts
@@ -12,14 +12,16 @@ import {RoboticWorkforce} from '../../../src/server/cards/base/RoboticWorkforce'
 import {Units} from '../../../src/common/Units';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {UnderworldTestHelper} from '../../underworld/UnderworldTestHelper';
+import {IGame} from '../../../src/server/IGame';
 
 describe('Gyropolis', function() {
   let card: Gyropolis;
+  let game: IGame;
   let player: TestPlayer;
 
   beforeEach(function() {
     card = new Gyropolis();
-    [/* game */, player] = testGame(2);
+    [game, player] = testGame(2);
   });
 
   it('Should play', function() {
@@ -70,7 +72,9 @@ describe('Gyropolis', function() {
     player.production.override(Units.of({energy: 2}));
     expect(roboticWorkforce.canPlay(player)).is.true;
 
-    const selectCard = cast(roboticWorkforce.play(player), SelectCard);
+    cast(roboticWorkforce.play(player), undefined);
+    runAllActions(game);
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
     expect(selectCard.cards).deep.eq([card]);
     selectCard.cb([selectCard.cards[0]]);
     expect(player.production.asUnits()).deep.eq(Units.of({megacredits: 2}));


### PR DESCRIPTION
These got deprioritized at the same time as part of addressing #5488. By and large, these two behaviors don't need to be priority options; discard after you get all the cards you can get! Implement robotic workforce after gaining all the required production you can get!

Though these are close-to-the-edge cases, I'm surprised that Robotic Workforce had such high priority for this long.