### PR TITLE
Add HOST .env variable to server.listen(port, host)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,7 +7,8 @@
 # PORT=8080
 
 ## What hostname to use
-# HOST=
+## When this is unspecified, the server listens to all network interfaces
+# HOST=localhost
 
 ## Your TLS certificate path (=> `fullchain.pem` created by certbot)
 # CERT_PATH=

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -99,12 +99,17 @@ async function start() {
   }
   GameLoader.getInstance().maintenance();
 
-  const port = process.env.PORT || 8080;
-  const host = process.env.HOST || '::';
   console.log(`Starting ${raw_settings.head}, built at ${raw_settings.builtAt}`);
-  console.log(`Starting server listening to ${host} on port ${port}`);
 
-  server.listen({'port': port, 'host': host});
+  const port = process.env.PORT || 8080;
+  const host = process.env.HOST;
+  if (host) {
+    console.log(`Starting server listening to ${host} on port ${port}`);
+  } else {
+    console.log(`Starting server on port ${port}`);
+  }
+
+  server.listen({port: port, host: host});
 
   if (!process.env.SERVER_ID) {
     console.log(`The secret serverId for this server is ${ansi.style.bold}${serverId}${ansi.style.reset}.`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -104,7 +104,7 @@ async function start() {
   console.log(`Starting ${raw_settings.head}, built at ${raw_settings.builtAt}`);
   console.log(`Starting server listening to ${host} on port ${port}`);
 
-  server.listen({"port": port, "host": host});
+  server.listen({'port': port, 'host': host});
 
   if (!process.env.SERVER_ID) {
     console.log(`The secret serverId for this server is ${ansi.style.bold}${serverId}${ansi.style.reset}.`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -100,10 +100,11 @@ async function start() {
   GameLoader.getInstance().maintenance();
 
   const port = process.env.PORT || 8080;
+  const host = process.env.HOST || '::';
   console.log(`Starting ${raw_settings.head}, built at ${raw_settings.builtAt}`);
-  console.log(`Starting server on port ${port}`);
+  console.log(`Starting server listening to ${host} on port ${port}`);
 
-  server.listen(port);
+  server.listen({"port": port, "host": host});
 
   if (!process.env.SERVER_ID) {
     console.log(`The secret serverId for this server is ${ansi.style.bold}${serverId}${ansi.style.reset}.`);


### PR DESCRIPTION
Issue #7376 

- Maintain existing behavior by using '::' as default host to listen to all IPv4 and IPv6 addresses
  - As far as I understand, on the vast majority of systems '::' also encompasses '0.0.0.0', but this is not 100% given. On systems where that is not the case, the existing behavior with the unspecified host in `server.listen(port)` would _not_ be preserved.
- Add localhost as suggested HOST to .env.sample
  - However, this is not the default value, so this could be confusing? Would it be better to leave it empty?
- `server.listen(port)` with `port = process.env.PORT` is also present in [analyze_ma.ts](https://github.com/terraforming-mars/terraforming-mars/blob/main/src/server/tools/analyze_ma.ts#L40)
  - I'm not sure what analyze_ma.ts is used for, but it could be that the HOST should also be applied there analogously