### PR TITLE
Fix Adhai Orbit Construction

### DIFF
--- a/src/server/cards/pathfinders/AdhaiHighOrbitConstructions.ts
+++ b/src/server/cards/pathfinders/AdhaiHighOrbitConstructions.ts
@@ -20,11 +20,6 @@ export class AdhaiHighOrbitConstructions extends CorporationCard implements ICor
       startingMegaCredits: 43,
       resourceType: CardResource.ORBITAL,
 
-      behavior: {
-        // This is the onCardPlayed effect.
-        addResources: 1,
-      },
-
       metadata: {
         cardNumber: 'PfC23',
         description: 'You start with 43 M€.',


### PR DESCRIPTION
Creating extra orbitals on game start because of migration to the new API for corporate cards. I forgot to clean a little of it up.