### PR TITLE
Auto select preludes in create game form

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -497,6 +497,7 @@
                   v-bind:moonExpansion="moonExpansion"
                   v-bind:pathfindersExpansion="pathfindersExpansion"
                   v-bind:ceoExtension="ceoExtension"
+                  v-bind:underworldExpansion="underworldExpansion"
                   v-bind:prelude2Expansion="prelude2Expansion"
               ></PreludesFilter>
             </div>

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -496,6 +496,7 @@
                   v-bind:communityCardsOption="communityCardsOption"
                   v-bind:moonExpansion="moonExpansion"
                   v-bind:pathfindersExpansion="pathfindersExpansion"
+                  v-bind:ceoExtension="ceoExtension"
                   v-bind:prelude2Expansion="prelude2Expansion"
               ></PreludesFilter>
             </div>

--- a/src/client/components/create/PreludesFilter.vue
+++ b/src/client/components/create/PreludesFilter.vue
@@ -175,6 +175,7 @@ export default Vue.extend({
       case 'pathfinders': return 'Pathfinders';
       case 'ceo': return 'CEOs';
       case 'underworld': return 'Underworld';
+      case 'prelude2': return 'Prelude 2';
       }
       return '';
     },

--- a/src/client/components/create/PreludesFilter.vue
+++ b/src/client/components/create/PreludesFilter.vue
@@ -66,6 +66,9 @@ export default Vue.extend({
     ceoExtension: {
       type: Boolean,
     },
+    underworldExpansion: {
+      type: Boolean,
+    },
     prelude2Expansion: {
       type: Boolean,
     },
@@ -93,6 +96,7 @@ export default Vue.extend({
         ...this.moonExpansion ? preludeCardNames('moon') : [],
         ...this.pathfindersExpansion ? preludeCardNames('pathfinders') : [],
         ...this.ceoExtension ? preludeCardNames('ceo') : [],
+        ...this.underworldExpansion ? preludeCardNames('underworld') : [],
         ...this.prelude2Expansion ? preludeCardNames('prelude2') : [],
       ],
       GAME_MODULES: GAME_MODULES,
@@ -170,6 +174,7 @@ export default Vue.extend({
       case 'moon': return 'The Moon';
       case 'pathfinders': return 'Pathfinders';
       case 'ceo': return 'CEOs';
+      case 'underworld': return 'Underworld';
       }
       return '';
     },
@@ -202,6 +207,9 @@ export default Vue.extend({
     },
     ceoExtension(enabled) {
       this.watchSelect('ceo', enabled);
+    },
+    underworldExpansion(enabled) {
+      this.watchSelect('underworld', enabled);
     },
     prelude2Expansion(enabled) {
       this.watchSelect('prelude2', enabled);

--- a/src/client/components/create/PreludesFilter.vue
+++ b/src/client/components/create/PreludesFilter.vue
@@ -63,6 +63,9 @@ export default Vue.extend({
     pathfindersExpansion: {
       type: Boolean,
     },
+    ceoExtension: {
+      type: Boolean,
+    },
     prelude2Expansion: {
       type: Boolean,
     },
@@ -89,6 +92,7 @@ export default Vue.extend({
         ...this.communityCardsOption ? preludeCardNames('community') : [],
         ...this.moonExpansion ? preludeCardNames('moon') : [],
         ...this.pathfindersExpansion ? preludeCardNames('pathfinders') : [],
+        ...this.ceoExtension ? preludeCardNames('ceo') : [],
         ...this.prelude2Expansion ? preludeCardNames('prelude2') : [],
       ],
       GAME_MODULES: GAME_MODULES,
@@ -165,6 +169,7 @@ export default Vue.extend({
       case 'community': return 'Community';
       case 'moon': return 'The Moon';
       case 'pathfinders': return 'Pathfinders';
+      case 'ceo': return 'CEOs';
       }
       return '';
     },
@@ -194,6 +199,9 @@ export default Vue.extend({
     },
     pathfindersExpansion(enabled) {
       this.watchSelect('pathfinders', enabled);
+    },
+    ceoExtension(enabled) {
+      this.watchSelect('ceo', enabled);
     },
     prelude2Expansion(enabled) {
       this.watchSelect('prelude2', enabled);


### PR DESCRIPTION
CEO and Underworld preludes now auto-select when those expansions are selected in the Create Game Form. Also, titles for CEOs, Underworld and Prelude 2 are now present in the Custom Preludes list, as they are for all other expansions.