### PR TITLE
Update ceo_cards.json

### DIFF
--- a/src/locales/hu/ceo_cards.json
+++ b/src/locales/hu/ceo_cards.json
@@ -39,7 +39,7 @@
   "Effect: Ignore placement restrictions for greenery and city tiles on Mars.": "Hatás: Figyelmen kívül hagyhatod a Növényzetlapka és Városlapka lehelyezési szabályait.",
   "Effect: Gain 2 M€ when you place a greenery or city tile on Mars.": "Hatás: Kapsz 2 M€-et, amikor lehelyezel egy Növényzetlapkát vagy Városlapkát.",
   "Greta": "Greta",
-  "When you take an action or play a card that increases your TR THIS GENERATION (max 10 times), gain 4 M€.": "Amikor akciót hajtasz végre, vagy kijátszol egy kártyát, ami növeli a TR-et (legfeljebb 10 alkalommal), kapsz 4 M€-et.",
+  "When you take an action or play a card that increases your TR THIS GENERATION (max 10 times), gain 4 M€.": "Amikor akciót hajtasz végre, vagy kijátszol egy kártyát, ami növeli a TR-ed EBBEN A GENERÁCIÓBAN (legfeljebb 10 alkalommal), kapsz 4 M€-et.",
   "HAL 9000": "HAL 9000",
   "Once per game, decrease each of your productions 1 step to gain 4 of that resource.": "Egyszer a játék során, csökkentsd minden termelésed 1-el, hogy kapj minden standart erőforrásból 4-et!",
   "Ingrid": "Ingrid",


### PR DESCRIPTION
The translation was missing the important information that CEO is only valid in the generation in which it was played.