### PR TITLE
Experimental: alawys show expansion icon in upper right of a card.

### DIFF
--- a/src/client/components/card/CardExpansion.vue
+++ b/src/client/components/card/CardExpansion.vue
@@ -6,6 +6,7 @@
 
 import Vue from 'vue';
 import {GameModule} from '@/common/cards/GameModule';
+import {getPreferences} from '@/client/utils/PreferencesManager';
 
 const MODULE_TO_CSS: Omit<Record<GameModule, string>, 'base'> = {
   corpera: 'corporate-icon',
@@ -44,6 +45,8 @@ export default Vue.extend({
       }
       if (this.isCorporation) {
         classes.push('card-corporation-expansion');
+      } else if (getPreferences().experimental_ui) {
+        classes.push('card-standard-expansion');
       }
 
       return classes.join(' ');

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -5,6 +5,12 @@
     right: 33px;
 }
 
+.card-standard-expansion {
+  position: absolute;
+  top: 90px;
+  right: 33px;
+}
+
 .card-container {
     .project-icon:after,
     .preludeCard-icon:after {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/20667bd9-d669-48b3-bafe-996abc17a4e2)

This is experimental for now. When a card has resources, the icon is not visible. So for now, all expansion icons are in the upper right of the card.