### PR TITLE
store game diff state from init game

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^8.20.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-vue": "^9.2.0",
+    "fast-json-patch": "^3.1.1",
     "fork-ts-checker-webpack-plugin": "^6.2.13",
     "jsdom": "^22.1.0",
     "less": "^3.10.3",


### PR DESCRIPTION
POC for using significantly less database storage.
Core change: 
1. Saving game with save.id>0 will just store a diff. 
2. loading Game will compare diff of highest save.game with save.game=0 and recreate state.

It should be optimized and tested further. E.g. by also storing diffs for other data or by using iterative diffs or maybe deleting not required states.

Breaking change for old games!
For migrating old games data it would need a additional migration script.