### PR TITLE
Allow make_static_json work without a .git directory.

### DIFF
--- a/make_static_json.js
+++ b/make_static_json.js
@@ -56,7 +56,7 @@ function getBuildMetadata() /* {head: string, date: string} */ {
     return {head, date: rest.join(' ')};
   } catch (error) {
     console.error('unable to generate app version', error);
-    throw error;
+    return {head: 'n/a', date: 'n/a'};
   }
 }
 


### PR DESCRIPTION
This probably happens when someone downloads a tarball or zip file of the source.

Perhaps it's worth updating instructions to require Git.