### PR TITLE
Move most uses of card.production to card.productionBox.

### DIFF
--- a/src/server/awards/amazonisPlanitia/Engineer.ts
+++ b/src/server/awards/amazonisPlanitia/Engineer.ts
@@ -34,7 +34,7 @@ export const BESPOKE_PRODUCTION_CARDS: ReadonlyArray<CardName> = [
   CardName.RARE_EARTH_ELEMENTS,
   CardName.MICROBIOLOGY_PATENTS,
   CardName.OUMUAMUA_TYPE_OBJECT_SURVEY,
-  CardName.RARE_EARTH_ELEMENTS,
+  CardName.SMALL_OPEN_PIT_MINE,
 ] as const;
 
 // Mapping from [CardName => boolean] indicating whether a card is eligible for Engineer.
@@ -62,7 +62,9 @@ export class Engineer implements IAward {
    * this award.
    */
   public static autoInclude(card: ICard) {
-    if (card.produce !== undefined) return true;
+    if (card.productionBox !== undefined) {
+      return true;
+    }
     const production = card.behavior?.production;
     if (production !== undefined) {
       return Object.keys(production).length > 0;

--- a/src/server/cards/ICard.ts
+++ b/src/server/cards/ICard.ts
@@ -20,6 +20,7 @@ import {JSONValue} from '../../common/Types';
 import {IStandardProjectCard} from './IStandardProjectCard';
 import {Warning} from '../../common/cards/Warning';
 import {Resource} from '../../common/Resource';
+import {Units} from '../../common/Units';
 
 /*
  * Represents a card which has an action that itself allows a player
@@ -132,6 +133,24 @@ export interface ICard {
   warnings: Set<Warning>;
 
   behavior?: Behavior,
+
+  /**
+   * Returns the contents of the card's production box.
+   *
+   * Use with Robotic Workforce and Cyberia Systems.
+   *
+   * Prefer this to `produce` and prefer `behavior` to this.
+   */
+  productionBox?(player: IPlayer): Units;
+
+  /**
+   * Applies the production change for the card's production box.
+   *
+   * Use with Robotic Workforce and Cyberia Systems.
+   * (Special case for Small Open Pit Mine.)
+   *
+   * Prefer both `productionBox` and `behavior` over this.
+   */
   produce?(player: IPlayer): void;
 
   /** Terraform Rating predicted when this card is played */

--- a/src/server/cards/ares/SolarFarm.ts
+++ b/src/server/cards/ares/SolarFarm.ts
@@ -2,7 +2,6 @@ import {Card} from '../Card';
 import {CardName} from '../../../common/cards/CardName';
 import {SelectSpace} from '../../inputs/SelectSpace';
 import {CanAffordOptions, IPlayer} from '../../IPlayer';
-import {Resource} from '../../../common/Resource';
 import {SpaceBonus} from '../../../common/boards/SpaceBonus';
 import {TileType} from '../../../common/TileType';
 import {CardType} from '../../../common/cards/CardType';
@@ -10,6 +9,7 @@ import {IProjectCard} from '../IProjectCard';
 import {Tag} from '../../../common/cards/Tag';
 import {CardRenderer} from '../render/CardRenderer';
 import {message} from '../../logs/MessageBuilder';
+import {Units} from '../../../common/Units';
 
 export class SolarFarm extends Card implements IProjectCard {
   constructor() {
@@ -35,13 +35,13 @@ export class SolarFarm extends Card implements IProjectCard {
     return player.game.board.getAvailableSpacesOnLand(player, canAffordOptions).length > 0;
   }
 
-  public produce(player: IPlayer) {
+  public productionBox(player: IPlayer) {
     const space = player.game.board.getSpaceByTileCard(this.name);
     if (space === undefined) {
       throw new Error('Solar Farm space not found');
     }
     const plantsOnSpace = space.bonus.filter((b) => b === SpaceBonus.PLANT).length;
-    player.production.add(Resource.ENERGY, plantsOnSpace, {log: true});
+    return Units.of({energy: plantsOnSpace});
   }
 
   public override bespokePlay(player: IPlayer) {
@@ -51,7 +51,7 @@ export class SolarFarm extends Card implements IProjectCard {
           tileType: TileType.SOLAR_FARM,
           card: this.name,
         });
-        this.produce(player);
+        player.production.adjust(this.productionBox(player), {log: true});
         space.adjacency = {bonus: [SpaceBonus.ENERGY, SpaceBonus.ENERGY]};
         return undefined;
       });

--- a/src/server/cards/base/MiningCard.ts
+++ b/src/server/cards/base/MiningCard.ts
@@ -12,6 +12,7 @@ import {Tag} from '../../../common/cards/Tag';
 import {SpaceBonus} from '../../../common/boards/SpaceBonus';
 import {TileType} from '../../../common/TileType';
 import {SelectResourceTypeDeferred} from '../../deferredActions/SelectResourceTypeDeferred';
+import {Units} from '../../../common/Units';
 
 export abstract class MiningCard extends Card implements IProjectCard {
   public bonusResource?: Array<Resource>;
@@ -58,10 +59,13 @@ export abstract class MiningCard extends Card implements IProjectCard {
     return TileType.MINING_AREA;
   }
 
-  public produce(player: IPlayer) {
+  public productionBox() {
+    // TODO(kberg): Matches Specialzied Settlement
+    const units = {...Units.EMPTY};
     if (this.bonusResource && this.bonusResource.length === 1) {
-      player.production.add(this.bonusResource[0], 1, {log: true});
+      units[this.bonusResource[0]] += 1;
     }
+    return units;
   }
 
   public override bespokePlay(player: IPlayer): SelectSpace {

--- a/src/server/cards/base/RoboticWorkforceBase.ts
+++ b/src/server/cards/base/RoboticWorkforceBase.ts
@@ -2,11 +2,11 @@ import {Tag} from '../../../common/cards/Tag';
 import {Card, StaticCardProperties} from '../Card';
 import {IPlayer} from '../../IPlayer';
 import {SelectCard} from '../../inputs/SelectCard';
-import {CardName} from '../../../common/cards/CardName';
 import {ICard} from '../ICard';
 import {Behavior} from '../../behavior/Behavior';
 import {getBehaviorExecutor} from '../../behavior/BehaviorExecutor';
 import {PlayerInput} from '../../PlayerInput';
+import {CardName} from '../../../common/cards/CardName';
 
 export abstract class RoboticWorkforceBase extends Card {
   constructor(properties: StaticCardProperties) {
@@ -31,12 +31,15 @@ export abstract class RoboticWorkforceBase extends Card {
     if (!card.tags.includes(Tag.BUILDING) && !card.tags.includes(Tag.WILD)) {
       return false;
     }
-    if (card.name === CardName.SPECIALIZED_SETTLEMENT) {
-      return player.production.energy >= 1;
+
+    // Small Open Pit Mine allows a player to choose between two options. Both are
+    // positive production so accept it rather than dig deep.
+    if (card.name === CardName.SMALL_OPEN_PIT_MINE) {
+      return true;
     }
 
-    if (card.produce !== undefined) {
-      return true;
+    if (card.productionBox !== undefined) {
+      return player.production.canAdjust(card.productionBox(player));
     }
 
     if (card.behavior !== undefined) {
@@ -69,6 +72,8 @@ export abstract class RoboticWorkforceBase extends Card {
 
         if (card.produce) {
           card.produce(player);
+        } else if (card.productionBox) {
+          player.production.adjust(card.productionBox(player), {log: true});
         } else if (card.behavior !== undefined) {
           getBehaviorExecutor().execute(this.productionBehavior(card.behavior), player, card);
         }

--- a/src/server/cards/pathfinders/SpecializedSettlement.ts
+++ b/src/server/cards/pathfinders/SpecializedSettlement.ts
@@ -10,6 +10,7 @@ import {Resource} from '../../../common/Resource';
 import {CardRenderer} from '../render/CardRenderer';
 import {SpaceBonus} from '../../../common/boards/SpaceBonus';
 import {SelectResourceTypeDeferred} from '../../deferredActions/SelectResourceTypeDeferred';
+import {Units} from '../../../common/Units';
 
 export class SpecializedSettlement extends Card implements IProjectCard {
   constructor() {
@@ -66,7 +67,7 @@ export class SpecializedSettlement extends Card implements IProjectCard {
   }
 
   public override bespokePlay(player: IPlayer) {
-    this.defaultProduce(player);
+    player.production.adjust(SpecializedSettlement.defaultProductionBox);
     return new SelectSpace(
       'Select space for city tile',
       player.game.board.getAvailableSpacesForCity(player))
@@ -93,16 +94,14 @@ export class SpecializedSettlement extends Card implements IProjectCard {
       );
   }
 
-  public produce(player: IPlayer) {
-    this.defaultProduce(player);
-    if (this.bonusResource && this.bonusResource.length === 1) {
-      player.production.add(this.bonusResource[0], 1, {log: true});
-    }
-  }
+  private static defaultProductionBox = Units.of({energy: -1, megacredits: 3});
 
-  private defaultProduce(player: IPlayer) {
-    player.production.add(Resource.ENERGY, -1);
-    player.production.add(Resource.MEGACREDITS, 3);
+  public productionBox() {
+    const units = {...SpecializedSettlement.defaultProductionBox};
+    if (this.bonusResource && this.bonusResource.length === 1) {
+      units[this.bonusResource[0]] += 1;
+    }
+    return units;
   }
 
   public produceForTile(player: IPlayer, bonusResources: Array<Resource>) {

--- a/src/server/cards/underworld/Landfill.ts
+++ b/src/server/cards/underworld/Landfill.ts
@@ -6,7 +6,6 @@ import {Card} from '../Card';
 import {Tag} from '../../../common/cards/Tag';
 import {IPlayer} from '../../IPlayer';
 import {Units} from '../../../common/Units';
-import {Resource} from '../../../common/Resource';
 
 export class Landfill extends Card implements IProjectCard {
   constructor() {
@@ -29,14 +28,14 @@ export class Landfill extends Card implements IProjectCard {
     });
   }
 
-  public produce(player: IPlayer) {
+  public productionBox(player: IPlayer) {
     const count = Units.keys.filter((type) => player.production[type] > 0).length;
-    player.production.add(Resource.MEGACREDITS, count, {log: true});
+    return Units.of({megacredits: count});
   }
 
 
   override bespokePlay(player: IPlayer) {
-    this.produce(player);
+    player.production.adjust(this.productionBox(player), {log: true});
     return undefined;
   }
 }

--- a/tests/awards/amazonisPlanitia/Engineer.spec.ts
+++ b/tests/awards/amazonisPlanitia/Engineer.spec.ts
@@ -7,6 +7,7 @@ import {Tardigrades} from '../../../src/server/cards/base/Tardigrades';
 import {MicroMills} from '../../../src/server/cards/base/MicroMills';
 import {Cartel} from '../../../src/server/cards/base/Cartel';
 import {DarksideMiningSyndicate} from '../../../src/server/cards/moon/DarksideMiningSyndicate';
+import {SpecializedSettlement} from '../../../src/server/cards/pathfinders/SpecializedSettlement';
 
 describe('Engineer', () => {
   let award: Engineer;
@@ -28,6 +29,8 @@ describe('Engineer', () => {
     expect(award.getScore(player)).eq(2);
     player.playedCards.push(new DarksideMiningSyndicate());
     expect(award.getScore(player)).eq(3);
+    player.playedCards.push(new SpecializedSettlement());
+    expect(award.getScore(player)).eq(4);
   });
 
   // A good way to prevent future failures is to duplicate the Robotic Workforce style of test.


### PR DESCRIPTION
This will facilitate better prediction for Cyberia Systems. It has the side effect of making a better calculation for Specialized Settlement and Robotic Workforce, in the case where the player gained one energy production (e.g. on Terra Cimmeria.)

The final remnant of card.production is Small Open Pit Mine, which lets a player choose between two options. This can't be reduced to a single option, but as a single-case, it will probably be hard-coded into dealing with Cyberia Systems.