### PR TITLE
Remove translation duplication warnings

### DIFF
--- a/src/tools/make_static_json.ts
+++ b/src/tools/make_static_json.ts
@@ -30,9 +30,9 @@ function getAllTranslations(): {[key: string]: Translation} {
             if (translations[phrase] === undefined) {
               translations[phrase] = {};
             }
-            if (translations[phrase][lang] !== undefined) {
-              console.log(`${lang}: Repeated translation for [${phrase}]`);
-            }
+            // if (translations[phrase][lang] !== undefined) {
+            //   console.log(`${lang}: Repeated translation for [${phrase}]`);
+            // }
             translations[phrase][lang] = json[phrase];
           }
         } catch (e) {


### PR DESCRIPTION
I'm having trouble deploying; Heroku's build container is running out of memory. Perhaps this is the cause of the change.