### PR TITLE
Symbol overlays to support color visualization

### DIFF
--- a/src/client/components/Award.vue
+++ b/src/client/components/Award.vue
@@ -7,14 +7,23 @@
     <div class="ma-name ma-name--awards award-block" :class="nameCss">
       <span v-i18n>{{ award.name }}</span>
       <div v-if="showScores" class="ma-scores player_home_block--milestones-and-awards-scores">
-        <p
-          v-for="score in sortedScores"
-          :key="score.playerColor"
-          class="ma-score"
-          :class="`player_bg_color_${score.playerColor}`"
-          v-text="score.playerScore"
-          data-test="player-score"
-        />
+        <template v-for="score in sortedScores">
+          <p
+            v-if="playerSymbol(score.playerColor).length > 0"
+            :key="score.playerColor"
+            class="ma-score"
+            :class="`player_bg_color_${score.playerColor}`"
+            v-text="playerSymbol(score.playerColor)"
+            data-test="player-score"
+          />
+          <p
+            :key="score.playerColor"
+            class="ma-score"
+            :class="`player_bg_color_${score.playerColor}`"
+            v-text="score.playerScore"
+            data-test="player-score"
+          />
+      </template>
       </div>
     </div>
 
@@ -28,6 +37,8 @@
 import Vue from 'vue';
 import {FundedAwardModel, AwardScore} from '@/common/models/FundedAwardModel';
 import {getAward} from '@/client/MilestoneAwardManifest';
