### PR TITLE
Defer adding science resource to Olympus Conference for Hyperspace Drive Prototype

### DIFF
--- a/src/server/cards/base/OlympusConference.ts
+++ b/src/server/cards/base/OlympusConference.ts
@@ -44,9 +44,6 @@ export class OlympusConference extends Card implements IProjectCard {
     }
   }
   public onScienceTagAdded(player: IPlayer, count: number) {
-    // For cards like Hyperspace Drive Prototype, we want to defer adding a resource from the tag
-    // until after resource is added via the card (so the tag can be used to remove the resource).
-    const priority = (this.resourceCount === 0 && count === 1) ? Priority.DEFAULT : Priority.SUPERPOWER;
     for (let i = 0; i < count; i++) {
       player.defer(() => {
         // Can't remove a resource
@@ -66,7 +63,7 @@ export class OlympusConference extends Card implements IProjectCard {
           }),
         ).setTitle('Select an option for Olympus Conference');
       },
-      priority); // Unshift that deferred action
+      Priority.OLYMPUS_CONFERENCE); // Unshift that deferred action
     }
     return undefined;
   }

--- a/src/server/cards/base/OlympusConference.ts
+++ b/src/server/cards/base/OlympusConference.ts
@@ -44,6 +44,9 @@ export class OlympusConference extends Card implements IProjectCard {
     }
   }
   public onScienceTagAdded(player: IPlayer, count: number) {
+    // For cards like Hyperspace Drive Prototype, we want to defer adding a resource from the tag
+    // until after resource is added via the card (so the tag can be used to remove the resource).
+    const priority = (this.resourceCount === 0 && count === 1) ? Priority.DEFAULT : Priority.SUPERPOWER;
     for (let i = 0; i < count; i++) {
       player.defer(() => {
         // Can't remove a resource
@@ -63,7 +66,7 @@ export class OlympusConference extends Card implements IProjectCard {
           }),
         ).setTitle('Select an option for Olympus Conference');
       },
-      Priority.SUPERPOWER); // Unshift that deferred action
+      priority); // Unshift that deferred action
     }
     return undefined;
   }

--- a/src/server/cards/underworld/HyperspaceDrivePrototype.ts
+++ b/src/server/cards/underworld/HyperspaceDrivePrototype.ts
@@ -40,7 +40,6 @@ export class HyperspaceDrivePrototype extends Card implements IProjectCard {
       player.game.log('${0} has no fighter resource cards and gained 1 titanium.', (b) => b.player(player));
       player.stock.titanium += 1;
     }
