### PR TITLE
Properly discard unchosen preludes and CEOs during initial card selection.

### DIFF
--- a/src/server/Draft.ts
+++ b/src/server/Draft.ts
@@ -6,6 +6,7 @@ import {IProjectCard} from './cards/IProjectCard';
 import {LunaProjectOffice} from './cards/moon/LunaProjectOffice';
 import {SelectCard} from './inputs/SelectCard';
 import {message} from './logs/MessageBuilder';
+import {IPreludeCard} from './cards/prelude/IPreludeCard';
 
 export type DraftType = 'none' | 'initial' | 'prelude' | 'standard';
 
@@ -257,7 +258,8 @@ class PreludeDraft extends Draft {
 
   override endRound() {
     for (const player of this.game.getPlayers()) {
-      player.dealtPreludeCards = player.draftedCards;
+      // TODO(kberg): player.draftedCards is not ideal here.
+      player.dealtPreludeCards = player.draftedCards as Array<IPreludeCard>;
       player.draftedCards = [];
     }
 

--- a/src/server/IPlayer.ts
+++ b/src/server/IPlayer.ts
@@ -7,6 +7,7 @@ import {SpendableCardResource} from '../common/inputs/Spendable';
 import {ICard, IActionCard} from './cards/ICard';
 import {TRSource} from '../common/cards/TRSource';
 import {IProjectCard} from './cards/IProjectCard';
+import {IPreludeCard} from './cards/prelude/IPreludeCard';
 import {PlayerInput} from './PlayerInput';
 import {Resource} from '../common/Resource';
 import {CardResource} from '../common/CardResource';
@@ -97,7 +98,7 @@ export interface IPlayer {
 
   // Cards
   dealtCorporationCards: Array<ICorporationCard>;
-  dealtPreludeCards: Array<IProjectCard>;
+  dealtPreludeCards: Array<IPreludeCard>;
   dealtCeoCards: Array<ICeoCard>;
   dealtProjectCards: Array<IProjectCard>;
   cardsInHand: Array<IProjectCard>;

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1,7 +1,7 @@
 import * as constants from '../common/constants';
 import {PlayerId} from '../common/Types';
 import {MILESTONE_COST, REDS_RULING_POLICY_COST} from '../common/constants';
-import {cardsFromJSON, ceosFromJSON, corporationCardsFromJSON, newCorporationCard} from './createCard';
+import {cardsFromJSON, ceosFromJSON, corporationCardsFromJSON, newCorporationCard, preludesFromJSON} from './createCard';
 import {CardName} from '../common/cards/CardName';
 import {CardType} from '../common/cards/CardType';
 import {Color} from '../common/Color';
@@ -186,7 +186,7 @@ export class Player implements IPlayer {
 
   // Cards
   public dealtCorporationCards: Array<ICorporationCard> = [];
-  public dealtPreludeCards: Array<IProjectCard> = [];
+  public dealtPreludeCards: Array<IPreludeCard> = [];
   public dealtCeoCards: Array<ICeoCard> = [];
   public dealtProjectCards: Array<IProjectCard> = [];
   public cardsInHand: Array<IProjectCard> = [];
@@ -2013,7 +2013,7 @@ export class Player implements IPlayer {
 
     player.pendingInitialActions = corporationCardsFromJSON(d.pendingInitialActions ?? []);
     player.dealtCorporationCards = corporationCardsFromJSON(d.dealtCorporationCards);
-    player.dealtPreludeCards = cardsFromJSON(d.dealtPreludeCards);
+    player.dealtPreludeCards = preludesFromJSON(d.dealtPreludeCards);
     player.dealtCeoCards = ceosFromJSON(d.dealtCeoCards);
     player.dealtProjectCards = cardsFromJSON(d.dealtProjectCards);
     player.cardsInHand = cardsFromJSON(d.cardsInHand);

--- a/src/server/createCard.ts
+++ b/src/server/createCard.ts
@@ -56,31 +56,14 @@ export function newCeo(cardName: CardName): ICeoCard | undefined {
   return _createCard(cardName, ['ceoCards']);
 }
 
-export function preludesFromJSON(cards: Array<CardName>): Array<IPreludeCard> {
+function cfj<T extends ICard>(cards: Array<CardName>, resolver: (c: CardName) => T | undefined): Array<T> {
   if (cards === undefined) {
-    console.warn('missing cards calling preludesFromJSON');
+    console.warn('parameter of array of cards is undefined when calling cardsFromJSON');
     return [];
   }
-  const result: Array<IPreludeCard> = [];
+  const result: Array<T> = [];
   cards.forEach((element: CardName) => {
-    const card = newPrelude(element);
-    if (card !== undefined) {
-      result.push(card);
-    } else {
-      console.warn(`card ${element} not found while loading game.`);
-    }
-  });
-  return result;
-}
-
-export function ceosFromJSON(cards: Array<CardName>): Array<ICeoCard> {
-  if (cards === undefined) {
-    console.warn('missing cards calling ceosFromJSON');
-    return [];
-  }
-  const result: Array<ICeoCard> = [];
-  cards.forEach((element: CardName) => {
-    const card = newCeo(element);
+    const card = resolver(element);
     if (card !== undefined) {
       result.push(card);
     } else {
@@ -91,35 +74,18 @@ export function ceosFromJSON(cards: Array<CardName>): Array<ICeoCard> {
 }
 
 export function cardsFromJSON(cards: Array<CardName>): Array<IProjectCard> {
-  if (cards === undefined) {
-    console.warn('parameter of array of cards is undefined when calling cardsFromJSON');
-    return [];
-  }
-  const result: Array<IProjectCard> = [];
-  cards.forEach((element: CardName) => {
-    const card = newProjectCard(element);
-    if (card !== undefined) {
-      result.push(card);
-    } else {
-      console.warn(`card ${element} not found while loading game.`);
-    }
-  });
-  return result;
+  return cfj(cards, newProjectCard);
 }
 
 export function corporationCardsFromJSON(cards: Array<CardName>): Array<ICorporationCard> {
-  if (cards === undefined) {
-    console.warn('missing cards calling corporationCardsFromJSON');
-    return [];
-  }
-  const result: Array<ICorporationCard> = [];
-  cards.forEach((element: CardName) => {
-    const card = newCorporationCard(element);
-    if (card !== undefined) {
-      result.push(card);
-    } else {
-      console.warn(`corporation ${element} not found while loading game.`);
-    }
-  });
-  return result;
+  return cfj(cards, newCorporationCard);
 }
+
+export function ceosFromJSON(cards: Array<CardName>): Array<ICeoCard> {
+  return cfj(cards, newCeo);
+}
+
+export function preludesFromJSON(cards: Array<CardName>): Array<IPreludeCard> {
+  return cfj(cards, newPrelude);
+}
+

--- a/src/server/inputs/SelectInitialCards.ts
+++ b/src/server/inputs/SelectInitialCards.ts
@@ -12,6 +12,7 @@ import {InputResponse, isSelectInitialCardsResponse} from '../../common/inputs/I
 export class SelectInitialCards extends OptionsInput<undefined> {
   constructor(private player: IPlayer, cb: (corporation: ICorporationCard) => undefined) {
     super('initialCards', '', []);
+    const game = player.game;
     let corporation: ICorporationCard;
     this.title = ' ';
     this.buttonLabel = 'Start';
@@ -29,11 +30,11 @@ export class SelectInitialCards extends OptionsInput<undefined> {
     );
 
     // Give each player Merger in this variant
-    if (player.game.gameOptions.twoCorpsVariant) {
+    if (game.gameOptions.twoCorpsVariant) {
       player.dealtPreludeCards.push(new Merger());
     }
 
-    if (player.game.gameOptions.preludeExtension) {
+    if (game.gameOptions.preludeExtension) {
       this.options.push(
         new SelectCard(titles.SELECT_PRELUDE_TITLE, undefined, player.dealtPreludeCards, {min: 2, max: 2})
           .andThen((preludeCards) => {
@@ -45,16 +46,13 @@ export class SelectInitialCards extends OptionsInput<undefined> {
           }));
     }
 
-    if (player.game.gameOptions.ceoExtension) {
+    if (game.gameOptions.ceoExtension) {
       this.options.push(
         new SelectCard(titles.SELECT_CEO_TITLE, undefined, player.dealtCeoCards, {min: 1, max: 1}).andThen((ceoCards) => {
           if (ceoCards.length !== 1) {
             throw new InputError('Only select 1 CEO');
           }
-          // Push chosen card to hand
           player.ceoCardsInHand.push(ceoCards[0]);
-          // Discard unchosen CEOs
-          player.dealtCeoCards.filter((c) => c !== ceoCards[0]).forEach((c) => player.game.ceoDeck.discard(c));
           return undefined;
         }));
     }
@@ -76,6 +74,7 @@ export class SelectInitialCards extends OptionsInput<undefined> {
 
   private completed(corporation: ICorporationCard) {
     const player = this.player;
+    const game = player.game;
     // Check for negative M€
     const cardCost = corporation.cardCost !== undefined ? corporation.cardCost : player.cardCost;
     if (corporation.name !== CardName.BEGINNER_CORPORATION && player.cardsInHand.length * cardCost > corporation.startingMegaCredits) {
@@ -83,18 +82,30 @@ export class SelectInitialCards extends OptionsInput<undefined> {
       player.preludeCardsInHand = [];
       throw new InputError('Too many cards selected');
     }
-    // discard all unpurchased cards
-    player.dealtProjectCards.forEach((card) => {
-      if (player.cardsInHand.includes(card) === false) {
-        player.game.projectDeck.discard(card);
-      }
-    });
 
-    player.dealtCorporationCards.forEach((card) => {
-      if (card.name !== corporation.name) {
-        player.game.corporationDeck.discard(card);
+    for (const card of player.dealtProjectCards) {
+      if (player.cardsInHand.includes(card) === false) {
+        game.projectDeck.discard(card);
       }
-    });
+    }
+
+    for (const card of player.dealtCorporationCards) {
+      if (card.name !== corporation.name) {
+        game.corporationDeck.discard(card);
+      }
+    }
+
+    for (const card of player.dealtPreludeCards) {
+      if (player.preludeCardsInHand.includes(card) === false) {
+        game.preludeDeck.discard(card);
+      }
+    }
+
+    for (const card of player.dealtCeoCards) {
+      if (player.ceoCardsInHand.includes(card) === false) {
+        game.ceoDeck.discard(card);
+      }
+    }
   }
 
   public toModel(player: IPlayer): SelectInitialCardsModel {

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -295,3 +295,10 @@ export function doWait<T>(player: TestPlayer, klass: new (...args: any[]) => T, 
   f(cast(waitingFor, klass));
   cb?.();
 }
+
+/**
+ * Returns the name of any named item. Ideal for iterating with the Array.map and other iterative functions.
+ */
+export function toName<T>(item: {name: T}): T {
+  return item.name;
+}


### PR DESCRIPTION
This required a little bit of work rewriting some type management, with an unfortunate 'as' added to createCard. We'll get rid of it I'm sure.

Helps with #6813 but doesn't solve it.