### PR TITLE
Fix Luna First Incorporated bug.

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -58,6 +58,7 @@ export const VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST = 3;
 export const TERRA_CIMMERIA_COLONY_COST = 5;
 
 // Moon
+export const MAXIMUM_MOON_RATE = 8;
 export const MAXIMUM_HABITAT_RATE = 8;
 export const MAXIMUM_MINING_RATE = 8;
 export const MAXIMUM_LOGISTICS_RATE = 8;

--- a/tests/cards/moon/LunaFirstIncorporated.spec.ts
+++ b/tests/cards/moon/LunaFirstIncorporated.spec.ts
@@ -3,50 +3,55 @@ import {testGame} from '../../TestGame';
 import {LunaFirstIncorporated} from '../../../src/server/cards/moon/LunaFirstIncorporated';
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 import {TestPlayer} from '../../TestPlayer';
+import {IGame} from '../../../src/server/IGame';
 describe('LunaFirstIncorporated', () => {
   let player: TestPlayer;
+  let game: IGame;
   let otherPlayer: TestPlayer;
   let card: LunaFirstIncorporated;
 
   beforeEach(() => {
-    [/* game */, player, otherPlayer] = testGame(2, {moonExpansion: true});
+    [game, player, otherPlayer] = testGame(2, {moonExpansion: true});
     card = new LunaFirstIncorporated();
+    card.play(player);
   });
 
-  it('effect', () => {
-    card.play(player);
-
-    // Case 1
-    player.production.override({megacredits: 0});
-    player.megaCredits = 0;
-
+  it('effect, mining rate, other player', () => {
     MoonExpansion.raiseMiningRate(otherPlayer, 1);
     expect(player.megaCredits).eq(1);
     expect(player.production.megacredits).eq(0);
+  });
 
-    // Case 2
-    player.production.override({megacredits: 0});
-    player.megaCredits = 0;
-
+  it('effect, habitat rate, other player', () => {
     MoonExpansion.raiseHabitatRate(otherPlayer, 2);
     expect(player.megaCredits).eq(2);
     expect(player.production.megacredits).eq(0);
+  });
 
-    // Case 3
-    player.production.override({megacredits: 0});
-    player.megaCredits = 0;
-
+  it('effect, logistic rate, other player', () => {
     MoonExpansion.raiseLogisticRate(player, 1);
     expect(player.megaCredits).eq(1);
     expect(player.production.megacredits).eq(1);
+  });
 
-    // Case 4
-    player.production.override({megacredits: 0});
-    player.megaCredits = 0;
-
+  it('effect, mining rate, self', () => {
     MoonExpansion.raiseMiningRate(player, 2);
     expect(player.megaCredits).eq(2);
     expect(player.production.megacredits).eq(2);
+  });
+
+  it('effect, near max', () => {
+    game.moonData!.habitatRate = 7;
+    MoonExpansion.raiseHabitatRate(player, 2);
+    expect(player.megaCredits).eq(1);
+    expect(player.production.megacredits).eq(1);
+  });
+
+  it('effect, at max', () => {
+    game.moonData!.habitatRate = 8;
+    MoonExpansion.raiseHabitatRate(player, 1);
+    expect(player.megaCredits).eq(0);
+    expect(player.production.megacredits).eq(0);
   });
 });
 


### PR DESCRIPTION
Moved all raise[Moon]Rate methods into one reusable method. The bug was due to all three tracks repeating the same code. Ah, repetition.