### PR TITLE
Add special case for not showing Venera Base space when pathfinders is enabled but turmoil is not

### DIFF
--- a/src/server/boards/BoardBuilder.ts
+++ b/src/server/boards/BoardBuilder.ts
@@ -7,6 +7,7 @@ import {Random} from '../../common/utils/Random';
 import {inplaceShuffle} from '../utils/shuffle';
 import {GameOptions} from '../game/GameOptions';
 import {expansionSpaceColonies} from '../../common/boards/expansionSpaceColonies';
+import {CardName} from '../../common/cards/CardName';
 
 function colonySpace(id: SpaceId): Space {
   return {id, spaceType: SpaceType.COLONY, x: -1, y: -1, bonus: []};
@@ -94,6 +95,15 @@ export class BoardBuilder {
       case 'pathfinders': e = 'pathfindersExpansion'; break;
       case 'venus': e = 'venusNextExtension'; break;
       }
+
+      // Special case for Venera Base when Pathfinders is included, but Turmoil is not
+      if (entry.card === CardName.VENERA_BASE) {
+        if (this.gameOptions.includedCards.includes(entry.card) || (this.gameOptions.pathfindersExpansion && this.gameOptions.turmoilExtension)) {
+          this.spaces.push(colonySpace(entry.name));
+        }
+        continue;
+      }
+
       if (this.gameOptions[e] || this.gameOptions.includedCards.includes(entry.card)) {
         this.spaces.push(colonySpace(entry.name));
       }


### PR DESCRIPTION
Manual tests:
Pathfinders on, Turmoil off: board space not showing
Pathfinders on, Turmoil on: board space showing
Pathfinders off, Turmoil on: board space not showing
Pathfinders off, Turmoil on, Venera Base manually added to deck: board space showing