### PR TITLE
#6613

### DIFF
--- a/src/client/components/card/CardContent.vue
+++ b/src/client/components/card/CardContent.vue
@@ -1,8 +1,10 @@
 <template>
   <div :class="getClasses()">
-    <CardRequirementsComponent v-if="requirements.length > 0" :requirements="requirements"/>
-    <CardRenderData v-if="metadata.renderData" :renderData="metadata.renderData" />
-    <CardDescription v-if="hasDescription" :item="metadata.description" />
+    <CardRequirementsComponent v-if="requirements.length > 0" :requirements="requirements"/>      
+    <CardRenderData v-if="metadata.renderData && metadata.renderData.rows.length > 0" :renderData="{ rows: [metadata.renderData.rows[0]] }" />
+    <CardDescription v-if="isCorporation && hasDescription" :item="metadata.description"/>
+    <CardRenderData v-if="metadata.renderData.rows.length > 1" :renderData="{ rows: metadata.renderData.rows.slice(1) }" />
+    <CardDescription v-if="!isCorporation && hasDescription" :item="metadata.description"/>
     <CardVictoryPoints v-if="metadata.victoryPoints" :victoryPoints="metadata.victoryPoints" />
     <div class="padBottom" v-if="padBottom" style="padding-bottom: 22px;"></div>
   </div>

--- a/src/client/components/card/CardTitle.vue
+++ b/src/client/components/card/CardTitle.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="getMainClasses()">
+  <div :class="[getMainClasses(), { 'is-corporation': isCorporation() }]">
     <div v-if="isPrelude()" class="prelude-label">prelude</div>
     <div v-if="isCorporation()" class="corporation-label">corporation</div>
     <div v-if="isCeo()" class="ceo-label">CEO</div>

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -1015,6 +1015,7 @@
             line-height: 20px;
             font-weight: bold;
             text-align: center;
+            padding-bottom: 0px;
 
             // Adding scrolling for cards with huge description
             &:not(.global-event-card-content) {
@@ -1034,7 +1035,7 @@
             }
 
             .card-corporation-box {
-                position: absolute;
+                position: relative;
                 display: flex;
                 flex-flow: column;
                 justify-content: center;
@@ -1042,8 +1043,6 @@
                 border-radius: 10px;
                 background: linear-gradient(to bottom right, #cccccc, #aaaaaa, #dddddd, #cccccc, #aaaaaa, #cacaca, #aaaaaa, #cccccc);
                 box-shadow: 0 0 0px 1px rgba(0, 0, 0.5);
-                bottom: 8px;
-                left: 8px;
                 width: 216px;
                 padding: 0 4px;
                 /* hide points on hover by poppig the overlay on top of them*/
@@ -2479,6 +2478,11 @@
             overflow: hidden;
             white-space: nowrap;
             height: 27px;
+        /* Conditional height adjustment for corporation cards */
+        &.is-corporation {
+            height: 40px;
+        }
+
             .corporation-label {
                 text-transform: uppercase;
                 float: left;


### PR DESCRIPTION
Problem:
Some corporation cards get their description text hidden.

Result of fix looks like this:
BEFORE
![image](https://github.com/user-attachments/assets/cc208590-b10a-4e50-964c-cb5798894b7e)

AFTER (Now it scrolls)
![image](https://github.com/user-attachments/assets/b3f5eddd-258d-4538-be86-1f008981a9e2)
![image](https://github.com/user-attachments/assets/3a75dbc0-48c3-47c5-85c4-286994b98c4b)

BEFORE
![image](https://github.com/user-attachments/assets/8b27c5ba-988d-4f57-b37e-81efdebb2206)

AFTER (Now it scrolls)
![image](https://github.com/user-attachments/assets/b1562b67-6261-4199-9855-aa488e11e364)
![image](https://github.com/user-attachments/assets/32c9bec9-6a8a-4286-b2b9-cdeea31d9e81)

Here is a rough description of the proposed fix.

1.	Moved card-description between card-rows. I added something to make this only apply to corporation cards, because I didn't want to accidentally mess up anything else. 
2.	Made card-corporation box position: relative. Got rid of the left: 8px and bottom: 8px.
3.	To stop the overlap of content with the card-title, I changed the height of the card-title to 40px. I added something to make this only apply to corporation cards, because I didn't want to accidentally mess up anything else.
4.	To not have the content overflow out of the bottom of the card, added padding-bottom: 0px to .card-content.

I'm relatively new to contributing so if I did anything wrong just let me know and am happy to fix/change.