### PR TITLE
Make cards that operate on science tags compatible with Leavitt colony

### DIFF
--- a/src/server/cards/ICard.ts
+++ b/src/server/cards/ICard.ts
@@ -122,7 +122,10 @@ export interface ICard {
   onProductionGain?(player: IPlayer, resource: Resource, amount: number): void;
   onProductionPhase?(player: IPlayer): void;
 
+  /** Optional callback when ANY player adds a colony. */
   onColonyAdded?(player: IPlayer, cardOwner: IPlayer): void;
+  /** Optional callback when `player` adds a colony to Leavitt. */
+  onColonyAddedToLeavitt?(player: IPlayer): void;
 
   cost?: number; /** Used with IProjectCard and PreludeCard. */
   type: CardType;

--- a/src/server/cards/base/MarsUniversity.ts
+++ b/src/server/cards/base/MarsUniversity.ts
@@ -32,7 +32,13 @@ export class MarsUniversity extends Card implements IProjectCard {
 
   public onCardPlayed(player: IPlayer, card: IProjectCard) {
     const scienceTags = player.tags.cardTagCount(card, Tag.SCIENCE);
-    for (let i = 0; i < scienceTags; i++) {
+    this.onScienceTagAdded(player, scienceTags);
+  }
+  public onColonyAddedToLeavitt(player: IPlayer) {
+    this.onScienceTagAdded(player, 1);
+  }
+  public onScienceTagAdded(player: IPlayer, count: number) {
+    for (let i = 0; i < count; i++) {
       player.defer(() => {
         // No card to discard
         if (player.cardsInHand.length === 0) {

--- a/src/server/cards/base/OlympusConference.ts
+++ b/src/server/cards/base/OlympusConference.ts
@@ -35,7 +35,13 @@ export class OlympusConference extends Card implements IProjectCard {
 
   public onCardPlayed(player: IPlayer, card: IProjectCard) {
     const scienceTags = player.tags.cardTagCount(card, Tag.SCIENCE);
-    for (let i = 0; i < scienceTags; i++) {
+    this.onScienceTagAdded(player, scienceTags);
+  }
+  public onColonyAddedToLeavitt(player: IPlayer) {
+    this.onScienceTagAdded(player, 1);
+  }
+  public onScienceTagAdded(player: IPlayer, count: number) {
+    for (let i = 0; i < count; i++) {
       player.defer(() => {
         // Can't remove a resource
         if (this.resourceCount === 0) {

--- a/src/server/cards/ceos/Faraday.ts
+++ b/src/server/cards/ceos/Faraday.ts
@@ -59,11 +59,21 @@ export class Faraday extends CeoCard {
   }
 
   public onCardPlayed(player: IPlayer, card: IProjectCard) {
-    if (card.tags.length === 0 || card.type === CardType.EVENT || !player.canAfford(2)) return;
+    if (card.tags.length === 0 || card.type === CardType.EVENT || !player.canAfford(2)) {
+      return;
+    }
 
+    this.processTags(player, card.tags);
+  }
+
+  public onColonyAddedToLeavitt(player: IPlayer) {
+    this.processTags(player, [Tag.SCIENCE]);
+  }
+
+  private processTags(player: IPlayer, tags: ReadonlyArray<Tag>) {
     const counts = this.countTags(player);
 
-    const tagsOnCard = MultiSet.from(card.tags);
+    const tagsOnCard = MultiSet.from(tags);
     tagsOnCard.forEachMultiplicity((countOnCard, tagOnCard) => {
       if (INVALID_TAGS.includes(tagOnCard)) return;
       if (this.gainedMultiple(countOnCard, counts[tagOnCard])) {

--- a/src/server/cards/colonies/Aridor.ts
+++ b/src/server/cards/colonies/Aridor.ts
@@ -58,22 +58,31 @@ export class Aridor extends CorporationCard {
     return undefined;
   }
 
+  private processTags(player: IPlayer, tags: ReadonlyArray<Tag>) {
+    for (const tag of tags) {
+      const currentSize = this.allTags.size;
+      this.allTags.add(tag);
+      if (this.allTags.size > currentSize) {
+        // TODO(kberg): Replace with M€
+        player.game.log('${0} gained 1 MC production from ${1} for ${2}', (b) => b.player(player).card(this).string(tag));
+        player.production.add(Resource.MEGACREDITS, 1, {log: true});
+      }
+    }
+  }
+
   public onCorpCardPlayed(player: IPlayer, card: ICorporationCard) {
     return this.onCardPlayed(player, card);
+  }
+
+  public onColonyAddedToLeavitt(player: IPlayer) {
+    this.processTags(player, [Tag.SCIENCE]);
   }
 
   public onCardPlayed(player: IPlayer, card: ICard) {
     if (!player.isCorporation(this.name)) {
       return;
     }
-    for (const tag of this.tagsForCard(card)) {
-      const currentSize = this.allTags.size;
-      this.allTags.add(tag);
-      if (this.allTags.size > currentSize) {
-        player.game.log('${0} gained 1 MC production from ${1} for ${2}', (b) => b.player(player).card(this).string(tag));
-        player.production.add(Resource.MEGACREDITS, 1, {log: true});
-      }
-    }
+    this.processTags(player, this.tagsForCard(card));
   }
 
   public serialize(serialized: SerializedCard) {

--- a/src/server/cards/promo/CarbonNanosystems.ts
+++ b/src/server/cards/promo/CarbonNanosystems.ts
@@ -30,7 +30,10 @@ export class CarbonNanosystems extends Card implements IProjectCard {
 
   public onCardPlayed(player: IPlayer, card: IProjectCard) {
     const tags = card.tags.filter((tag) => tag === Tag.SCIENCE).length;
-    player.addResourceTo(this, tags);
+    player.addResourceTo(this, {qty: tags, log: true});
     return undefined;
+  }
+  public onColonyAddedToLeavitt(player: IPlayer): void {
+    player.addResourceTo(this, {qty: 1, log: true});
   }
 }

--- a/src/server/cards/promo/PharmacyUnion.ts
+++ b/src/server/cards/promo/PharmacyUnion.ts
@@ -104,39 +104,7 @@ export class PharmacyUnion extends CorporationCard {
 
     if (isPharmacyUnion && hasScienceTag) {
       const scienceTags = player.tags.cardTagCount(card, Tag.SCIENCE);
-      for (let i = 0; i < scienceTags; i++) {
-        player.defer(() => {
-          if (this.isDisabled) return undefined;
-
-          if (this.resourceCount > 0) {
-            if (player.canAfford({cost: 0, tr: {tr: 1}}) === false) {
-              // TODO (Lynesth): Remove this when #1670 is fixed
-              game.log('${0} cannot remove a disease from ${1} to gain 1 TR because of unaffordable Reds policy cost', (b) => b.player(player).card(this));
-            } else {
-              this.resourceCount--;
-              player.increaseTerraformRating();
-              game.log('${0} removed a disease from ${1} to gain 1 TR', (b) => b.player(player).card(this));
-            }
-            return undefined;
-          }
-
-          if (player.canAfford({cost: 0, tr: {tr: 3}}) === false) {
-            // TODO (Lynesth): Remove this when #1670 is fixed
-            game.log('${0} cannot turn ${1} face down to gain 3 TR because of unaffordable Reds policy cost', (b) => b.player(player).card(this));
-            return undefined;
-          }
-
-          return new OrOptions(
-            new SelectOption('Turn this card face down and gain 3 TR', 'Gain TR').andThen(() => {
-              this.isDisabled = true;
-              player.increaseTerraformRating(3);
-              game.log('${0} turned ${1} face down to gain 3 TR', (b) => b.player(player).card(this));
-              return undefined;
-            }),
-            new SelectOption('Do nothing', 'Do nothing'),
-          );
-        }, -1); // Make it a priority
-      }
+      this.onScienceTagAdded(player, scienceTags);
     }
 
 
@@ -150,6 +118,46 @@ export class PharmacyUnion extends CorporationCard {
         game.log('${0} added a disease to ${1} and lost ${2} M€', (b) => b.player(player).card(this).number(megaCreditsLost));
         return undefined;
       }, Priority.SUPERPOWER);
+    }
+  }
+
+  public onColonyAddedToLeavitt(player: IPlayer) {
+    this.onScienceTagAdded(player, 1);
+  }
+  public onScienceTagAdded(player: IPlayer, count: number) {
+    const game = player.game;
+    for (let i = 0; i < count; i++) {
+      player.defer(() => {
+        if (this.isDisabled) return undefined;
+
+        if (this.resourceCount > 0) {
+          if (player.canAfford({cost: 0, tr: {tr: 1}}) === false) {
+            // TODO (Lynesth): Remove this when #1670 is fixed
+            game.log('${0} cannot remove a disease from ${1} to gain 1 TR because of unaffordable Reds policy cost', (b) => b.player(player).card(this));
+          } else {
+            this.resourceCount--;
+            player.increaseTerraformRating();
+            game.log('${0} removed a disease from ${1} to gain 1 TR', (b) => b.player(player).card(this));
+          }
+          return undefined;
+        }
+
+        if (player.canAfford({cost: 0, tr: {tr: 3}}) === false) {
+          // TODO (Lynesth): Remove this when #1670 is fixed
+          game.log('${0} cannot turn ${1} face down to gain 3 TR because of unaffordable Reds policy cost', (b) => b.player(player).card(this));
+          return undefined;
+        }
+
+        return new OrOptions(
+          new SelectOption('Turn this card face down and gain 3 TR', 'Gain TR').andThen(() => {
+            this.isDisabled = true;
+            player.increaseTerraformRating(3);
+            game.log('${0} turned ${1} face down to gain 3 TR', (b) => b.player(player).card(this));
+            return undefined;
+          }),
+          new SelectOption('Do nothing', 'Do nothing'),
+        );
+      }, -1); // Make it a priority
     }
   }
 

--- a/src/server/cards/underworld/StemFieldSubsidies.ts
+++ b/src/server/cards/underworld/StemFieldSubsidies.ts
@@ -32,6 +32,12 @@ export class StemFieldSubsidies extends Card implements IProjectCard {
 
   public onCardPlayed(player: IPlayer, card: IProjectCard) {
     const count = player.tags.cardTagCount(card, Tag.SCIENCE);
+    this.onScienceTagAdded(player, count);
+  }
+  public onColonyAddedToLeavitt(player: IPlayer): void {
+    this.onScienceTagAdded(player, 1);
+  }
+  public onScienceTagAdded(player: IPlayer, count: number) {
     if (count > 0) {
       player.game.defer(new IdentifySpacesDeferred(player, count));
     }

--- a/src/server/cards/venusNext/VenusianAnimals.ts
+++ b/src/server/cards/venusNext/VenusianAnimals.ts
@@ -34,4 +34,7 @@ export class VenusianAnimals extends Card implements IProjectCard {
     const qty = player.tags.cardTagCount(card, Tag.SCIENCE);
     player.addResourceTo(this, {qty, log: true});
   }
+  public onColonyAddedToLeavitt(player: IPlayer): void {
+    player.addResourceTo(this, {qty: 1, log: true});
+  }
 }

--- a/src/server/colonies/Colony.ts
+++ b/src/server/colonies/Colony.ts
@@ -97,6 +97,12 @@ export abstract class Colony implements IColony {
         card.onColonyAdded?.(player, cardOwner);
       }
     }
+
+    if (this.name === ColonyName.LEAVITT) {
+      for (const card of player.tableau) {
+        card.onColonyAddedToLeavitt?.(player);
+      }
+    }
   }
 
   /*

--- a/tests/cards/base/OlympusConference.spec.ts
+++ b/tests/cards/base/OlympusConference.spec.ts
@@ -10,6 +10,7 @@ import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {TestPlayer} from '../../TestPlayer';
 import {cast, runAllActions} from '../../TestingUtils';
 import {testGame} from '../../TestGame';
+import {Leavitt} from '../../../src/server/cards/community/Leavitt';
 
 describe('OlympusConference', function() {
   let card: OlympusConference;
@@ -32,17 +33,15 @@ describe('OlympusConference', function() {
 
     // No resource
     card.onCardPlayed(player, card);
-    expect(game.deferredActions).has.lengthOf(1);
-    const input = game.deferredActions.peek()!.execute();
-    game.deferredActions.pop();
-    expect(input).is.undefined;
+    runAllActions(game);
+    cast(player.popWaitingFor(), undefined);
     expect(card.resourceCount).to.eq(1);
 
     // Resource available
     card.onCardPlayed(player, card);
-    expect(game.deferredActions).has.lengthOf(1);
+    runAllActions(game);
 
-    const orOptions = cast(game.deferredActions.peek()!.execute(), OrOptions);
+    const orOptions = cast(player.popWaitingFor(), OrOptions);
     game.deferredActions.pop();
     orOptions.options[1].cb();
     expect(card.resourceCount).to.eq(2);
@@ -125,5 +124,15 @@ describe('OlympusConference', function() {
     game.deferredActions.pop();
     orOptions2.options[1].cb();
     expect(card.resourceCount).to.eq(2);
+  });
+
+  it('Compatible with Leavitt #6349', () => {
+    player.playedCards.push(card);
+    const leavitt = new Leavitt();
+    leavitt.addColony(player);
+
+    runAllActions(game);
+    cast(player.popWaitingFor(), undefined);
+    expect(card.resourceCount).to.eq(1);
   });
 });

--- a/tests/cards/ceo/Faraday.spec.ts
+++ b/tests/cards/ceo/Faraday.spec.ts
@@ -9,6 +9,7 @@ import {cast, fakeCard, runAllActions} from '../../TestingUtils';
 import {CardType} from '../../../src/common/cards/CardType';
 import {CrewTraining} from '../../../src/server/cards/pathfinders/CrewTraining';
 import {DeclareCloneTag} from '../../../src/server/pathfinders/DeclareCloneTag';
+import {Leavitt} from '../../../src/server/cards/community/Leavitt';
 
 describe('Faraday', function() {
   let card: Faraday;
@@ -185,5 +186,22 @@ describe('Faraday', function() {
     expect(player.megaCredits).to.eq(PLAYER_INITIALMC - CARD_DRAW_COST);
     expect(player.cardsInHand).has.length(1);
     expect(player.cardsInHand[0].tags.includes(Tag.EARTH)).is.true;
+  });
+
+  it('Compatible with Leavitt #6349', () => {
+    player.playedCards.push(fakeCard({tags: [Tag.SCIENCE, Tag.SCIENCE, Tag.SCIENCE, Tag.SCIENCE]}));
+
+    const leavitt = new Leavitt();
+    leavitt.addColony(player);
+
+    runAllActions(game);
+
+    // Now that it's Science tags, we should be prompted to draw an Science card
+    const orOptions = cast(player.popWaitingFor(), OrOptions);
+    orOptions.options[0].cb();
+    runAllActions(game);
+    expect(player.megaCredits).to.eq(PLAYER_INITIALMC - CARD_DRAW_COST);
+    expect(player.cardsInHand).has.length(1);
+    expect(player.cardsInHand[0].tags.includes(Tag.SCIENCE)).is.true;
   });
 });

--- a/tests/cards/colonies/Aridor.spec.ts
+++ b/tests/cards/colonies/Aridor.spec.ts
@@ -14,6 +14,7 @@ import {SelectColony} from '../../../src/server/inputs/SelectColony';
 import {InputResponse} from '../../../src/common/inputs/InputResponse';
 import {ColonyName} from '../../../src/common/colonies/ColonyName';
 import {GHGProducingBacteria} from '../../../src/server/cards/base/GHGProducingBacteria';
+import {Leavitt} from '../../../src/server/cards/community/Leavitt';
 
 let card: Aridor;
 let game: IGame;
@@ -116,5 +117,17 @@ describe('Aridor', function() {
     const reserializedAridor = cast(reserializedPlayer.corporations?.[0], Aridor);
 
     expect(Array.from(reserializedAridor.allTags)).deep.eq([Tag.ANIMAL, Tag.SCIENCE, Tag.CITY, Tag.BUILDING]);
+  });
+
+  it('Compatible with Leavitt #6349', () => {
+    player.corporations.push(card);
+
+    expect(player.production.megacredits).eq(0);
+
+    const leavitt = new Leavitt();
+    leavitt.addColony(player);
+
+    runAllActions(game);
+    expect(player.production.megacredits).eq(1);
   });
 });

--- a/tests/cards/community/Leavitt.spec.ts
+++ b/tests/cards/community/Leavitt.spec.ts
@@ -9,6 +9,7 @@ import {Tag} from '../../../src/common/cards/Tag';
 import {cast, runAllActions} from '../../TestingUtils';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
 import {testGame} from '../../TestGame';
+import {VenusianAnimals} from '../../../src/server/cards/venusNext/VenusianAnimals';
 
 describe('Leavitt', function() {
   let leavitt: Leavitt;
@@ -124,5 +125,17 @@ describe('Leavitt', function() {
     expect(player.tags.count(Tag.SCIENCE)).to.eq(0);
     leavitt.addColony(player);
     expect(player.tags.count(Tag.SCIENCE)).to.eq(1);
+  });
+
+  // #6349
+  it('Leavitt is compatible with Venusian Animals', () => {
+    const venusianAnimals = new VenusianAnimals();
+    player.playedCards.push(venusianAnimals);
+
+    expect(venusianAnimals.resourceCount).eq(0);
+
+    leavitt.addColony(player);
+
+    expect(venusianAnimals.resourceCount).eq(1);
   });
 });

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -18,6 +18,7 @@ import {Virus} from '../../../src/server/cards/base/Virus';
 import {cast, runAllActions} from '../../TestingUtils';
 import {Player} from '../../../src/server/Player';
 import {testGame} from '../../TestGame';
+import {Leavitt} from '../../../src/server/cards/community/Leavitt';
 
 describe('PharmacyUnion', function() {
   let card: PharmacyUnion;
@@ -32,7 +33,7 @@ describe('PharmacyUnion', function() {
   });
 
   it('Should play', function() {
-    player.corporations.length = 0; // Resetting so when setting the corproation it doesn't do anything flaky.
+    player.corporations.length = 0; // Resetting so when setting the corporation it doesn't do anything flaky.
     [game, player] = testGame(1, {skipInitialCardSelection: false});
     const pi = cast(player.getWaitingFor(), SelectInitialCards);
     pi.options[0].cb([card]);
@@ -213,5 +214,17 @@ describe('PharmacyUnion', function() {
     const reserializedPlayer = Player.deserialize(serializedPlayer);
     const reserializedPharmacyUnion = cast(reserializedPlayer.corporations?.[0], PharmacyUnion);
     expect(reserializedPharmacyUnion.isDisabled).is.true;
+  });
+
+  it('Compatible with Leavitt #6349', () => {
+    card.resourceCount = 2;
+
+    const leavitt = new Leavitt();
+    leavitt.addColony(player);
+
+    runAllActions(game);
+
+    expect(card.resourceCount).to.eq(1);
+    expect(player.getTerraformRating()).to.eq(21);
   });
 });

--- a/tests/cards/underworld/StemFieldSubsidies.spec.ts
+++ b/tests/cards/underworld/StemFieldSubsidies.spec.ts
@@ -8,6 +8,7 @@ import {IGame} from '../../../src/server/IGame';
 import {TestPlayer} from '../../TestPlayer';
 import {CardResource} from '../../../src/common/CardResource';
 import {assertIsAddResourceToCard} from '../../assertions';
+import {Leavitt} from '../../../src/server/cards/community/Leavitt';
 
 describe('StemFieldSubsidies', () => {
   let card: StemFieldSubsidies;
@@ -64,6 +65,18 @@ describe('StemFieldSubsidies', () => {
     assertIsIdentificationAction(player, player.popWaitingFor());
     runAllActions(game);
     assertIsAddResourceToCard(player.popWaitingFor(), 1, [card, otherCard], card);
+    cast(player.popWaitingFor(), undefined);
+    runAllActions(game);
+    expect(card.resourceCount).eq(1);
+  });
+
+  it('Compatible with Leavitt #6349', () => {
+    const leavitt = new Leavitt();
+    leavitt.addColony(player);
+
+    runAllActions(game);
+    assertIsIdentificationAction(player, player.popWaitingFor());
+    runAllActions(game);
     cast(player.popWaitingFor(), undefined);
     runAllActions(game);
     expect(card.resourceCount).eq(1);

--- a/tests/cards/venusNext/VenusianAnimals.spec.ts
+++ b/tests/cards/venusNext/VenusianAnimals.spec.ts
@@ -5,6 +5,7 @@ import {VenusianAnimals} from '../../../src/server/cards/venusNext/VenusianAnima
 import {IGame} from '../../../src/server/IGame';
 import {TestPlayer} from '../../TestPlayer';
 import {testGame} from '../../TestGame';
+import {Leavitt} from '../../../src/server/cards/community/Leavitt';
 
 describe('VenusianAnimals', function() {
   let card: VenusianAnimals;
@@ -34,5 +35,16 @@ describe('VenusianAnimals', function() {
     expect(card.resourceCount).to.eq(3);
 
     expect(card.getVictoryPoints(player)).to.eq(3);
+  });
+
+  it('Compatible with Leavitt #6349', () => {
+    player.playedCards.push(card);
+
+    expect(card.resourceCount).eq(0);
+
+    const leavitt = new Leavitt();
+    leavitt.addColony(player);
+
+    expect(card.resourceCount).eq(1);
   });
 });


### PR DESCRIPTION
This used to work but I'm sure stopped working at some point when I did a bunch of things. The cleanest way to fix this is to add a custom callback. Not the very best, but it does the job.

Cards impacted include

Pharmacy Union
Mars University
Stem Field Subsidies
Venusian Animals
Carbon Nanosystems
Olympus Conference
Faraday
Aridor

Cards not impacted include

Collegium Copernicus:
  Specifically says it only works with cards. There's an argument that
  this should count, but I think this is OK.
Valley Trust:
  represents a discount when playing a science tag. There's an argument
  that this should enable the player to get a 2MC discount when buying
  a colony on Leavitt, but it's not very good.

Fixes #6349