### PR TITLE
Mostly, fix Spice to work with Pharmacy Union

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -582,6 +582,7 @@ export class Game implements IGame, Logger {
   }
 
   private playerHasPickedCorporationCard(player: IPlayer, corporationCard: ICorporationCard): void {
+    // TODO(kberg): I think we can get rid of this weird validation at a later time.
     player.pickedCorporationCard = corporationCard;
     if (this.players.every((p) => p.pickedCorporationCard !== undefined)) {
       for (const somePlayer of this.getPlayersInGenerationOrder()) {

--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -76,6 +76,14 @@ import {SendDelegateToArea} from './deferredActions/SendDelegateToArea';
 import {BuildColony} from './deferredActions/BuildColony';
 import {newInitialDraft, newPreludeDraft, newStandardDraft} from './Draft';
 
+// Can be overridden by tests
+
+let createGameLog: () => Array<LogMessage> = () => [];
+
+export function setGameLog(f: () => Array<LogMessage>) {
+  createGameLog = f;
+}
+
 export class Game implements IGame, Logger {
   public readonly id: GameId;
   public readonly gameOptions: Readonly<GameOptions>;
@@ -89,7 +97,7 @@ export class Game implements IGame, Logger {
   public deferredActions: DeferredActionsQueue = new DeferredActionsQueue();
   public createdTime: Date = new Date(0);
   public gameAge: number = 0; // Each log event increases it
-  public gameLog: Array<LogMessage> = [];
+  public gameLog: Array<LogMessage> = createGameLog();
   public undoCount: number = 0; // Each undo increases it
   public inputsThisRound = 0;
   public resettable: boolean = false;

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -895,7 +895,7 @@ export class Player implements IPlayer {
       this.pay(payment);
     }
 
-    ColoniesHandler.onCardPlayed(this.game, selectedCard);
+    ColoniesHandler.maybeActivateColonies(this.game, selectedCard);
 
     if (selectedCard.type !== CardType.PROXY) {
       this.lastCardPlayed = selectedCard.name;
@@ -1081,7 +1081,7 @@ export class Player implements IPlayer {
     }
 
     this.triggerOtherCorpEffects(corporationCard);
-    ColoniesHandler.onCardPlayed(this.game, corporationCard);
+    ColoniesHandler.maybeActivateColonies(this.game, corporationCard);
     PathfindersExpansion.onCardPlayed(this, corporationCard);
 
     if (!additionalCorp) {

--- a/src/server/cards/promo/PharmacyUnion.ts
+++ b/src/server/cards/promo/PharmacyUnion.ts
@@ -18,7 +18,7 @@ export class PharmacyUnion extends CorporationCard {
   constructor() {
     super({
       name: CardName.PHARMACY_UNION,
-      startingMegaCredits: 46, // 54 minus 8 for the 2 deseases
+      startingMegaCredits: 46, // 54 minus 8 for the 2 diseases
       resourceType: CardResource.DISEASE,
 
       behavior: {

--- a/src/server/cards/promo/PharmacyUnion.ts
+++ b/src/server/cards/promo/PharmacyUnion.ts
@@ -97,7 +97,7 @@ export class PharmacyUnion extends CorporationCard {
           );
           orOptions.title = 'Choose the order of tag resolution for Pharmacy Union';
           return orOptions;
-        }, -1); // Make it a priority
+        }, Priority.SUPERPOWER); // Make it a priority
         return undefined;
       }
     }
@@ -157,7 +157,7 @@ export class PharmacyUnion extends CorporationCard {
           }),
           new SelectOption('Do nothing', 'Do nothing'),
         );
-      }, -1); // Make it a priority
+      }, Priority.SUPERPOWER); // Make it a priority
     }
   }
 

--- a/src/server/colonies/ColoniesHandler.ts
+++ b/src/server/colonies/ColoniesHandler.ts
@@ -22,7 +22,7 @@ export class ColoniesHandler {
     return game.colonies.filter((colony) => colony.isActive && colony.visitor === undefined);
   }
 
