### PR TITLE
Fix link to wiki due to wiki header rename (Solar Phase -> World Government Terraforming)

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -196,7 +196,7 @@
 
                             <input type="checkbox" v-model="solarPhaseOption" id="WGT-checkbox">
                             <label for="WGT-checkbox">
-                                <span v-i18n>World Government Terraforming</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#solar-phase" class="tooltip" target="_blank">&#9432;</a>
+                                <span v-i18n>World Government Terraforming</span>&nbsp;<a href="https://github.com/terraforming-mars/terraforming-mars/wiki/Variants#world-government-terraforming" class="tooltip" target="_blank">&#9432;</a>
                             </label>
 
                             <template v-if="playersCount === 1">


### PR DESCRIPTION
Fix link to wiki due to header rename:
https://github.com/terraforming-mars/terraforming-mars/wiki/Variants/_compare/16d7b7be46dc2a6fde414506e624246f8f9b427a...39f835b06355380830b42ba62c0da311a0372c88