### PR TITLE
Update Engineer Award to include Prelude 2 Bespoke Production Cards

### DIFF
--- a/src/server/awards/amazonisPlanitia/Engineer.ts
+++ b/src/server/awards/amazonisPlanitia/Engineer.ts
@@ -36,6 +36,7 @@ export const BESPOKE_PRODUCTION_CARDS: ReadonlyArray<CardName> = [
   CardName.SMALL_OPEN_PIT_MINE,
   // Prelude 2
   CardName.CLOUD_TOURISM,
+  CardName.MICROGRAVITY_NUTRITION,
 ] as const;
 
 // Mapping from [CardName => boolean] indicating whether a card is eligible for Engineer.

--- a/src/server/awards/amazonisPlanitia/Engineer.ts
+++ b/src/server/awards/amazonisPlanitia/Engineer.ts
@@ -34,6 +34,8 @@ export const BESPOKE_PRODUCTION_CARDS: ReadonlyArray<CardName> = [
   CardName.MICROBIOLOGY_PATENTS,
   CardName.OUMUAMUA_TYPE_OBJECT_SURVEY,
   CardName.SMALL_OPEN_PIT_MINE,
+  // Prelude 2
+  CardName.CLOUD_TOURISM,
 ] as const;
 
 // Mapping from [CardName => boolean] indicating whether a card is eligible for Engineer.


### PR DESCRIPTION
Reviewed the list of currently implemented prelude 2 cards and added relevant cards to be included in the engineer award count