### PR TITLE
Deserialization of canUseCorruptionAsMegacredits attribute in Player

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1937,6 +1937,7 @@ export class Player implements IPlayer {
     player.canUseHeatAsMegaCredits = d.canUseHeatAsMegaCredits;
     player.canUsePlantsAsMegacredits = d.canUsePlantsAsMegaCredits;
     player.canUseTitaniumAsMegacredits = d.canUseTitaniumAsMegacredits;
+    player.canUseCorruptionAsMegacredits = d.canUseCorruptionAsMegacredits;
     player.cardCost = d.cardCost;
     player.colonies.cardDiscount = d.cardDiscount;
     player.colonies.tradeDiscount = d.colonyTradeDiscount;

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -224,7 +224,7 @@ describe('Player', function() {
       heatProduction: 12,
       titaniumValue: 13,
       steelValue: 14,
-      canUseCorruptionAsMegacredits: false,
+      canUseCorruptionAsMegacredits: true,
       canUseHeatAsMegaCredits: false,
       canUseTitaniumAsMegacredits: false,
       canUsePlantsAsMegaCredits: false,
@@ -277,6 +277,7 @@ describe('Player', function() {
 
     expect(newPlayer.color).eq(Color.PURPLE);
     expect(newPlayer.colonies.tradesThisGeneration).eq(100);
+    expect(newPlayer.canUseCorruptionAsMegacredits).eq(true);
   });
   it('pulls self replicating robots target cards', function() {
     const player = new Player('blue', Color.BLUE, false, 0, 'p-blue');


### PR DESCRIPTION
Could fix #6511 

canUseCorruptionAsMegacredits was not deserialized