+import {playerSymbol} from '@/client/utils/playerSymbol';
+import {Color} from '@/common/Color';
 
 export default Vue.extend({
   name: 'Award',
@@ -42,6 +53,11 @@ export default Vue.extend({
     },
     showDescription: {
       type: Boolean,
+    },
+  },
+  methods: {
+    playerSymbol(color: Color) {
+      return playerSymbol(color);
     },
   },
   computed: {

--- a/src/client/components/BoardSpace.vue
+++ b/src/client/components/BoardSpace.vue
@@ -11,7 +11,7 @@
       <div class="board-space-coords">({{ space.y }}, {{ space.x }}) ({{ space.id }})</div>
     </template>
     <template v-if="tileView === 'show'">
-      <div :class="'board-cube board-cube--'+space.color" v-if="space.color !== undefined"></div>
+      <div :class="playerColorCss" v-if="space.color !== undefined"></div>
       <template v-if="space.gagarin !== undefined">
         <div v-if="space.gagarin === 0" class='gagarin'></div>
         <div v-else class='gagarin visited'></div>
@@ -40,6 +40,7 @@ import BoardSpaceTile from '@/client/components/board/BoardSpaceTile.vue';
 import UndergroundResources from '@/client/components/board/UndergroundResources.vue';
 import {TileView} from '@/client/components/board/TileView';
 import {SpaceModel} from '@/common/models/SpaceModel';
+import {getPreferences} from '../utils/PreferencesManager';
 
 export default Vue.extend({
   name: 'board-space',
@@ -75,6 +76,13 @@ export default Vue.extend({
   computed: {
     showBonus(): boolean {
       return this.space?.tileType === undefined || this.tileView === 'hide';
+    },
+    playerColorCss(): string {
+      if (this.space?.color === undefined) {
+        return '';
+      }
+      const css = 'board-cube board-cube--' + this.space.color;
+      return getPreferences().symbol_overlay ? css + ' overlay' : css;
     },
   },
 });

--- a/src/client/components/GameHome.vue
+++ b/src/client/components/GameHome.vue
@@ -5,7 +5,7 @@
         <ul>
           <li v-for="(player, index) in (game === undefined ? [] : game.players)" :key="player.color">
             <span class="turn-order" v-i18n>{{getTurnOrder(index)}}</span>
-            <span :class="'color-square ' + getPlayerCubeColorClass(player.color)"></span>
+            <span :class="'color-square ' + getPlayerCubeColorClass(player.color)">{{playerSymbol(player.color)}}</span>
             <span class="player-name"><a :href="getHref(player.id)">{{player.name}}</a></span>
             <AppButton title="copy" size="tiny" @click="copyUrl(player.id)"/>
             <span v-if="isPlayerUrlCopied(player.id)" class="copied-notice"><span v-i18n>Copied!</span></span>
@@ -41,6 +41,7 @@ import {playerColorClass} from '@/common/utils/utils';
 import GameSetupDetail from '@/client/components/GameSetupDetail.vue';
 import {ParticipantId} from '@/common/Types';
 import {Color} from '@/common/Color';
+import {playerSymbol} from '@/client/utils/playerSymbol';
 
 // taken from https://stackoverflow.com/a/46215202/83336
 // The solution to copying to the clipboard in this case is
@@ -115,6 +116,9 @@ export default Vue.extend({
     },
     isPlayerUrlCopied(playerId: string): boolean {
       return playerId === this.urlCopiedPlayerId;
+    },
+    playerSymbol(color: Color) {
+      return playerSymbol(color);
     },
   },
 });

--- a/src/client/components/Milestone.vue
+++ b/src/client/components/Milestone.vue
@@ -6,15 +6,24 @@
     <div class="ma-name--milestones" :class="nameCss">
       <span v-i18n>{{milestone.name}}</span>
       <div v-if="showScores" class="ma-scores player_home_block--milestones-and-awards-scores">
-        <p
-          v-for="score in sortedScores"
-          :key="score.playerColor"
-          class="ma-score"
-          :class="`player_bg_color_${score.playerColor}`"
-          v-text="score.playerScore"
-          data-test="player-score"
-        />
-      </div>
+        <template v-for="score in sortedScores">
+          <p
+            v-if="playerSymbol(score.playerColor).length > 0"
+            :key="score.playerColor"
+            class="ma-score"
+            :class="`player_bg_color_${score.playerColor}`"
+            v-text="playerSymbol(score.playerColor)"
+            data-test="player-score"
+          />
+          <p
+            :key="score.playerColor"
+            class="ma-score"
+            :class="`player_bg_color_${score.playerColor}`"
+            v-text="score.playerScore"
+            data-test="player-score"
+          />
+      </template>
+    </div>
     </div>
 
     <div v-if="showDescription" class="ma-description">
@@ -28,6 +37,9 @@
 import Vue from 'vue';
 import {ClaimedMilestoneModel, MilestoneScore} from '@/common/models/ClaimedMilestoneModel';
 import {getMilestone} from '@/client/MilestoneAwardManifest';
+import {playerSymbol} from '@/client/utils/playerSymbol';
+import {Color} from '@/common/Color';
+
 export default Vue.extend({
   name: 'Milestone',
   props: {
@@ -40,6 +52,11 @@ export default Vue.extend({
     },
     showDescription: {
       type: Boolean,
+    },
+  },
+  methods: {
+    playerSymbol(color: Color): string {
+      return playerSymbol(color);
     },
   },
   computed: {

--- a/src/client/components/PreferencesDialog.vue
+++ b/src/client/components/PreferencesDialog.vue
@@ -62,6 +62,16 @@
           <span class="tooltip tooltip-left" :data-tooltip="$t('Show information that can be helpful\n to players who are still learning the games')">&#9432;</span>
         </label>
       </div>
+
+      <div class="preferences_panel_item">
+        <label class="form-switch">
+          <input type="checkbox" v-on:change="updatePreferences" v-model="prefs.symbol_overlay" data-test="symbol_overlay">
+          <i class="form-icon"></i>
+          <span v-i18n>Symbol Overlay</span>
+          <span class="tooltip tooltip-left" :data-tooltip="$t('Add symbols on top of player colors.')">&#9432;</span>
+        </label>
+      </div>
+
       <div class="preferences_panel_item">
         <label class="form-switch">
           <input type="checkbox" v-on:change="updatePreferences" v-model="prefs.experimental_ui" data-test="experimental_ui">

--- a/src/client/components/overview/PlayerInfo.vue
+++ b/src/client/components/overview/PlayerInfo.vue
@@ -3,7 +3,7 @@
         <div class="player-status-and-res">
         <div class="player-status">
           <div class="player-info-details">
-            <div class="player-info-name" @click="togglePlayerDetails">{{ player.name }}</div>
+            <div class="player-info-name" @click="togglePlayerDetails">{{ playerSymbol + player.name }}</div>
             <span @click="togglePlayerDetails" v-for="(corporationName, index) in getCorporationName()" :key="index" v-i18n>
               <div class="player-info-corp" :title="$t(corporationName)">
                 {{ corporationName }}
@@ -55,6 +55,7 @@ import {CardType} from '@/common/cards/CardType';
 import {getCard} from '@/client/cards/ClientCardManifest';
 import {Phase} from '@/common/Phase';
 import {ActionLabel} from './ActionLabel';
+import {playerSymbol} from '@/client/utils/playerSymbol';
 
 export default Vue.extend({
   name: 'PlayerInfo',
@@ -95,6 +96,9 @@ export default Vue.extend({
   computed: {
     tooltipCss(): string {
       return 'tooltip tooltip-' + (this.isTopBar ? 'bottom' : 'top');
+    },
+    playerSymbol(): string {
+      return playerSymbol(this.player.color, ' ');
     },
     Phase(): typeof Phase {
       return Phase;

--- a/src/client/utils/PreferencesManager.ts
+++ b/src/client/utils/PreferencesManager.ts
@@ -16,8 +16,9 @@ export type Preferences = {
   hide_tile_confirmation: boolean,
   hide_discount_on_cards: boolean,
   hide_animated_sidebar: boolean,
-  experimental_ui: boolean,
   debug_view: boolean,
+  symbol_overlay: boolean,
+  experimental_ui: boolean,
   lang: string,
 }
 
@@ -43,6 +44,9 @@ const defaults: Preferences = {
   hide_tile_confirmation: false,
   hide_discount_on_cards: false,
   hide_animated_sidebar: false,
+
+  symbol_overlay: false,
+
   experimental_ui: false,
   debug_view: false,
 };

--- a/src/client/utils/playerSymbol.ts
+++ b/src/client/utils/playerSymbol.ts
@@ -1,0 +1,22 @@
+import {getPreferences} from '@/client/utils/PreferencesManager';
+import {Color} from '@/common/Color';
+
+export const SYMBOL_FOR_COLOR: Record<Color, string> = {
+  red: '▲',
+  blue: '+',
+  black: '∇',
+  yellow: '∗',
+  green: '◆',
+  purple: '◉',
+  orange: '▢',
+  pink: '◈',
+  bronze: '▦',
+  neutral: '★',
+} as const;
+
+export function playerSymbol(color: Color, optionalSuffix: string = '') {
+  if (getPreferences().symbol_overlay) {
+    return SYMBOL_FOR_COLOR[color] + optionalSuffix;
+  }
+  return '';
+}

--- a/src/styles/board.less
+++ b/src/styles/board.less
@@ -264,7 +264,6 @@
 	filter: drop-shadow(2px 2px 3px black);
 }
 
-// Is this unused?
 .occupied-colony-space {
 	position: absolute;
 	background: rgba(0,0,0,0.7);
@@ -312,6 +311,88 @@
 // TODO(kberg): this only works at the moment because I've made the neutral cube bronze.
 .board-cube--neutral {
 	background: url(./assets/board_icons.png) -142px -91px no-repeat;
+}
+
+.overlay_base {
+  position: absolute;
+  font-size: 15px;
+}
+
+.board-cube--red.overlay::after {
+  .overlay_base;
+  content: "▲";
+  margin-left: 3px;
+  margin-top: -2px;
+}
+
+.board-cube--blue.overlay::after {
+  .overlay_base;
+  content: "+";
+  margin-left: 7px;
+  margin-top: -2px;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.board-cube--black.overlay::after {
+  .overlay_base;
+  content: "∇";
+  margin-left: 5px;
+  margin-top: 1px;
+}
+
+.board-cube--yellow.overlay::after {
+  .overlay_base;
+  content: "∗";
+  margin-left: 4px;
+  margin-top: -1px;
+  font-weight: bold;
+}
+
+.board-cube--green.overlay::after {
+  .overlay_base;
+  content: "◆";
+  margin-left: 5px;
+  margin-top: -2px;
+}
+
+.board-cube--purple.overlay::after {
+  .overlay_base;
+  content: "◉";
+  margin-left: 5px;
+  margin-top: 0px;
+  font-size: 13px;
+}
+
+.board-cube--orange.overlay::after {
+  .overlay_base;
+  content: "▢";
+  margin-left: 5px;
+  margin-top: 0px;
+  font-size: 13px;
+}
+
+.board-cube--pink.overlay::after {
+  .overlay_base;
+  content: "◈";
+  margin-left: 5px;
+  margin-top: -2px;
+}
+
+.board-cube--bronze.overlay::after {
+  .overlay_base;
+  content: "▦";
+  margin-left: 5px;
+  margin-top: 3px;
+  font-size: 9px;
+}
+
+.board-cube--neutral.overlay::after {
+  .overlay_base;
+  font-size: 13px;
+  content: "★";
+  margin-left: 4px;
+  margin-top: 1px;
 }
 
 .board-outer-spaces {


### PR DESCRIPTION
![purple](https://github.com/user-attachments/assets/7a4e021b-68d0-4355-bdf4-72baae61ff9b)
![bronze](https://github.com/user-attachments/assets/cd8e80f2-41e2-44eb-b9d4-9ce389d680fc)
![pink](https://github.com/user-attachments/assets/ab132089-f877-45e4-b497-31116b09d203)
![orange](https://github.com/user-attachments/assets/3f85fcf0-746a-4de0-ba4a-5e89c25dd903)
![green](https://github.com/user-attachments/assets/cc268ac0-aba5-499a-8218-98b844b46760)
![black](https://github.com/user-attachments/assets/74c750e0-3810-444b-b749-4f60762c6a97)
![yellow](https://github.com/user-attachments/assets/aa049524-d978-4cb3-9e83-59539610f704)
![blue](https://github.com/user-attachments/assets/dfbc8889-31bb-4409-881d-a2acd81fba14)
![neutral](https://github.com/user-attachments/assets/6bea7bc5-ebfd-4a0a-bcc9-4bca2bf10ff8)
![red](https://github.com/user-attachments/assets/436bf7c4-b164-4e59-a2fd-7a13fa4f37a1)
![image](https://github.com/user-attachments/assets/6d2556f8-ce1c-4ee3-b80a-20fc6e931be1)
![image](https://github.com/user-attachments/assets/874fb337-9b91-4d2f-880d-48ceb6dafae1)

There's definitely more to cover (colonies, turmoil, player logs, and more.)