### PR TITLE
Fix: Corporation Visualizations

### DIFF
--- a/src/client/components/card/CardCorporationLogo.vue
+++ b/src/client/components/card/CardCorporationLogo.vue
@@ -87,7 +87,7 @@
       </div>
     </template>
     <template v-else-if="title === CardName.UNITED_NATIONS_MARS_INITIATIVE">
-      <span class="card-unmi-logo">UNITED<br/>NATIONS<br/>MARS<br/>INITIATIVE</span>
+      <span class="card-unmi-logo">UNITED NATIONS<br/>MARS INITIATIVE</span>
     </template>
     <template v-else-if="title === CardName.UTOPIA_INVEST">
       <div class="card-utopia-logo">

--- a/src/server/cards/corporation/UnitedNationsMarsInitiative.ts
+++ b/src/server/cards/corporation/UnitedNationsMarsInitiative.ts
@@ -20,8 +20,8 @@ export class UnitedNationsMarsInitiative extends CorporationCard implements IAct
         description: 'You start with 40 M€.',
         renderData: CardRenderer.builder((b) => {
           // TODO(chosta): find a not so hacky solutions to spacing
-          b.br.br.br;
-          b.empty().nbsp.nbsp.nbsp.nbsp.megacredits(40);
+          // b.br.br.br;
+          b.empty().megacredits(40);
           b.corpBox('action', (ce) => {
             ce.action('If your Terraform Rating was raised this generation, you may pay 3 M€ to raise it 1 step more.', (eb) => {
               eb.megacredits(3).startAction.tr(1).asterix();

--- a/src/server/cards/pathfinders/Odyssey.ts
+++ b/src/server/cards/pathfinders/Odyssey.ts
@@ -19,7 +19,7 @@ export class Odyssey extends CorporationCard implements ICorporationCard, IActio
         cardNumber: 'PfC18',
         description: 'You start with 33 M€.',
         renderData: CardRenderer.builder((b) => {
-          b.br.br.br.br.br.br.megacredits(33).nbsp.nbsp.nbsp;
+          b.megacredits(33);
           b.colon().cards(1, {secondaryTag: Tag.EVENT}).asterix().br;
           b.text('(Effect: Your event cards stay face up, and their tags are in use as if those were automated (green) cards.)',
             Size.TINY, false, false).br;

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -2459,7 +2459,6 @@
 .card-mons-insurance {
     .card-content-corporation > .card-description {
         position: relative;
-        top: -16px;
     }
 }
 

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -566,10 +566,9 @@
             top: 14px;
             left: 1px;
             font-size: 15px;
-            width: 90px;
+            width: 150px;
             color: white;
             line-height: 23px;
-            padding: 5px;
             text-align: center;
             font-weight: normal;
             box-shadow: 3px 3px 6px grey;

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -1053,6 +1053,7 @@
         box-shadow: 0 0 0px 1px rgba(0, 0, 0.5);
         width: 216px;
         padding: 0 4px;
+        margin: 4px 0;
         /* hide points on hover by poppig the overlay on top of them*/
         &:hover {
             box-shadow: 0px 0px 4px 1px #353594;
@@ -1879,6 +1880,9 @@
             display: flex;
             flex-flow: row;
             align-items: center;
+        }
+        .card-row:empty {
+            margin: 0;
         }
     }
     .card-description {

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -2456,10 +2456,8 @@
     }
 }
 /* fixes */
-.card-mons-insurance {
-    .card-content-corporation > .card-description {
-        position: relative;
-    }
+.card-nirgal-enterprises .card-title {
+    height: 60px !important;
 }
 
 .card-party {

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -986,9 +986,9 @@
         }
         .card-odyssey-logo {
             background-image: url(./assets/pathfinders/corp-logo-odyssey.png);
-            height: 90px;
-            width: 125px;
-            background-size: 125px 90px;
+            height: 70px;
+            width: 97px;
+            background-size: 97px 70px;
             margin-top: 10px;
         }
         .card-aurorai-logo {

--- a/src/styles/language_hacks.less
+++ b/src/styles/language_hacks.less
@@ -342,14 +342,6 @@
         margin-left: 153px;
     }
 
-    // /* UNMI */
-    // .card-united-nations-mars-initiative .contentCorporation > .description {
-    //     margin-left: 15px !important;
-    // }
-    // .card-united-nations-mars-initiative .contentCorporation > .description .resource {
-    //     margin-right: 10px;
-    // }
-
     /***
     Corporations specific modifications
     ***/

--- a/src/styles/language_hacks.less
+++ b/src/styles/language_hacks.less
@@ -342,13 +342,13 @@
         margin-left: 153px;
     }
 
-    /* UNMI */
-    .card-united-nations-mars-initiative .contentCorporation > .description {
-        margin-left: 15px !important;
-    }
-    .card-united-nations-mars-initiative .contentCorporation > .description .resource {
-        margin-right: 10px;
-    }
+    // /* UNMI */
+    // .card-united-nations-mars-initiative .contentCorporation > .description {
+    //     margin-left: 15px !important;
+    // }
+    // .card-united-nations-mars-initiative .contentCorporation > .description .resource {
+    //     margin-right: 10px;
+    // }
 
     /***
     Corporations specific modifications


### PR DESCRIPTION
Before fix:
![image](https://github.com/user-attachments/assets/ac9c11fb-9184-45cd-a2a2-45552c05b0cb)

After fix:
![image](https://github.com/user-attachments/assets/95e08219-dafb-4c7e-ad69-8456935865a5)

Brief description of fix:
- part of the issue was that there were empty card rows with margin, so I made those have 0 margin
- also gave the card-corporation-box a bit more top margin to match the rest of the card

Note: This fix is not specific to this card, but a more general fix that will impact all corporation cards. Credicor is just an example of the issue.