-  public static onCardPlayed(game: IGame, card: ICard) {
+  public static maybeActivateColonies(game: IGame, card: ICard) {
     if (!game.gameOptions.coloniesExtension) return;
     game.colonies.forEach((colony) => {
       if (colony.isActive === false && ColoniesHandler.cardActivatesColony(colony, card)) {

--- a/src/server/turmoil/parties/Greens.ts
+++ b/src/server/turmoil/parties/Greens.ts
@@ -83,7 +83,7 @@ class GreensPolicy03 implements IPolicy {
     const tags = [Tag.ANIMAL, Tag.PLANT, Tag.MICROBE];
     const tagCount = card.tags.filter((tag) => tags.includes(tag)).length;
 
-    player.stock.add(Resource.MEGACREDITS, tagCount * 2);
+    player.defer(() => player.stock.add(Resource.MEGACREDITS, tagCount * 2));
   }
 }
 

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -223,7 +223,7 @@ export function cast<T>(obj: any, klass: ConstructorOf<T> | undefined): T | unde
     return undefined;
   }
   if (!(obj instanceof klass)) {
-    throw new Error(`Not an instance of ${klass.name}: ${obj.constructor.name}`);
+    throw new Error(`Not an instance of ${klass.name}: ${obj?.constructor?.name}`);
   }
   return obj;
 }

--- a/tests/cards/promo/Merger.spec.ts
+++ b/tests/cards/promo/Merger.spec.ts
@@ -137,9 +137,17 @@ describe('Merger', () => {
     expect(player.isCorporation(CardName.SATURN_SYSTEMS)).is.true;
 
     player2.playCard(new VestaShipyard());
-    expect(player.production.megacredits).to.eq(1); // Saturn Sys
+    runAllActions(game);
+
+    expect(player.production.megacredits).to.eq(1); // Saturn Systems
 
     player2.playCard(new Ants());
+
+    runAllActions(game);
+    const orOptions = cast(player2.popWaitingFor(), OrOptions);
+    orOptions.options[1].cb(); // Gain MC.
+    runAllActions(game);
+
     expect(player.megaCredits).to.eq(2); // Splice
   });
 

--- a/tests/turmoil/parties/Greens.spec.ts
+++ b/tests/turmoil/parties/Greens.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {IGame} from '../../../src/server/IGame';
 import {Space} from '../../../src/server/boards/Space';
-import {cast, setRulingParty, addGreenery} from '../../TestingUtils';
+import {cast, setRulingParty, addGreenery, runAllActions} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {GREENS_BONUS_1, GREENS_BONUS_2, GREENS_POLICY_4} from '../../../src/server/turmoil/parties/Greens';
 import {Lichen} from '../../../src/server/cards/base/Lichen';
@@ -58,8 +58,8 @@ describe('Greens', function() {
   it('Ruling policy 3: When you play an animal, plant or microbe tag, gain 2 MC', function() {
     setRulingParty(game, PartyName.GREENS, 'gp03');
 
-    const lichen = new Lichen();
-    player.playCard(lichen);
+    player.playCard(new Lichen());
+    runAllActions(game);
     expect(player.megaCredits).to.eq(2);
   });
 

--- a/tests/utils/log-the-log.ts
+++ b/tests/utils/log-the-log.ts
@@ -1,0 +1,17 @@
+import {setGameLog} from '../../src/server/Game';
+import {LogMessage} from '../../src/common/logs/LogMessage';
+import {formatLogMessage} from '../TestingUtils';
+
+
+class LoggingArray extends Array<LogMessage> {
+  override push(...items: Array<LogMessage>): number {
+    for (const item of items) {
+      console.warn(formatLogMessage(item));
+    }
+    return super.push(...items);
+  }
+}
+
+setGameLog(() => {
+  return new LoggingArray();
+});


### PR DESCRIPTION
The key commit in this set of commits confirms Pharmacy Union effects occur before cards with positive Microbe effects.

The Splice/Pharmacy Union issue was limited specifically to when the played microbe card did NOT store microbe resources. So that part of splice is now deferred, and that ought to do it.

Greens gp03 had a similar behavior and was also adjusted.

Fixes #5674 
Related to #3126