### PR TITLE
Keep a running total of tags on event cards.

### DIFF
--- a/src/server/player/Tags.ts
+++ b/src/server/player/Tags.ts
@@ -152,16 +152,12 @@ export class Tags {
     return count;
   }
 
-  // Counts the tags in the player's play area only.
+  // Counts the tags in the player's play area.
   protected rawCount(tag: Tag, includeEventsTags: boolean) {
     let tagCount = this.player.playedCards.tags[tag];
 
     if (includeEventsTags) {
-      for (const card of this.player.playedCards) {
-        if (card.type === CardType.EVENT) {
-          tagCount += card.tags.filter((cardTag) => cardTag === tag).length;
-        }
-      }
+      tagCount += this.player.playedCards.eventTags[tag];
     }
 
     return tagCount;

--- a/tests/cards/PlayedCards.spec.ts
+++ b/tests/cards/PlayedCards.spec.ts
@@ -65,9 +65,11 @@ describe('PlayedCards', () => {
     const comet = new Comet();
     playedCards.push(comet);
     expect(partialize(playedCards.tags)).deep.eq({});
+    expect(partialize(playedCards.eventTags)).deep.eq({space: 1});
     // Removing the event doesn't change the count.
     playedCards.remove(comet);
     expect(partialize(playedCards.tags)).deep.eq({});
+    expect(partialize(playedCards.eventTags)).deep.eq({});
   });
 
   it('Counts tags, retag', () => {


### PR DESCRIPTION
Not many actions care about it, but when it's called, at least it's efficient.