### PR TITLE
Use canSave on the UI side to prevent issues with Focused Organization.

### DIFF
--- a/src/client/components/SelectCard.vue
+++ b/src/client/components/SelectCard.vue
@@ -139,6 +139,16 @@ export default Vue.extend({
     getData(): Array<CardName> {
       return Array.isArray(this.$data.cards) ? this.$data.cards.map((card) => card.name) : [this.$data.cards.name];
     },
+    canSave() {
+      const len = this.getData().length;
+      if (len > this.playerinput.min) {
+        return false;
+      }
+      if (len < this.playerinput.max) {
+        return false;
+      }
+      return true;
+    },
     saveData() {
       this.onsave({type: 'card', cards: this.getData()});
     },

--- a/src/client/components/SelectResource.vue
+++ b/src/client/components/SelectResource.vue
@@ -47,6 +47,9 @@ export default Vue.extend({
     AppButton,
   },
   methods: {
+    canSave() {
+      return this.unit !== undefined;
+    },
     saveData() {
       if (this.unit === undefined) {
         return;


### PR DESCRIPTION
Fixes #6944

Another, better solution is to provide a validate step for each playerInput, but that seems to get a little tricky, particularly as there's a difference between PlayerInput and BasePlayerInput, being that one of them is typed. That makes it difficult for a validate step to include type checking.