### PR TITLE
Pathfinders aesthetic changes

### DIFF
--- a/src/server/cards/pathfinders/EarlyExpedition.ts
+++ b/src/server/cards/pathfinders/EarlyExpedition.ts
@@ -25,7 +25,10 @@ export class EarlyExpedition extends Card implements IProjectCard {
       metadata: {
         cardNumber: 'Pf18',
         renderData: CardRenderer.builder((b) => {
-          b.minus().production((pb) => pb.energy(1)).production((pb) => pb.megacredits(3)).br;
+          b.production((pb) => {
+            pb.minus().energy(1).br;
+            pb.plus().megacredits(3);
+          });
           b.resource(CardResource.DATA).asterix().city().asterix();
         }),
         description: 'Temperature must be -18 C or lower. Decrease your energy production 1 step and ' +

--- a/src/server/cards/pathfinders/MartianCulture.ts
+++ b/src/server/cards/pathfinders/MartianCulture.ts
@@ -27,7 +27,7 @@ export class MartianCulture extends ActionCard implements IProjectCard {
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 data to ANY card.', (eb) => eb.empty().startAction.resource(CardResource.DATA).asterix());
         }),
-        description: 'Requires any 2 Mars tags in play.  1 VP for every 2 data here.',
+        description: 'Requires ANY 2 Mars tags in play.  1 VP for every 2 data here.',
       },
     });
   }


### PR DESCRIPTION
Changes production box on Early Expedition, so it is visually in line with other city cards; capitalises the word 'any' on Martian Culture