### PR TITLE
Preserve log view across game refresh

### DIFF
--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -25,7 +25,11 @@
         title="Latest logs"
         data-test="log-latest"
         @click="showLatestLogs"
-      ><span class="log-latest-button-icon" aria-hidden="true"></span></button>
+      >
+        <svg class="log-latest-button-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+          <path d="M12 5v14M19 12l-7 7-7-7"/>
+        </svg>
+      </button>
       <div class='debugid'>(debugid {{step}})</div>
     </div>
     <CardPanel v-if="selectedMessage !== undefined" :message="selectedMessage" :players="players" @hide="selectedMessage = undefined"/>

--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -18,16 +18,16 @@
           <LogMessageComponent v-for="(message, index) in messages" :key="index" :message="message" :viewModel="viewModel" @click="messageClicked(message)" @spaceClicked="spaceClicked"/>
         </ul>
       </div>
+      <button
+        type="button"
+        class="log-latest-button"
+        aria-label="Latest logs"
+        title="Latest logs"
+        data-test="log-latest"
+        @click="showLatestLogs"
+      ><span class="log-latest-button-icon" aria-hidden="true"></span></button>
       <div class='debugid'>(debugid {{step}})</div>
     </div>
-    <button
-      type="button"
-      class="log-latest-button"
-      aria-label="Latest logs"
-      title="Latest logs"
-      data-test="log-latest"
-      @click="showLatestLogs"
-    >&#x2193;</button>
     <CardPanel v-if="selectedMessage !== undefined" :message="selectedMessage" :players="players" @hide="selectedMessage = undefined"/>
   </div>
 </template>

--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -13,12 +13,13 @@
       <span class="label-additional" v-if="players.length === 1"><span :class="lastGenerationClass" v-i18n>of {{lastSoloGeneration}}</span></span>
     </div>
     <div class="panel log-panel">
-      <div id="logpanel-scrollable" class="panel-body">
+      <div id="logpanel-scrollable" class="panel-body" @scroll="updateScrollState">
         <ul v-if="messages">
           <LogMessageComponent v-for="(message, index) in messages" :key="index" :message="message" :viewModel="viewModel" @click="messageClicked(message)" @spaceClicked="spaceClicked"/>
         </ul>
       </div>
       <button
+        v-show="showScrollToBottomButton"
         type="button"
         class="log-latest-button"
         aria-label="Latest logs"