-    // If the player has Olympus Conference, its effect should take place after this gets a resource on it.
     const scienceCards = player.getResourceCards(CardResource.SCIENCE);
     if (scienceCards.length > 0) {
       player.game.defer(new AddResourcesToCard(player, CardResource.SCIENCE), Priority.HYPERSPACE_DRIVE_PROTOTYPE);

--- a/src/server/cards/underworld/HyperspaceDrivePrototype.ts
+++ b/src/server/cards/underworld/HyperspaceDrivePrototype.ts
@@ -7,6 +7,7 @@ import {Tag} from '../../../common/cards/Tag';
 import {IPlayer} from '../../IPlayer';
 import {CardResource} from '../../../common/CardResource';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
+import {Priority} from '../../deferredActions/Priority';
 
 export class HyperspaceDrivePrototype extends Card implements IProjectCard {
   constructor() {
@@ -39,10 +40,10 @@ export class HyperspaceDrivePrototype extends Card implements IProjectCard {
       player.game.log('${0} has no fighter resource cards and gained 1 titanium.', (b) => b.player(player));
       player.stock.titanium += 1;
     }
-    // TODO(kberg): If the player has olympus conference, its effect should take place after this gets a resource on it.
+    // If the player has Olympus Conference, its effect should take place after this gets a resource on it.
     const scienceCards = player.getResourceCards(CardResource.SCIENCE);
     if (scienceCards.length > 0) {
-      player.game.defer(new AddResourcesToCard(player, CardResource.SCIENCE));
+      player.game.defer(new AddResourcesToCard(player, CardResource.SCIENCE), Priority.SUPERPOWER);
     } else {
       player.game.log('${0} has no science cards and gained 1 TR.', (b) => b.player(player));
       player.increaseTerraformRating();

--- a/src/server/cards/underworld/HyperspaceDrivePrototype.ts
+++ b/src/server/cards/underworld/HyperspaceDrivePrototype.ts
@@ -43,7 +43,7 @@ export class HyperspaceDrivePrototype extends Card implements IProjectCard {
     // If the player has Olympus Conference, its effect should take place after this gets a resource on it.
     const scienceCards = player.getResourceCards(CardResource.SCIENCE);
     if (scienceCards.length > 0) {
-      player.game.defer(new AddResourcesToCard(player, CardResource.SCIENCE), Priority.SUPERPOWER);
+      player.game.defer(new AddResourcesToCard(player, CardResource.SCIENCE), Priority.HYPERSPACE_DRIVE_PROTOTYPE);
     } else {
       player.game.log('${0} has no science cards and gained 1 TR.', (b) => b.player(player));
       player.increaseTerraformRating();

--- a/src/server/deferredActions/Priority.ts
+++ b/src/server/deferredActions/Priority.ts
@@ -9,7 +9,16 @@ export enum Priority {
   PHARMACY_UNION,
   /** Any effect from one of your opponent's card that triggers during your turn. */
   OPPONENT_TRIGGER,
-
+  /**
+   * Resolve Hyperspace Drive Prototype before Olympus Conference
+   *
+   * https://docs.google.com/drawings/d/1VXfVmoJWU_QmMDwZ-liVh5ZvWVmmpl2kuo_3ANz4omY/edit?usp=sharing
+   */
+  HYPERSPACE_DRIVE_PROTOTYPE,
+  /**
+   * Resolve Olympus Conference before Sponsored Academies and Mars U.
+   */
+  OLYMPUS_CONFERENCE,
   /** When you must discard before you can draw. Making a determination that Sponsored Academies should come before Mars U. */
   SPONSORED_ACADEMIES,
   DRAW_CARDS,

--- a/tests/cards/base/OlympusConference.spec.ts
+++ b/tests/cards/base/OlympusConference.spec.ts
@@ -137,7 +137,7 @@ describe('OlympusConference', () => {
     expect(card.resourceCount).to.eq(1);
   });
 
-  it ('Allows for resource to be added first when Hyperspace Drive Prototype is played', () => {
+  it('Allows for resource to be added first when Hyperspace Drive Prototype is played', () => {
     player.playedCards.push(card);
     card.resourceCount = 0;
     const hyperspaceDrivePrototype = new HyperspaceDrivePrototype();

--- a/tests/cards/base/OlympusConference.spec.ts
+++ b/tests/cards/base/OlympusConference.spec.ts
@@ -11,6 +11,7 @@ import {TestPlayer} from '../../TestPlayer';
 import {cast, runAllActions} from '../../TestingUtils';
 import {testGame} from '../../TestGame';
 import {Leavitt} from '../../../src/server/cards/community/Leavitt';
+import {HyperspaceDrivePrototype} from '../../../src/server/cards/underworld/HyperspaceDrivePrototype';
 
 describe('OlympusConference', () => {
   let card: OlympusConference;
@@ -134,5 +135,20 @@ describe('OlympusConference', () => {
     runAllActions(game);
     cast(player.popWaitingFor(), undefined);
     expect(card.resourceCount).to.eq(1);
+  });
+
+  it ('Allows for resource to be added first when Hyperspace Drive Prototype is played', () => {
+    player.playedCards.push(card);
+    card.resourceCount = 0;
+    const hyperspaceDrivePrototype = new HyperspaceDrivePrototype();
+    player.playCard(hyperspaceDrivePrototype);
+    runAllActions(game);
+
+    const orOptions = cast(player.popWaitingFor(), OrOptions);
+    game.deferredActions.pop();
+    orOptions.options[0].cb();
+
+    expect(card.resourceCount).to.eq(0);
+    expect(player.cardsInHand).has.lengthOf(1);
   });
 });


### PR DESCRIPTION
Fixes #7505

I have chosen the Priority values so that if a player also had Mars University, this interaction would take place before discard and draw. I will add a test(/s) and manual test worked as expected