### PR TITLE
Fix: draft save behaviour + in memory database saving

### DIFF
--- a/src/server/Draft.ts
+++ b/src/server/Draft.ts
@@ -77,7 +77,7 @@ export abstract class Draft {
     const players = this.game.getPlayers();
 
     // When restoring drafting, it might be that nothing was dealt yet.
-    if (players.every((p) => p.needsToDraft === undefined)) {
+    if (!players.some((p) => p.needsToDraft !== undefined)) {
       this._startDraft();
       return;
     }

--- a/src/server/Draft.ts
+++ b/src/server/Draft.ts
@@ -35,16 +35,8 @@ export abstract class Draft {
   /** Start an entire draft iteration (or draft round). Saves the game, sets all the cards up, and asks players to make their first choice. */
   // TODO(kberg): Create a startDraft() which draws, and a continueDraft() which uses the cards a player is handed.
   public startDraft() {
-    // Fixes #6810. Clearly there's a structural problem elsewhere, but
-    // let's start here.
-    for (const player of this.game.getPlayers()) {
-      player.needsToDraft = true;
-    }
-
     // Might be better to save the game after the draft, given how draft state is
     // restored now.
-    //
-    // (And how now the hack above is included.)
     this.game.save();
     this._startDraft();
   }
@@ -68,6 +60,9 @@ export abstract class Draft {
     for (const [player, draftHand] of zip(this.game.getPlayers(), arrays)) {
       player.draftHand = draftHand;
       player.needsToDraft = true;
+    }
+    this.game.save();
+    for (const player of this.game.getPlayers()) {
       this.askPlayerToDraft(player);
     }
   }
@@ -82,7 +77,7 @@ export abstract class Draft {
     const players = this.game.getPlayers();
 
     // When restoring drafting, it might be that nothing was dealt yet.
-    if (!players.some((p) => p.needsToDraft !== undefined)) {
+    if (players.every((p) => p.needsToDraft === undefined)) {
       this._startDraft();
       return;
     }

--- a/tests/testing/InMemoryDatabase.ts
+++ b/tests/testing/InMemoryDatabase.ts
@@ -5,7 +5,7 @@ import {GameIdLedger, IDatabase} from '../../src/server/database/IDatabase';
 import {GameId, ParticipantId} from '../../src/common/Types';
 
 export class InMemoryDatabase implements IDatabase {
-  public data: Map<GameId, Array<SerializedGame>> = new Map();
+  public data: Map<GameId, Array<SerializedGame | undefined>> = new Map();
   protected completedGames: Map<GameId, Date> = new Map();
 
   initialize(): Promise<unknown> {
@@ -63,8 +63,8 @@ export class InMemoryDatabase implements IDatabase {
     const gameId = game.id;
     const row = this.data.get(gameId) || [];
     this.data.set(gameId, row);
-    while (row.length < game.lastSaveId) {
-      row.push();
+    while (row.length <= game.lastSaveId) {
+      row.push(undefined);
     }
     row[game.lastSaveId] = game.serialize();
     game.lastSaveId++;
@@ -111,9 +111,10 @@ export class InMemoryDatabase implements IDatabase {
   async getParticipants(): Promise<Array<GameIdLedger>> {
     const entries: Array<GameIdLedger> = [];
     this.data.forEach((games, gameId) => {
-      const firstSave = games[0];
-      const participantIds: Array<ParticipantId> = firstSave.players.map((p) => p.id);
-      if (firstSave.spectatorId) participantIds.push(firstSave.spectatorId);
+      // Last save is always defined
+      const lastSave = games[games.length - 1]!;
+      const participantIds: Array<ParticipantId> = lastSave.players.map((p) => p.id);
+      if (lastSave.spectatorId) participantIds.push(lastSave.spectatorId);
       entries.push({gameId, participantIds});
     });
     return entries;


### PR DESCRIPTION
This is where tinkering with #6839 led me. I'm not completely sure of this solution yet so I'm opening it as a draft PR.

This change makes it so that the game is always saved after draft cards are dealt. That should mean that both:
1. Previous "hack" that fixed the behavior of #6810 isn't needed because when the game saves after dealing the cards players needToDraft properties are properly saved.
2. #6839 no longer occurs because partial information that lead to a bad restore isn't saved.

This change additionally fixes a problem with InMemoryDatabase which would freeze on saving a game with a higher lastSaveId because it would use push() which adds no new elements. 