@@ -68,6 +69,7 @@ type LogPanelModel = {
   messages: Array<LogMessage>,
   selectedGeneration: number,
   selectedMessage: LogMessage | undefined,
+  showScrollToBottomButton: boolean,
 };
 
 export default defineComponent({
@@ -92,6 +94,7 @@ export default defineComponent({
       messages: [],
       selectedGeneration: -1,
       selectedMessage: undefined,
+      showScrollToBottomButton: false,
     };
   },
   components: {
@@ -182,13 +185,18 @@ export default defineComponent({
       const scrollablePanel = this.scrollablePanel;
       if (scrollablePanel !== null) {
         scrollablePanel.scrollTop = scrollablePanel.scrollHeight;
+        this.updateScrollState();
       }
     },
     restoreScrollTop(scrollTop: number) {
       const scrollablePanel = this.scrollablePanel;
       if (scrollablePanel !== null) {
         scrollablePanel.scrollTop = scrollTop;
+        this.updateScrollState();
       }
+    },
+    updateScrollState(): void {
+      this.showScrollToBottomButton = !this.isNearBottom();
     },
     isNearBottom(): boolean {
       const scrollablePanel = this.scrollablePanel;

--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -20,6 +20,14 @@
       </div>
       <div class='debugid'>(debugid {{step}})</div>
     </div>
+    <button
+      type="button"
+      class="log-latest-button"
+      aria-label="Latest logs"
+      title="Latest logs"
+      data-test="log-latest"
+      @click="showLatestLogs"
+    >&#x2193;</button>
     <CardPanel v-if="selectedMessage !== undefined" :message="selectedMessage" :players="players" @hide="selectedMessage = undefined"/>
   </div>
 </template>
@@ -40,6 +48,15 @@ import CardPanel from '@/client/components/logpanel/CardPanel.vue';
 import {isMarsSpace} from '@/common/boards/spaces';
 
 let logAbortController: AbortController | undefined;
+
+type LogPanelViewState = {
+  participantId: ParticipantId,
+  selectedGeneration: number,
+  scrollTop: number,
+  stickToBottom: boolean,
+};
+
+let logPanelViewState: LogPanelViewState | undefined;
 
 type LogPanelModel = {
   messages: Array<LogMessage>,
@@ -108,7 +125,11 @@ export default defineComponent({
       }
       this.selectedGeneration = gen;
     },
-    getLogsForGeneration(generation: number): void {
+    showLatestLogs(): void {
+      this.selectedGeneration = this.generation;
+      this.getLogsForGeneration(this.generation, undefined, true);
+    },
+    getLogsForGeneration(generation: number, restoredState?: LogPanelViewState, forceScrollToEnd = false): void {
       const messages = this.messages;
       // abort any pending requests
       if (logAbortController) {
@@ -137,8 +158,10 @@ export default defineComponent({
           if (getPreferences().enable_sounds && window.location.search.includes('experimental=1') ) {
             SoundManager.newLog();
           }
-          if (generation === this.generation) {
+          if (forceScrollToEnd || restoredState?.stickToBottom === true || (restoredState === undefined && generation === this.generation)) {
             this.$nextTick(this.scrollToEnd);
+          } else if (restoredState !== undefined) {
+            this.$nextTick(() => this.restoreScrollTop(restoredState.scrollTop));
           }
         })
         .catch((err) => {
@@ -150,10 +173,27 @@ export default defineComponent({
         });
     },
     scrollToEnd() {
-      const scrollablePanel = document.getElementById('logpanel-scrollable');
+      const scrollablePanel = this.getScrollablePanel();
       if (scrollablePanel !== null) {
         scrollablePanel.scrollTop = scrollablePanel.scrollHeight;
       }
+    },
+    restoreScrollTop(scrollTop: number) {
+      const scrollablePanel = this.getScrollablePanel();
+      if (scrollablePanel !== null) {
+        scrollablePanel.scrollTop = scrollTop;
+      }
+    },
+    getScrollablePanel(): HTMLElement | null {
+      return document.getElementById('logpanel-scrollable');
+    },
+    isNearBottom(): boolean {
+      const scrollablePanel = this.getScrollablePanel();
+      if (scrollablePanel === null) {
+        return true;
+      }
+      const remaining = scrollablePanel.scrollHeight - scrollablePanel.clientHeight - scrollablePanel.scrollTop;
+      return remaining <= 24;
     },
     getClassesGenIndicator(gen: number): string {
       const classes = ['log-gen-indicator'];
@@ -193,8 +233,20 @@ export default defineComponent({
     },
   },
   mounted() {
-    this.selectedGeneration = this.generation;
-    this.getLogsForGeneration(this.generation);
+    const restoredState = this.id !== undefined && logPanelViewState?.participantId === this.id ? logPanelViewState : undefined;
+    this.selectedGeneration = restoredState?.selectedGeneration ?? this.generation;
+    this.getLogsForGeneration(this.selectedGeneration, restoredState);
+  },
+  beforeUnmount() {
+    const scrollablePanel = this.getScrollablePanel();
+    if (this.id !== undefined) {
+      logPanelViewState = {
+        participantId: this.id,
+        selectedGeneration: this.selectedGeneration,
+        scrollTop: scrollablePanel?.scrollTop ?? 0,
+        stickToBottom: this.isNearBottom(),
+      };
+    }
   },
 });
 

--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -58,12 +58,16 @@ const BOTTOM_SCROLL_THRESHOLD = 24; // Roughly one line of log text.
 
 type ScrollPosition = number | 'bottom';
 
-type LogPanelViewState = {
+type ViewState = {
+  // The current generation viewed in the log panel, which might be different
+  // from the current generation in the game.
   selectedGeneration: number,
+  // Either 'bottom' which means continue scrolling as new entries appear,
+  // or a number which is the pixel height from the top of the widget.
   scrollPosition: ScrollPosition,
 };
 
-let logPanelViewState: LogPanelViewState | undefined;
+let viewState: ViewState | undefined;
 
 type LogPanelModel = {
   messages: Array<LogMessage>,
@@ -247,12 +251,12 @@ export default defineComponent({
     },
   },
   mounted() {
-    const restoredState = logPanelViewState;
+    const restoredState = viewState;
     this.selectedGeneration = restoredState?.selectedGeneration ?? this.generation;
     this.getLogsForGeneration(this.selectedGeneration, restoredState?.scrollPosition ?? 'bottom');
   },
   beforeUnmount() {
-    logPanelViewState = {
+    viewState = {
       selectedGeneration: this.selectedGeneration,
       scrollPosition: this.isNearBottom() ? 'bottom' : this.scrollablePanel?.scrollTop ?? 'bottom',
     };

--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -58,7 +58,6 @@ const BOTTOM_SCROLL_THRESHOLD = 24; // Roughly one line of log text.
 type ScrollPosition = number | 'bottom';
 
 type LogPanelViewState = {
-  participantId: ParticipantId,
   selectedGeneration: number,
   scrollPosition: ScrollPosition,
 };
@@ -240,18 +239,15 @@ export default defineComponent({
     },
   },
   mounted() {
-    const restoredState = this.id !== undefined && logPanelViewState?.participantId === this.id ? logPanelViewState : undefined;
+    const restoredState = logPanelViewState;
     this.selectedGeneration = restoredState?.selectedGeneration ?? this.generation;
     this.getLogsForGeneration(this.selectedGeneration, restoredState?.scrollPosition ?? 'bottom');
   },
   beforeUnmount() {
-    if (this.id !== undefined) {
-      logPanelViewState = {
-        participantId: this.id,
-        selectedGeneration: this.selectedGeneration,
-        scrollPosition: this.isNearBottom() ? 'bottom' : this.scrollablePanel?.scrollTop ?? 'bottom',
-      };
-    }
+    logPanelViewState = {
+      selectedGeneration: this.selectedGeneration,
+      scrollPosition: this.isNearBottom() ? 'bottom' : this.scrollablePanel?.scrollTop ?? 'bottom',
+    };
   },
 });
 

--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -53,11 +53,14 @@ import {isMarsSpace} from '@/common/boards/spaces';
 
 let logAbortController: AbortController | undefined;
 
+const BOTTOM_SCROLL_THRESHOLD = 24; // Roughly one line of log text.
+
+type ScrollPosition = number | 'bottom';
+
 type LogPanelViewState = {
   participantId: ParticipantId,
   selectedGeneration: number,
-  scrollTop: number,
-  stickToBottom: boolean,
+  scrollPosition: ScrollPosition,
 };
 
 let logPanelViewState: LogPanelViewState | undefined;
@@ -125,15 +128,15 @@ export default defineComponent({
     },
     selectGeneration(gen: number): void {
       if (gen !== this.selectedGeneration) {
-        this.getLogsForGeneration(gen);
+        this.getLogsForGeneration(gen, gen === this.generation ? 'bottom' : undefined);
       }
       this.selectedGeneration = gen;
     },
     showLatestLogs(): void {
       this.selectedGeneration = this.generation;
-      this.getLogsForGeneration(this.generation, undefined, true);
+      this.getLogsForGeneration(this.generation, 'bottom');
     },
-    getLogsForGeneration(generation: number, restoredState?: LogPanelViewState, forceScrollToEnd = false): void {
+    getLogsForGeneration(generation: number, scrollPosition?: ScrollPosition): void {
       const messages = this.messages;
       // abort any pending requests
       if (logAbortController) {
@@ -162,10 +165,10 @@ export default defineComponent({
           if (getPreferences().enable_sounds && window.location.search.includes('experimental=1') ) {
             SoundManager.newLog();
           }
-          if (forceScrollToEnd || restoredState?.stickToBottom === true || (restoredState === undefined && generation === this.generation)) {
+          if (scrollPosition === 'bottom') {
             this.$nextTick(this.scrollToEnd);
-          } else if (restoredState !== undefined) {
-            this.$nextTick(() => this.restoreScrollTop(restoredState.scrollTop));
+          } else if (scrollPosition !== undefined) {
+            this.$nextTick(() => this.restoreScrollTop(scrollPosition));
           }
         })
         .catch((err) => {
@@ -177,27 +180,24 @@ export default defineComponent({
         });
     },
     scrollToEnd() {
-      const scrollablePanel = this.getScrollablePanel();
+      const scrollablePanel = this.scrollablePanel;
       if (scrollablePanel !== null) {
         scrollablePanel.scrollTop = scrollablePanel.scrollHeight;
       }
     },
     restoreScrollTop(scrollTop: number) {
-      const scrollablePanel = this.getScrollablePanel();
+      const scrollablePanel = this.scrollablePanel;
       if (scrollablePanel !== null) {
         scrollablePanel.scrollTop = scrollTop;
       }
     },
-    getScrollablePanel(): HTMLElement | null {
-      return document.getElementById('logpanel-scrollable');
-    },
     isNearBottom(): boolean {
-      const scrollablePanel = this.getScrollablePanel();
+      const scrollablePanel = this.scrollablePanel;
       if (scrollablePanel === null) {
         return true;
       }
       const remaining = scrollablePanel.scrollHeight - scrollablePanel.clientHeight - scrollablePanel.scrollTop;
-      return remaining <= 24;
+      return remaining <= BOTTOM_SCROLL_THRESHOLD;
     },
     getClassesGenIndicator(gen: number): string {
       const classes = ['log-gen-indicator'];
@@ -235,20 +235,21 @@ export default defineComponent({
     id(): ParticipantId | undefined {
       return this.viewModel.id;
     },
+    scrollablePanel(): HTMLElement | null {
+      return document.getElementById('logpanel-scrollable');
+    },
   },
   mounted() {
     const restoredState = this.id !== undefined && logPanelViewState?.participantId === this.id ? logPanelViewState : undefined;
     this.selectedGeneration = restoredState?.selectedGeneration ?? this.generation;
-    this.getLogsForGeneration(this.selectedGeneration, restoredState);
+    this.getLogsForGeneration(this.selectedGeneration, restoredState?.scrollPosition ?? 'bottom');
   },
   beforeUnmount() {
-    const scrollablePanel = this.getScrollablePanel();
     if (this.id !== undefined) {
       logPanelViewState = {
         participantId: this.id,
         selectedGeneration: this.selectedGeneration,
-        scrollTop: scrollablePanel?.scrollTop ?? 0,
-        stickToBottom: this.isNearBottom(),
+        scrollPosition: this.isNearBottom() ? 'bottom' : this.scrollablePanel?.scrollTop ?? 'bottom',
       };
     }
   },

--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -43,6 +43,10 @@
   background: @grey_900;
   position: relative;
 
+  > .panel-body {
+    padding-right: 40px;
+  }
+
   li {
     margin-top: 0;
     list-style-type: none;
@@ -54,22 +58,55 @@
 }
 
 .log-latest-button {
-  width: 32px;
-  height: 24px;
-  margin: 4px 5px 0;
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
   padding: 0;
   border: 1px solid rgba(170, 170, 170, 0.6);
   border-radius: 4px;
-  background: #333;
-  color: #ccc;
+  background: rgba(51, 51, 51, 0.92);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+  color: #ddd;
   cursor: pointer;
-  font: inherit;
-  font-size: 18px;
-  line-height: 1;
 
   &:hover {
     background: #ccc;
     color: black;
+  }
+}
+
+.log-latest-button-icon {
+  position: relative;
+  width: 12px;
+  height: 14px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 1px;
+    left: 5px;
+    width: 2px;
+    height: 9px;
+    border-radius: 1px;
+    background: currentColor;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    right: 2px;
+    bottom: 1px;
+    width: 6px;
+    height: 6px;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg);
   }
 }
 .card-panel{

--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -44,7 +44,7 @@
   position: relative;
 
   > .panel-body {
-    padding-right: 40px;
+    padding-right: 64px;
   }
 
   li {
@@ -59,7 +59,7 @@
 
 .log-latest-button {
   position: absolute;
-  right: 8px;
+  right: 28px;
   bottom: 8px;
   z-index: 1;
   display: flex;

--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -65,13 +65,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   padding: 0;
-  border: 1px solid rgba(170, 170, 170, 0.6);
+  border: 1px solid rgba(170, 170, 170, 0.55);
   border-radius: 4px;
-  background: rgba(51, 51, 51, 0.92);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+  background: rgba(51, 51, 51, 0.9);
   color: #ddd;
   cursor: pointer;
 
@@ -79,34 +78,22 @@
     background: #ccc;
     color: black;
   }
+
+  &:focus-visible {
+    outline: 2px solid #ccc;
+    outline-offset: 2px;
+  }
 }
 
 .log-latest-button-icon {
-  position: relative;
-  width: 12px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
 
-  &::before {
-    content: '';
-    position: absolute;
-    top: 1px;
-    left: 5px;
-    width: 2px;
-    height: 9px;
-    border-radius: 1px;
-    background: currentColor;
-  }
-
-  &::after {
-    content: '';
-    position: absolute;
-    right: 2px;
-    bottom: 1px;
-    width: 6px;
-    height: 6px;
-    border-right: 2px solid currentColor;
-    border-bottom: 2px solid currentColor;
-    transform: rotate(45deg);
+  path {
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 }
 .card-panel{

--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -45,6 +45,7 @@
 
   > .panel-body {
     padding-right: 64px;
+    scrollbar-gutter: stable;
   }
 
   li {
@@ -171,6 +172,6 @@
     color: #888;
     position: absolute;
     bottom: 0px;
-    right: 50px;
+    right: 68px;
   }
 }

--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -52,6 +52,26 @@
     margin: 0 !important;
   }
 }
+
+.log-latest-button {
+  width: 32px;
+  height: 24px;
+  margin: 4px 5px 0;
+  padding: 0;
+  border: 1px solid rgba(170, 170, 170, 0.6);
+  border-radius: 4px;
+  background: #333;
+  color: #ccc;
+  cursor: pointer;
+  font: inherit;
+  font-size: 18px;
+  line-height: 1;
+
+  &:hover {
+    background: #ccc;
+    color: black;
+  }
+}
 .card-panel{
   display: inline-block;
   .btn {

--- a/tests/client/components/logpanel/LogPanel.spec.ts
+++ b/tests/client/components/logpanel/LogPanel.spec.ts
@@ -6,14 +6,59 @@ import {fakeViewModel} from '../testHelpers';
 
 describe('LogPanel', () => {
   let originalFetch: any;
+  let originalGetElementById: typeof document.getElementById;
+  let fetchCalls: Array<string>;
+
+  function installScrollablePanel() {
+    let scrollTop = 0;
+    let scrollHeight = 520;
+    const panel = {
+      get scrollTop() {
+        return scrollTop;
+      },
+      set scrollTop(value: number) {
+        scrollTop = value;
+      },
+      get scrollHeight() {
+        return scrollHeight;
+      },
+      clientHeight: 200,
+    } as HTMLElement;
+    document.getElementById = ((id: string) => id === 'logpanel-scrollable' ? panel : null) as typeof document.getElementById;
+    return {
+      getScrollTop: () => scrollTop,
+      setScrollTop: (value: number) => {
+        scrollTop = value;
+      },
+      setScrollHeight: (value: number) => {
+        scrollHeight = value;
+      },
+    };
+  }
+
+  async function flushLogs(wrapper: ReturnType<typeof shallowMount>) {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await wrapper.vm.$nextTick();
+  }
 
   beforeEach(() => {
     originalFetch = (global as any).fetch;
-    (global as any).fetch = () => Promise.resolve({ok: false, statusText: 'stubbed'});
+    originalGetElementById = document.getElementById.bind(document);
+    fetchCalls = [];
+    (global as any).fetch = (url: string) => {
+      fetchCalls.push(url);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    };
   });
 
   afterEach(() => {
     (global as any).fetch = originalFetch;
+    document.getElementById = originalGetElementById;
   });
 
   it('mounts without errors', () => {
@@ -25,5 +70,98 @@ describe('LogPanel', () => {
       },
     });
     expect(wrapper.exists()).to.be.true;
+  });
+
+  it('restores the selected generation and scroll position after remount', async () => {
+    const panel = installScrollablePanel();
+    const baseViewModel = fakeViewModel({id: 'p-log-reader' as any});
+    const viewModel = {...baseViewModel, game: {...baseViewModel.game, generation: 3}};
+    const first = shallowMount(LogPanel, {
+      ...globalConfig,
+      props: {viewModel, color: 'blue'},
+    });
+    await flushLogs(first);
+
+    (first.vm as any).selectedGeneration = 1;
+    panel.setScrollTop(120);
+    first.unmount();
+
+    const second = shallowMount(LogPanel, {
+      ...globalConfig,
+      props: {viewModel, color: 'blue'},
+    });
+    await flushLogs(second);
+
+    expect((second.vm as any).selectedGeneration).eq(1);
+    expect(fetchCalls[fetchCalls.length - 1]).includes('generation=1');
+    expect(panel.getScrollTop()).eq(120);
+  });
+
+  it('does not restore another participant\'s log state', async () => {
+    const panel = installScrollablePanel();
+    const firstViewModel = fakeViewModel({id: 'p-first-reader' as any});
+    const first = shallowMount(LogPanel, {
+      ...globalConfig,
+      props: {viewModel: firstViewModel, color: 'blue'},
+    });
+    await flushLogs(first);
+
+    (first.vm as any).selectedGeneration = 1;
+    panel.setScrollTop(80);
+    first.unmount();
+
+    const secondBase = fakeViewModel({id: 'p-second-reader' as any});
+    const secondViewModel = {...secondBase, game: {...secondBase.game, generation: 4}};
+    const second = shallowMount(LogPanel, {
+      ...globalConfig,
+      props: {viewModel: secondViewModel, color: 'red'},
+    });
+    await flushLogs(second);
+
+    expect((second.vm as any).selectedGeneration).eq(4);
+    expect(fetchCalls[fetchCalls.length - 1]).includes('generation=4');
+    expect(panel.getScrollTop()).eq(520);
+  });
+
+  it('continues following the end after remount when already at the bottom', async () => {
+    const panel = installScrollablePanel();
+    const viewModel = fakeViewModel({id: 'p-log-follower' as any});
+    const first = shallowMount(LogPanel, {
+      ...globalConfig,
+      props: {viewModel, color: 'blue'},
+    });
+    await flushLogs(first);
+
+    panel.setScrollTop(320);
+    first.unmount();
+    panel.setScrollHeight(640);
+
+    const second = shallowMount(LogPanel, {
+      ...globalConfig,
+      props: {viewModel, color: 'blue'},
+    });
+    await flushLogs(second);
+
+    expect(panel.getScrollTop()).eq(640);
+  });
+
+  it('returns to the current generation and the end of the log', async () => {
+    const panel = installScrollablePanel();
+    const baseViewModel = fakeViewModel({id: 'p-latest-reader' as any});
+    const viewModel = {...baseViewModel, game: {...baseViewModel.game, generation: 3}};
+    const wrapper = shallowMount(LogPanel, {
+      ...globalConfig,
+      props: {viewModel, color: 'blue'},
+    });
+    await flushLogs(wrapper);
+
+    (wrapper.vm as any).selectedGeneration = 1;
+    panel.setScrollTop(80);
+    await wrapper.find('[data-test="log-latest"]').trigger('click');
+    await flushLogs(wrapper);
+
+    expect((wrapper.vm as any).selectedGeneration).eq(3);
+    expect(fetchCalls[fetchCalls.length - 1]).includes('generation=3');
+    expect(panel.getScrollTop()).eq(520);
   });
 });

--- a/tests/client/components/logpanel/LogPanel.spec.ts
+++ b/tests/client/components/logpanel/LogPanel.spec.ts
@@ -97,32 +97,6 @@ describe('LogPanel', () => {
     expect(panel.getScrollTop()).eq(120);
   });
 
-  it('does not restore another participant\'s log state', async () => {
-    const panel = installScrollablePanel();
-    const firstViewModel = fakeViewModel({id: 'p-first-reader' as any});
-    const first = shallowMount(LogPanel, {
-      ...globalConfig,
-      props: {viewModel: firstViewModel, color: 'blue'},
-    });
-    await flushLogs(first);
-
-    (first.vm as any).selectedGeneration = 1;
-    panel.setScrollTop(80);
-    first.unmount();
-
-    const secondBase = fakeViewModel({id: 'p-second-reader' as any});
-    const secondViewModel = {...secondBase, game: {...secondBase.game, generation: 4}};
-    const second = shallowMount(LogPanel, {
-      ...globalConfig,
-      props: {viewModel: secondViewModel, color: 'red'},
-    });
-    await flushLogs(second);
-
-    expect((second.vm as any).selectedGeneration).eq(4);
-    expect(fetchCalls[fetchCalls.length - 1]).includes('generation=4');
-    expect(panel.getScrollTop()).eq(520);
-  });
-
   it('continues following the end after remount when already at the bottom', async () => {
     const panel = installScrollablePanel();
     const viewModel = fakeViewModel({id: 'p-log-follower' as any});

--- a/tests/client/components/logpanel/LogPanel.spec.ts
+++ b/tests/client/components/logpanel/LogPanel.spec.ts
@@ -119,6 +119,25 @@ describe('LogPanel', () => {
     expect(panel.getScrollTop()).eq(640);
   });
 
+  it('shows the scroll button only when away from the bottom', async () => {
+    const panel = installScrollablePanel();
+    const wrapper = shallowMount(LogPanel, {
+      ...globalConfig,
+      props: {viewModel: fakeViewModel(), color: 'blue'},
+    });
+    await flushLogs(wrapper);
+
+    expect((wrapper.vm as any).showScrollToBottomButton).is.false;
+
+    panel.setScrollTop(100);
+    await wrapper.find('#logpanel-scrollable').trigger('scroll');
+    expect((wrapper.vm as any).showScrollToBottomButton).is.true;
+
+    panel.setScrollTop(320);
+    await wrapper.find('#logpanel-scrollable').trigger('scroll');
+    expect((wrapper.vm as any).showScrollToBottomButton).is.false;
+  });
+
   it('returns to the current generation and the end of the log', async () => {
     const panel = installScrollablePanel();
     const baseViewModel = fakeViewModel({id: 'p-latest-reader' as any});


### PR DESCRIPTION
## Summary

Keeps the log where you were reading after game updates. The arrow returns to the latest logs.

## Demo

| Desktop | Mobile |
| --- | --- |
| ![Desktop](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-assets-log-view-refresh/.github/pr-assets/log-view-refresh/desktop.png) | ![Mobile](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-assets-log-view-refresh/.github/pr-assets/log-view-refresh/mobile.png) |

## Testing

- LogPanel tests
- lint and build

No gameplay changes.
