### PR TITLE
Make sure every corporation card includes `implements ICorporationCard`

### DIFF
--- a/src/server/cards/colonies/Aridor.ts
+++ b/src/server/cards/colonies/Aridor.ts
@@ -10,7 +10,7 @@ import {ColoniesHandler} from '../../colonies/ColoniesHandler';
 import {SerializedCard} from '../../SerializedCard';
 import {ICard} from '../ICard';
 
-export class Aridor extends CorporationCard {
+export class Aridor extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ARIDOR,

--- a/src/server/cards/colonies/Arklight.ts
+++ b/src/server/cards/colonies/Arklight.ts
@@ -7,7 +7,7 @@ import {ICard} from '../ICard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Arklight extends CorporationCard {
+export class Arklight extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ARKLIGHT,

--- a/src/server/cards/colonies/Polyphemos.ts
+++ b/src/server/cards/colonies/Polyphemos.ts
@@ -2,8 +2,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Polyphemos extends CorporationCard {
+export class Polyphemos extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.POLYPHEMOS,

--- a/src/server/cards/colonies/Poseidon.ts
+++ b/src/server/cards/colonies/Poseidon.ts
@@ -4,8 +4,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {all} from '../Options';
 import {IPlayer} from '../../IPlayer';
 import {Resource} from '../../../common/Resource';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Poseidon extends CorporationCard {
+export class Poseidon extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.POSEIDON,

--- a/src/server/cards/community/AgricolaInc.ts
+++ b/src/server/cards/community/AgricolaInc.ts
@@ -6,8 +6,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 import {inplaceRemove} from '../../../common/utils/utils';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class AgricolaInc extends CorporationCard {
+export class AgricolaInc extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.AGRICOLA_INC,

--- a/src/server/cards/community/Athena.ts
+++ b/src/server/cards/community/Athena.ts
@@ -6,8 +6,9 @@ import {PlaceHazardTile} from '../../deferredActions/PlaceHazardTile';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {TileType} from '../../../common/TileType';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Athena extends CorporationCard {
+export class Athena extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ATHENA,

--- a/src/server/cards/community/CuriosityII.ts
+++ b/src/server/cards/community/CuriosityII.ts
@@ -13,8 +13,9 @@ import {SpaceType} from '../../../common/boards/SpaceType';
 import {SpaceBonus} from '../../../common/boards/SpaceBonus';
 import {Phase} from '../../../common/Phase';
 import {TITLES} from '../../inputs/titles';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class CuriosityII extends CorporationCard {
+export class CuriosityII extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.CURIOSITY_II,

--- a/src/server/cards/community/Eris.ts
+++ b/src/server/cards/community/Eris.ts
@@ -13,6 +13,7 @@ import {Size} from '../../../common/cards/render/Size';
 import {TileType, tileTypeToString} from '../../../common/TileType';
 import {LogHelper} from '../../LogHelper';
 import {AresHandler} from '../../ares/AresHandler';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
 const ARES_CARDS = [
   CardName.BIOENGINEERING_ENCLOSURE,
@@ -43,7 +44,7 @@ const ARES_CARDS = [
   CardName.SOLAR_FARM,
 ];
 
-export class Eris extends CorporationCard {
+export class Eris extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ERIS,

--- a/src/server/cards/community/Incite.ts
+++ b/src/server/cards/community/Incite.ts
@@ -3,8 +3,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Incite extends CorporationCard {
+export class Incite extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.INCITE,

--- a/src/server/cards/community/JunkVentures.ts
+++ b/src/server/cards/community/JunkVentures.ts
@@ -4,8 +4,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {CardRenderer} from '../render/CardRenderer';
 import {ChooseCards} from '../../deferredActions/ChooseCards';
 import {IPlayer} from '../../IPlayer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class JunkVentures extends CorporationCard {
+export class JunkVentures extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.JUNK_VENTURES,

--- a/src/server/cards/community/Midas.ts
+++ b/src/server/cards/community/Midas.ts
@@ -2,8 +2,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Midas extends CorporationCard {
+export class Midas extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MIDAS,

--- a/src/server/cards/community/Playwrights.ts
+++ b/src/server/cards/community/Playwrights.ts
@@ -12,8 +12,9 @@ import {MoonExpansion} from '../../moon/MoonExpansion';
 import {all} from '../Options';
 import {SpecialDesignProxy} from './SpecialDesignProxy';
 import {inplaceRemove} from '../../../common/utils/utils';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Playwrights extends CorporationCard {
+export class Playwrights extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.PLAYWRIGHTS,

--- a/src/server/cards/community/ProjectWorkshop.ts
+++ b/src/server/cards/community/ProjectWorkshop.ts
@@ -17,8 +17,9 @@ import {PartyName} from '../../../common/turmoil/PartyName';
 import {REDS_RULING_POLICY_COST} from '../../../common/constants';
 import {SelectPaymentDeferred} from '../../deferredActions/SelectPaymentDeferred';
 import {TITLES} from '../../inputs/titles';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class ProjectWorkshop extends CorporationCard {
+export class ProjectWorkshop extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.PROJECT_WORKSHOP,

--- a/src/server/cards/community/UnitedNationsMissionOne.ts
+++ b/src/server/cards/community/UnitedNationsMissionOne.ts
@@ -6,8 +6,9 @@ import {IPlayer} from '../../IPlayer';
 import {all} from '../Options';
 import {Phase} from '../../../common/Phase';
 import {Resource} from '../../../common/Resource';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class UnitedNationsMissionOne extends CorporationCard {
+export class UnitedNationsMissionOne extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.UNITED_NATIONS_MISSION_ONE,

--- a/src/server/cards/corporation/BeginnerCorporation.ts
+++ b/src/server/cards/corporation/BeginnerCorporation.ts
@@ -2,8 +2,9 @@ import {CorporationCard} from './CorporationCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
+import {ICorporationCard} from './ICorporationCard';
 
-export class BeginnerCorporation extends CorporationCard {
+export class BeginnerCorporation extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.BEGINNER_CORPORATION,

--- a/src/server/cards/corporation/CrediCor.ts
+++ b/src/server/cards/corporation/CrediCor.ts
@@ -5,8 +5,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {IStandardProjectCard} from '../IStandardProjectCard';
 import {Resource} from '../../../common/Resource';
+import {ICorporationCard} from './ICorporationCard';
 
-export class CrediCor extends CorporationCard {
+export class CrediCor extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.CREDICOR,

--- a/src/server/cards/corporation/EcoLine.ts
+++ b/src/server/cards/corporation/EcoLine.ts
@@ -3,8 +3,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
+import {ICorporationCard} from './ICorporationCard';
 
-export class EcoLine extends CorporationCard {
+export class EcoLine extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ECOLINE,

--- a/src/server/cards/corporation/Helion.ts
+++ b/src/server/cards/corporation/Helion.ts
@@ -3,8 +3,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {IPlayer} from '../../IPlayer';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from './ICorporationCard';
 
-export class Helion extends CorporationCard {
+export class Helion extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.HELION,

--- a/src/server/cards/corporation/InterplanetaryCinematics.ts
+++ b/src/server/cards/corporation/InterplanetaryCinematics.ts
@@ -7,8 +7,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
 import {Resource} from '../../../common/Resource';
+import {ICorporationCard} from './ICorporationCard';
 
-export class InterplanetaryCinematics extends CorporationCard {
+export class InterplanetaryCinematics extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.INTERPLANETARY_CINEMATICS,

--- a/src/server/cards/corporation/Inventrix.ts
+++ b/src/server/cards/corporation/Inventrix.ts
@@ -2,8 +2,9 @@ import {CorporationCard} from './CorporationCard';
 import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from './ICorporationCard';
 
-export class Inventrix extends CorporationCard {
+export class Inventrix extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.INVENTRIX,

--- a/src/server/cards/corporation/MiningGuild.ts
+++ b/src/server/cards/corporation/MiningGuild.ts
@@ -11,8 +11,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {BoardType} from '../../boards/BoardType';
 import {digit} from '../Options';
 import {AresHandler} from '../../ares/AresHandler';
+import {ICorporationCard} from './ICorporationCard';
 
-export class MiningGuild extends CorporationCard {
+export class MiningGuild extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MINING_GUILD,

--- a/src/server/cards/corporation/PhoboLog.ts
+++ b/src/server/cards/corporation/PhoboLog.ts
@@ -4,8 +4,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {digit} from '../Options';
+import {ICorporationCard} from './ICorporationCard';
 
-export class PhoboLog extends CorporationCard {
+export class PhoboLog extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.PHOBOLOG,

--- a/src/server/cards/corporation/SaturnSystems.ts
+++ b/src/server/cards/corporation/SaturnSystems.ts
@@ -8,7 +8,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {all} from '../Options';
 import {ICard} from '../ICard';
 
-export class SaturnSystems extends CorporationCard {
+export class SaturnSystems extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.SATURN_SYSTEMS,

--- a/src/server/cards/corporation/Teractor.ts
+++ b/src/server/cards/corporation/Teractor.ts
@@ -2,8 +2,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {CorporationCard} from './CorporationCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from './ICorporationCard';
 
-export class Teractor extends CorporationCard {
+export class Teractor extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.TERACTOR,

--- a/src/server/cards/corporation/TharsisRepublic.ts
+++ b/src/server/cards/corporation/TharsisRepublic.ts
@@ -12,8 +12,9 @@ import {Board} from '../../boards/Board';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {all} from '../Options';
+import {ICorporationCard} from './ICorporationCard';
 
-export class TharsisRepublic extends CorporationCard {
+export class TharsisRepublic extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.THARSIS_REPUBLIC,

--- a/src/server/cards/corporation/Thorgate.ts
+++ b/src/server/cards/corporation/Thorgate.ts
@@ -4,8 +4,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {IPlayer} from '../../IPlayer';
 import {IStandardProjectCard} from '../IStandardProjectCard';
+import {ICorporationCard} from './ICorporationCard';
 
-export class Thorgate extends CorporationCard {
+export class Thorgate extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.THORGATE,

--- a/src/server/cards/moon/CrescentResearchAssociation.ts
+++ b/src/server/cards/moon/CrescentResearchAssociation.ts
@@ -4,8 +4,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {IProjectCard} from '../IProjectCard';
 import {CardRenderer} from '../render/CardRenderer';
 import {Tag} from '../../../common/cards/Tag';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class CrescentResearchAssociation extends CorporationCard {
+export class CrescentResearchAssociation extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.CRESCENT_RESEARCH_ASSOCIATION,

--- a/src/server/cards/moon/IntragenSanctuaryHeadquarters.ts
+++ b/src/server/cards/moon/IntragenSanctuaryHeadquarters.ts
@@ -9,7 +9,7 @@ import {all} from '../Options';
 import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 import {ICard} from '../ICard';
 
-export class IntragenSanctuaryHeadquarters extends CorporationCard {
+export class IntragenSanctuaryHeadquarters extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.INTRAGEN_SANCTUARY_HEADQUARTERS,

--- a/src/server/cards/moon/LunaFirstIncorporated.ts
+++ b/src/server/cards/moon/LunaFirstIncorporated.ts
@@ -6,8 +6,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {MoonExpansion} from '../../moon/MoonExpansion';
 import {Size} from '../../../common/cards/render/Size';
 import {all} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class LunaFirstIncorporated extends CorporationCard {
+export class LunaFirstIncorporated extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.LUNA_FIRST_INCORPORATED,

--- a/src/server/cards/moon/LunaTradeFederation.ts
+++ b/src/server/cards/moon/LunaTradeFederation.ts
@@ -8,10 +8,11 @@ import {MoonExpansion} from '../../moon/MoonExpansion';
 import {Space} from '../../boards/Space';
 import {Resource} from '../../../common/Resource';
 import {Size} from '../../../common/cards/render/Size';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 // import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 // import {all, multiplier} from '../Options';
 
-export class LunaTradeFederation extends CorporationCard {
+export class LunaTradeFederation extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.LUNA_TRADE_FEDERATION,

--- a/src/server/cards/moon/NanotechIndustries.ts
+++ b/src/server/cards/moon/NanotechIndustries.ts
@@ -7,8 +7,9 @@ import {CardResource} from '../../../common/CardResource';
 import {IPlayer} from '../../IPlayer';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
 import {MoonCards} from '../../moon/MoonCards';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class NanotechIndustries extends CorporationCard implements IActionCard {
+export class NanotechIndustries extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.NANOTECH_INDUSTRIES,

--- a/src/server/cards/moon/TempestConsultancy.ts
+++ b/src/server/cards/moon/TempestConsultancy.ts
@@ -7,8 +7,9 @@ import {Size} from '../../../common/cards/render/Size';
 import {Tag} from '../../../common/cards/Tag';
 import {Turmoil} from '../../turmoil/Turmoil';
 import {digit} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class TempestConsultancy extends CorporationCard {
+export class TempestConsultancy extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.TEMPEST_CONSULTANCY,

--- a/src/server/cards/moon/TheArchaicFoundationInstitute.ts
+++ b/src/server/cards/moon/TheArchaicFoundationInstitute.ts
@@ -9,8 +9,9 @@ import {ICard} from '../ICard';
 import {Size} from '../../../common/cards/render/Size';
 import {digit} from '../Options';
 import {LogHelper} from '../../LogHelper';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class TheArchaicFoundationInstitute extends CorporationCard {
+export class TheArchaicFoundationInstitute extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.THE_ARCHAIC_FOUNDATION_INSTITUTE,

--- a/src/server/cards/moon/TheDarksideofTheMoonSyndicate.ts
+++ b/src/server/cards/moon/TheDarksideofTheMoonSyndicate.ts
@@ -15,8 +15,9 @@ import {Phase} from '../../../common/Phase';
 import {all} from '../Options';
 import {Payment} from '../../../common/inputs/Payment';
 import {LogHelper} from '../../LogHelper';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class TheDarksideofTheMoonSyndicate extends CorporationCard {
+export class TheDarksideofTheMoonSyndicate extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.THE_DARKSIDE_OF_THE_MOON_SYNDICATE,

--- a/src/server/cards/moon/TheGrandLunaCapitalGroup.ts
+++ b/src/server/cards/moon/TheGrandLunaCapitalGroup.ts
@@ -12,8 +12,9 @@ import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictory
 import {Size} from '../../../common/cards/render/Size';
 import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 import {all} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class TheGrandLunaCapitalGroup extends CorporationCard {
+export class TheGrandLunaCapitalGroup extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.THE_GRAND_LUNA_CAPITAL_GROUP,

--- a/src/server/cards/pathfinders/AdhaiHighOrbitConstructions.ts
+++ b/src/server/cards/pathfinders/AdhaiHighOrbitConstructions.ts
@@ -9,8 +9,9 @@ import {isPlanetaryTag} from '../../pathfinders/PathfindersData';
 import {Size} from '../../../common/cards/render/Size';
 import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 import {IStandardProjectCard} from '../IStandardProjectCard';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class AdhaiHighOrbitConstructions extends CorporationCard {
+export class AdhaiHighOrbitConstructions extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS,

--- a/src/server/cards/pathfinders/Ambient.ts
+++ b/src/server/cards/pathfinders/Ambient.ts
@@ -11,7 +11,7 @@ import {MAX_TEMPERATURE} from '../../../common/constants';
 import {Size} from '../../../common/cards/render/Size';
 import {Units} from '../../../common/Units';
 
-export class Ambient extends CorporationCard {
+export class Ambient extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.AMBIENT,

--- a/src/server/cards/pathfinders/Aurorai.ts
+++ b/src/server/cards/pathfinders/Aurorai.ts
@@ -6,8 +6,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {CardResource} from '../../../common/CardResource';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
 import {Priority} from '../../deferredActions/Priority';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Aurorai extends CorporationCard {
+export class Aurorai extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.AURORAI,

--- a/src/server/cards/pathfinders/Chimera.ts
+++ b/src/server/cards/pathfinders/Chimera.ts
@@ -2,8 +2,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Chimera extends CorporationCard {
+export class Chimera extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.CHIMERA,

--- a/src/server/cards/pathfinders/CollegiumCopernicus.ts
+++ b/src/server/cards/pathfinders/CollegiumCopernicus.ts
@@ -16,7 +16,7 @@ import {message} from '../../logs/MessageBuilder';
 function tradeCost(player: IPlayer) {
   return Math.max(0, 3 - player.colonies.tradeDiscount);
 }
-export class CollegiumCopernicus extends CorporationCard implements IActionCard {
+export class CollegiumCopernicus extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.COLLEGIUM_COPERNICUS,

--- a/src/server/cards/pathfinders/GagarinMobileBase.ts
+++ b/src/server/cards/pathfinders/GagarinMobileBase.ts
@@ -10,8 +10,9 @@ import {IActionCard} from '../ICard';
 import {BoardType} from '../../boards/BoardType';
 import {Board} from '../../boards/Board';
 import {message} from '../../logs/MessageBuilder';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class GagarinMobileBase extends CorporationCard implements IActionCard {
+export class GagarinMobileBase extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.GAGARIN_MOBILE_BASE,

--- a/src/server/cards/pathfinders/HabitatMarte.ts
+++ b/src/server/cards/pathfinders/HabitatMarte.ts
@@ -2,8 +2,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class HabitatMarte extends CorporationCard {
+export class HabitatMarte extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.HABITAT_MARTE,

--- a/src/server/cards/pathfinders/MarsDirect.ts
+++ b/src/server/cards/pathfinders/MarsDirect.ts
@@ -4,11 +4,12 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {IProjectCard} from '../IProjectCard';
 import {CardRenderer} from '../render/CardRenderer';
 import {Tag} from '../../../common/cards/Tag';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
 // TODO(kberg): This card is actually different: it uses resources to track on this card, which
 // means this result can be changed by cards like CEO's Favorite Project.
 // It also means cards with a wild tag may impact this.
-export class MarsDirect extends CorporationCard {
+export class MarsDirect extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MARS_DIRECT,

--- a/src/server/cards/pathfinders/MarsFrontierAlliance.ts
+++ b/src/server/cards/pathfinders/MarsFrontierAlliance.ts
@@ -5,8 +5,9 @@ import {IPlayer} from '../../../server/IPlayer';
 import {PlayerInput} from '../../../server/PlayerInput';
 import {Turmoil} from '../../turmoil/Turmoil';
 import {ChooseAlliedParty} from '../../../server/deferredActions/ChooseAlliedParty';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class MarsFrontierAlliance extends CorporationCard {
+export class MarsFrontierAlliance extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MARS_FRONTIER_ALLIANCE,

--- a/src/server/cards/pathfinders/MarsMaths.ts
+++ b/src/server/cards/pathfinders/MarsMaths.ts
@@ -3,8 +3,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {IPlayer} from '../../IPlayer';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class MarsMaths extends CorporationCard {
+export class MarsMaths extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MARS_MATHS,

--- a/src/server/cards/pathfinders/MartianInsuranceGroup.ts
+++ b/src/server/cards/pathfinders/MartianInsuranceGroup.ts
@@ -6,8 +6,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardType} from '../../../common/cards/CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {IProjectCard} from '../IProjectCard';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class MartianInsuranceGroup extends CorporationCard {
+export class MartianInsuranceGroup extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MARTIAN_INSURANCE_GROUP,

--- a/src/server/cards/pathfinders/MindSetMars.ts
+++ b/src/server/cards/pathfinders/MindSetMars.ts
@@ -12,8 +12,9 @@ import {SendDelegateToArea} from '../../deferredActions/SendDelegateToArea';
 import {Turmoil} from '../../turmoil/Turmoil';
 import {PlaceCityTile} from '../../deferredActions/PlaceCityTile';
 import {Size} from '../../../common/cards/render/Size';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class MindSetMars extends CorporationCard {
+export class MindSetMars extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MIND_SET_MARS,

--- a/src/server/cards/pathfinders/Odyssey.ts
+++ b/src/server/cards/pathfinders/Odyssey.ts
@@ -7,8 +7,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {IActionCard} from '../ICard';
 import {Size} from '../../../common/cards/render/Size';
 import {SelectProjectCardToPlay} from '../../inputs/SelectProjectCardToPlay';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Odyssey extends CorporationCard implements IActionCard {
+export class Odyssey extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.ODYSSEY,

--- a/src/server/cards/pathfinders/Polaris.ts
+++ b/src/server/cards/pathfinders/Polaris.ts
@@ -11,8 +11,9 @@ import {Priority} from '../../deferredActions/Priority';
 import {Size} from '../../../common/cards/render/Size';
 import {Board} from '../../boards/Board';
 import {Phase} from '../../../common/Phase';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Polaris extends CorporationCard {
+export class Polaris extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.POLARIS,

--- a/src/server/cards/pathfinders/Ringcom.ts
+++ b/src/server/cards/pathfinders/Ringcom.ts
@@ -8,7 +8,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {all} from '../Options';
 import {ICard} from '../ICard';
 
-export class Ringcom extends CorporationCard {
+export class Ringcom extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.RINGCOM,

--- a/src/server/cards/pathfinders/RobinHaulings.ts
+++ b/src/server/cards/pathfinders/RobinHaulings.ts
@@ -10,8 +10,9 @@ import {IProjectCard} from '../IProjectCard';
 import {MAX_OXYGEN_LEVEL, MAX_VENUS_SCALE} from '../../../common/constants';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class RobinHaulings extends CorporationCard {
+export class RobinHaulings extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ROBIN_HAULINGS,

--- a/src/server/cards/pathfinders/SolBank.ts
+++ b/src/server/cards/pathfinders/SolBank.ts
@@ -3,8 +3,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardResource} from '../../../common/CardResource';
 import {IPlayer} from '../../IPlayer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class SolBank extends CorporationCard {
+export class SolBank extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.SOLBANK,

--- a/src/server/cards/pathfinders/SoylentSeedlingSystems.ts
+++ b/src/server/cards/pathfinders/SoylentSeedlingSystems.ts
@@ -6,8 +6,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {CardResource} from '../../../common/CardResource';
 import {Space} from '../../boards/Space';
 import {Board} from '../../boards/Board';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class SoylentSeedlingSystems extends CorporationCard {
+export class SoylentSeedlingSystems extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.SOYLENT_SEEDLING_SYSTEMS,

--- a/src/server/cards/pathfinders/Steelaris.ts
+++ b/src/server/cards/pathfinders/Steelaris.ts
@@ -13,8 +13,9 @@ import {Size} from '../../../common/cards/render/Size';
 import {BoardType} from '../../boards/BoardType';
 import {SpaceType} from '../../../common/boards/SpaceType';
 import {Units} from '../../../common/Units';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Steelaris extends CorporationCard {
+export class Steelaris extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.STEELARIS,

--- a/src/server/cards/prelude/CheungShingMARS.ts
+++ b/src/server/cards/prelude/CheungShingMARS.ts
@@ -2,8 +2,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {CorporationCard} from '../corporation/CorporationCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class CheungShingMARS extends CorporationCard {
+export class CheungShingMARS extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.CHEUNG_SHING_MARS,

--- a/src/server/cards/prelude/PointLuna.ts
+++ b/src/server/cards/prelude/PointLuna.ts
@@ -6,7 +6,7 @@ import {ICard} from '../ICard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class PointLuna extends CorporationCard {
+export class PointLuna extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.POINT_LUNA,

--- a/src/server/cards/prelude/RobinsonIndustries.ts
+++ b/src/server/cards/prelude/RobinsonIndustries.ts
@@ -8,8 +8,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {SelectPaymentDeferred} from '../../deferredActions/SelectPaymentDeferred';
 import {TITLES} from '../../inputs/titles';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class RobinsonIndustries extends CorporationCard implements IActionCard {
+export class RobinsonIndustries extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.ROBINSON_INDUSTRIES,

--- a/src/server/cards/prelude/ValleyTrust.ts
+++ b/src/server/cards/prelude/ValleyTrust.ts
@@ -5,8 +5,9 @@ import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {PreludesExpansion} from '../../preludes/PreludesExpansion';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class ValleyTrust extends CorporationCard {
+export class ValleyTrust extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.VALLEY_TRUST,

--- a/src/server/cards/prelude/Vitor.ts
+++ b/src/server/cards/prelude/Vitor.ts
@@ -9,8 +9,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Resource} from '../../../common/Resource';
 import {message} from '../../logs/MessageBuilder';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Vitor extends CorporationCard {
+export class Vitor extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.VITOR,

--- a/src/server/cards/prelude2/Ecotec.ts
+++ b/src/server/cards/prelude2/Ecotec.ts
@@ -9,8 +9,9 @@ import {Resource} from '../../../common/Resource';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
 import {SelectCard} from '../../inputs/SelectCard';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Ecotec extends CorporationCard {
+export class Ecotec extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ECOTEC,

--- a/src/server/cards/prelude2/NirgalEnterprises.ts
+++ b/src/server/cards/prelude2/NirgalEnterprises.ts
@@ -2,8 +2,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Tag} from '../../../common/cards/Tag';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class NirgalEnterprises extends CorporationCard {
+export class NirgalEnterprises extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.NIRGAL_ENTERPRISES,

--- a/src/server/cards/prelude2/PalladinShipping.ts
+++ b/src/server/cards/prelude2/PalladinShipping.ts
@@ -10,8 +10,9 @@ import {Resource} from '../../../common/Resource';
 import {IActionCard} from '../ICard';
 import {Behavior} from '../../behavior/Behavior';
 import {getBehaviorExecutor} from '../../behavior/BehaviorExecutor';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class PalladinShipping extends CorporationCard implements IActionCard {
+export class PalladinShipping extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.PALLADIN_SHIPPING,

--- a/src/server/cards/prelude2/SagittaFrontierServices.ts
+++ b/src/server/cards/prelude2/SagittaFrontierServices.ts
@@ -10,7 +10,7 @@ import {GainResources} from '../../deferredActions/GainResources';
 import {Resource} from '../../../common/Resource';
 import {Tag} from '../../../common/cards/Tag';
 
-export class SagittaFrontierServices extends CorporationCard {
+export class SagittaFrontierServices extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.SAGITTA_FRONTIER_SERVICES,

--- a/src/server/cards/promo/ArcadianCommunities.ts
+++ b/src/server/cards/promo/ArcadianCommunities.ts
@@ -7,8 +7,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {digit} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class ArcadianCommunities extends CorporationCard implements IActionCard {
+export class ArcadianCommunities extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.ARCADIAN_COMMUNITIES,

--- a/src/server/cards/promo/Astrodrill.ts
+++ b/src/server/cards/promo/Astrodrill.ts
@@ -12,8 +12,9 @@ import {Resource} from '../../../common/Resource';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {digit} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Astrodrill extends CorporationCard implements IActionCard {
+export class Astrodrill extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.ASTRODRILL,

--- a/src/server/cards/promo/Factorum.ts
+++ b/src/server/cards/promo/Factorum.ts
@@ -10,8 +10,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {SelectPaymentDeferred} from '../../deferredActions/SelectPaymentDeferred';
 import {TITLES} from '../../inputs/titles';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Factorum extends CorporationCard implements IActionCard {
+export class Factorum extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.FACTORUM,

--- a/src/server/cards/promo/KuiperCooperative.ts
+++ b/src/server/cards/promo/KuiperCooperative.ts
@@ -6,8 +6,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {CardResource} from '../../../common/CardResource';
 import {IActionCard} from '../ICard';
 import {Size} from '../../../common/cards/render/Size';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class KuiperCooperative extends CorporationCard implements IActionCard {
+export class KuiperCooperative extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.KUIPER_COOPERATIVE,

--- a/src/server/cards/promo/MonsInsurance.ts
+++ b/src/server/cards/promo/MonsInsurance.ts
@@ -5,8 +5,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {all} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class MonsInsurance extends CorporationCard {
+export class MonsInsurance extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MONS_INSURANCE,

--- a/src/server/cards/promo/PharmacyUnion.ts
+++ b/src/server/cards/promo/PharmacyUnion.ts
@@ -14,7 +14,7 @@ import {Resource} from '../../../common/Resource';
 import {all, digit} from '../Options';
 import {SerializedCard} from '../../SerializedCard';
 
-export class PharmacyUnion extends CorporationCard {
+export class PharmacyUnion extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.PHARMACY_UNION,

--- a/src/server/cards/promo/Philares.ts
+++ b/src/server/cards/promo/Philares.ts
@@ -10,8 +10,9 @@ import {BoardType} from '../../boards/BoardType';
 import {all} from '../Options';
 import {SelectResources} from '../../inputs/SelectResources';
 import {message} from '../../logs/MessageBuilder';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Philares extends CorporationCard {
+export class Philares extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.PHILARES,

--- a/src/server/cards/promo/Recyclon.ts
+++ b/src/server/cards/promo/Recyclon.ts
@@ -11,7 +11,7 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
 
-export class Recyclon extends CorporationCard {
+export class Recyclon extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.RECYCLON,

--- a/src/server/cards/promo/Splice.ts
+++ b/src/server/cards/promo/Splice.ts
@@ -14,7 +14,7 @@ import {message} from '../../logs/MessageBuilder';
 import {ICard} from '../ICard';
 import {GainResources} from '../../deferredActions/GainResources';
 
-export class Splice extends CorporationCard {
+export class Splice extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.SPLICE,

--- a/src/server/cards/promo/TychoMagnetics.ts
+++ b/src/server/cards/promo/TychoMagnetics.ts
@@ -5,8 +5,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {Resource} from '../../../common/Resource';
 import {IPlayer} from '../../IPlayer';
 import {SelectAmount} from '../../inputs/SelectAmount';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class TychoMagnetics extends CorporationCard {
+export class TychoMagnetics extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.TYCHO_MAGNETICS,

--- a/src/server/cards/turmoil/LakefrontResorts.ts
+++ b/src/server/cards/turmoil/LakefrontResorts.ts
@@ -10,8 +10,9 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {all} from '../Options';
 import {Board} from '../../boards/Board';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class LakefrontResorts extends CorporationCard {
+export class LakefrontResorts extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.LAKEFRONT_RESORTS,

--- a/src/server/cards/turmoil/Pristar.ts
+++ b/src/server/cards/turmoil/Pristar.ts
@@ -5,8 +5,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {Resource} from '../../../common/Resource';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Pristar extends CorporationCard {
+export class Pristar extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.PRISTAR,

--- a/src/server/cards/turmoil/SeptumTribus.ts
+++ b/src/server/cards/turmoil/SeptumTribus.ts
@@ -6,8 +6,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Resource} from '../../../common/Resource';
 import {Turmoil} from '../../turmoil/Turmoil';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class SeptumTribus extends CorporationCard implements IActionCard {
+export class SeptumTribus extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.SEPTUM_TRIBUS,

--- a/src/server/cards/turmoil/TerralabsResearch.ts
+++ b/src/server/cards/turmoil/TerralabsResearch.ts
@@ -2,8 +2,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class TerralabsResearch extends CorporationCard {
+export class TerralabsResearch extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.TERRALABS_RESEARCH,

--- a/src/server/cards/turmoil/UtopiaInvest.ts
+++ b/src/server/cards/turmoil/UtopiaInvest.ts
@@ -8,8 +8,9 @@ import {Resource} from '../../../common/Resource';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class UtopiaInvest extends CorporationCard implements IActionCard {
+export class UtopiaInvest extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.UTOPIA_INVEST,

--- a/src/server/cards/underworld/AnubisSecurities.ts
+++ b/src/server/cards/underworld/AnubisSecurities.ts
@@ -8,8 +8,9 @@ import {Resource} from '../../../common/Resource';
 import {all} from '../Options';
 import {Size} from '../../../common/cards/render/Size';
 import {Priority} from '../../deferredActions/Priority';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class AnubisSecurities extends CorporationCard {
+export class AnubisSecurities extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.ANUBIS_SECURITIES,

--- a/src/server/cards/underworld/DemetronLabs.ts
+++ b/src/server/cards/underworld/DemetronLabs.ts
@@ -12,8 +12,9 @@ import {sum} from '../../../common/utils/utils';
 import {Space} from '../../boards/Space';
 import {CardResource} from '../../../common/CardResource';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class DemetronLabs extends CorporationCard implements IActionCard {
+export class DemetronLabs extends CorporationCard implements ICorporationCard, IActionCard {
   constructor() {
     super({
       name: CardName.DEMETRON_LABS,

--- a/src/server/cards/underworld/KingdomofTauraro.ts
+++ b/src/server/cards/underworld/KingdomofTauraro.ts
@@ -5,8 +5,9 @@ import {CorporationCard} from '../corporation/CorporationCard';
 import {IPlayer} from '../../IPlayer';
 import {all} from '../Options';
 import {Resource} from '../../../common/Resource';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class KingdomofTauraro extends CorporationCard {
+export class KingdomofTauraro extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.KINGDOM_OF_TAURARO,

--- a/src/server/cards/venusNext/Aphrodite.ts
+++ b/src/server/cards/venusNext/Aphrodite.ts
@@ -3,8 +3,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {all} from '../Options';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Aphrodite extends CorporationCard {
+export class Aphrodite extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.APHRODITE,

--- a/src/server/cards/venusNext/Manutech.ts
+++ b/src/server/cards/venusNext/Manutech.ts
@@ -4,8 +4,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {Resource} from '../../../common/Resource';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Manutech extends CorporationCard {
+export class Manutech extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MANUTECH,

--- a/src/server/cards/venusNext/MorningStarInc.ts
+++ b/src/server/cards/venusNext/MorningStarInc.ts
@@ -3,8 +3,9 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {GlobalParameter} from '../../../common/GlobalParameter';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class MorningStarInc extends CorporationCard {
+export class MorningStarInc extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.MORNING_STAR_INC,

--- a/src/server/cards/venusNext/Viron.ts
+++ b/src/server/cards/venusNext/Viron.ts
@@ -5,8 +5,9 @@ import {IActionCard, ICard, isIActionCard, isIHasCheckLoops} from '../ICard';
 import {SelectCard} from '../../inputs/SelectCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
+import {ICorporationCard} from '../corporation/ICorporationCard';
 
-export class Viron extends CorporationCard {
+export class Viron extends CorporationCard implements ICorporationCard {
   constructor() {
     super({
       name: CardName.VIRON,


### PR DESCRIPTION
I'm going to start to plan to refactor coproration cards to have the same API as all other card types, particularly as it pertains to `onCardPlayed`, and `onCorpCardPlayed`. To make sure refactoring doesn't silently break the interface contract, this forces the `implements` clause.