### PR TITLE
Adjust Corporation Card Expansion Icon

### DIFF
--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -1,8 +1,8 @@
 @import "./variables.less";
 .card-corporation-expansion {
     position: absolute;
-    top: 75px;
-    right: 33px;
+    top: 38px;
+    right: -11px;
 }
 
 .card-standard-expansion {


### PR DESCRIPTION
The Icon on the Corporation Cards that shows the expansion would occasionally overlap the card. There's no real great place to place this icon, so I tucked it in the top right hand corner, slightly proud of the card to match the card's tag.

### Before: 
<img width="859" alt="image" src="https://github.com/user-attachments/assets/f55b65be-7b19-4417-af7d-72925f0f8335">

### After: 
Regular Cards:
![image](https://github.com/user-attachments/assets/54ca5f4a-0d5f-4324-b213-0b6745b20e67)
Small Cards:
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/5cbb1175-a8b3-44d8-b6a6-98cc1aadcacb">
