### PR TITLE
#7591 - Fix name of moved resource in CloudVortexOutpost

### DIFF
--- a/src/server/cards/underworld/CloudVortexOutpost.ts
+++ b/src/server/cards/underworld/CloudVortexOutpost.ts
@@ -55,7 +55,7 @@ export class CloudVortexOutpost extends PreludeCard {
       .andThen((card) => {
         this.resourceCount--;
         player.addResourceTo(card, 1);
-        LogHelper.logMoveResource(player, CardResource.ANIMAL, this, card);
+        LogHelper.logMoveResource(player, CardResource.FLOATER, this, card);
       });
     return undefined;
   }


### PR DESCRIPTION
Fixes #7591. Should have been fixed in #7592 , but I rolled it back like a goofball.