### PR TITLE
Feature/mobile start screen

### DIFF
--- a/src/client/components/LanguageIcon.vue
+++ b/src/client/components/LanguageIcon.vue
@@ -28,6 +28,19 @@ export default defineComponent({
       languagePanelOpen: false,
     };
   },
+  mounted() {
+    document.addEventListener('click', this.closeOnOutsideClick);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.closeOnOutsideClick);
+  },
+  methods: {
+    closeOnOutsideClick(event: MouseEvent) {
+      if (this.languagePanelOpen && event.target instanceof Node && !this.$el.contains(event.target)) {
+        this.languagePanelOpen = false;
+      }
+    },
+  },
   computed: {
     preferencesManager(): PreferencesManager {
       return PreferencesManager.INSTANCE;

--- a/src/client/components/LanguageIcon.vue
+++ b/src/client/components/LanguageIcon.vue
@@ -1,3 +1,16 @@
+<template>
+  <div ref="root" class="sidebar_item sidebar_item--language" :title="$t('Language')">
+    <div
+      class="sidebar_icon sidebar_icon--language"
+      :class="{'sidebar_item--is-active': languagePanelOpen}">
+      <div :class="`language-icon language-icon-for-sidebar language-icon--${lang}`"
+      :title="title"
+      @click="languagePanelOpen = !languagePanelOpen"></div>
+      </div>
+    <LanguageSelectionDialog v-show="languagePanelOpen" :preferencesManager="PreferencesManager.INSTANCE"/>
+  </div>
+</template>
+
 <script setup lang="ts">
 
 import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
@@ -22,16 +35,3 @@ function closeOnOutsideClick(event: MouseEvent) {
 onMounted(() => document.addEventListener('click', closeOnOutsideClick));
 onBeforeUnmount(() => document.removeEventListener('click', closeOnOutsideClick));
 </script>
-
-<template>
-  <div ref="root" class="sidebar_item sidebar_item--language" :title="$t('Language')">
-    <div
-      class="sidebar_icon sidebar_icon--language"
-      :class="{'sidebar_item--is-active': languagePanelOpen}">
-      <div :class="`language-icon language-icon-for-sidebar language-icon--${lang}`"
-      :title="title"
-      @click="languagePanelOpen = !languagePanelOpen"></div>
-      </div>
-    <LanguageSelectionDialog v-show="languagePanelOpen" :preferencesManager="PreferencesManager.INSTANCE"/>
-  </div>
-</template>

--- a/src/client/components/LanguageIcon.vue
+++ b/src/client/components/LanguageIcon.vue
@@ -1,5 +1,30 @@
+<script setup lang="ts">
+
+import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
+import {PreferencesManager} from '@/client/utils/PreferencesManager';
+import LanguageSelectionDialog from '@/client/components/LanguageSelectionDialog.vue';
+import {LANGUAGES} from '@/common/constants';
+
+const root = ref<HTMLElement>();
+const languagePanelOpen = ref(false);
+const lang = computed(() => PreferencesManager.INSTANCE.values().lang as keyof typeof LANGUAGES);
+const title = computed(() => {
+  const language = LANGUAGES[lang.value];
+  return `${language[0]} (${language[1]})`;
+});
+
+function closeOnOutsideClick(event: MouseEvent) {
+  if (languagePanelOpen.value && event.target instanceof Node && root.value?.contains(event.target) === false) {
+    languagePanelOpen.value = false;
+  }
+}
+
+onMounted(() => document.addEventListener('click', closeOnOutsideClick));
+onBeforeUnmount(() => document.removeEventListener('click', closeOnOutsideClick));
+</script>
+
 <template>
-  <div class="sidebar_item sidebar_item--language" :title="$t('Language')">
+  <div ref="root" class="sidebar_item sidebar_item--language" :title="$t('Language')">
     <div
       class="sidebar_icon sidebar_icon--language"
       :class="{'sidebar_item--is-active': languagePanelOpen}">
@@ -7,52 +32,6 @@
       :title="title"
       @click="languagePanelOpen = !languagePanelOpen"></div>
       </div>
-    <LanguageSelectionDialog v-show="languagePanelOpen" :preferencesManager="preferencesManager"/>
+    <LanguageSelectionDialog v-show="languagePanelOpen" :preferencesManager="PreferencesManager.INSTANCE"/>
   </div>
 </template>
-
-<script lang="ts">
-
-import {defineComponent} from 'vue';
-import {PreferencesManager} from '@/client/utils/PreferencesManager';
-import LanguageSelectionDialog from '@/client/components/LanguageSelectionDialog.vue';
-import {LANGUAGES} from '@/common/constants';
-
-export default defineComponent({
-  name: 'LanguageIcon',
-  components: {
-    LanguageSelectionDialog,
-  },
-  data() {
-    return {
-      languagePanelOpen: false,
-    };
-  },
-  mounted() {
-    document.addEventListener('click', this.closeOnOutsideClick);
-  },
-  beforeUnmount() {
-    document.removeEventListener('click', this.closeOnOutsideClick);
-  },
-  methods: {
-    closeOnOutsideClick(event: MouseEvent) {
-      if (this.languagePanelOpen && event.target instanceof Node && !this.$el.contains(event.target)) {
-        this.languagePanelOpen = false;
-      }
-    },
-  },
-  computed: {
-    preferencesManager(): PreferencesManager {
-      return PreferencesManager.INSTANCE;
-    },
-    lang(): keyof typeof LANGUAGES {
-      return PreferencesManager.INSTANCE.values().lang as keyof typeof LANGUAGES;
-    },
-    title(): string {
-      const lang = LANGUAGES[this.lang];
-      return `${lang[0]} (${lang[1]})`;
-    },
-  },
-});
-
-</script>

--- a/src/client/components/PreferencesIcon.vue
+++ b/src/client/components/PreferencesIcon.vue
@@ -1,3 +1,10 @@
+<template>
+  <div ref="root" class="sidebar_item sidebar_item--settings">
+    <i class="sidebar_icon sidebar_icon--settings" :title="$t('Player Settings')" :class="{'sidebar_item--is-active': preferencesPanelOpen}" @click="preferencesPanelOpen = !preferencesPanelOpen"></i>
+    <PreferencesDialog v-show="preferencesPanelOpen" @okButtonClicked="preferencesPanelOpen = false" :preferencesManager="PreferencesManager.INSTANCE"/>
+  </div>
+</template>
+
 <script setup lang="ts">
 
 import {onBeforeUnmount, onMounted, ref} from 'vue';
@@ -17,9 +24,3 @@ onMounted(() => document.addEventListener('click', closeOnOutsideClick));
 onBeforeUnmount(() => document.removeEventListener('click', closeOnOutsideClick));
 
 </script>
-<template>
-  <div ref="root" class="sidebar_item sidebar_item--settings">
-    <i class="sidebar_icon sidebar_icon--settings" :title="$t('Player Settings')" :class="{'sidebar_item--is-active': preferencesPanelOpen}" @click="preferencesPanelOpen = !preferencesPanelOpen"></i>
-    <PreferencesDialog v-show="preferencesPanelOpen" @okButtonClicked="preferencesPanelOpen = false" :preferencesManager="PreferencesManager.INSTANCE"/>
-  </div>
-</template>

--- a/src/client/components/PreferencesIcon.vue
+++ b/src/client/components/PreferencesIcon.vue
@@ -21,6 +21,19 @@ export default defineComponent({
       preferencesPanelOpen: false,
     };
   },
+  mounted() {
+    document.addEventListener('click', this.closeOnOutsideClick);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.closeOnOutsideClick);
+  },
+  methods: {
+    closeOnOutsideClick(event: MouseEvent) {
+      if (this.preferencesPanelOpen && event.target instanceof Node && !this.$el.contains(event.target)) {
+        this.preferencesPanelOpen = false;
+      }
+    },
+  },
   computed: {
     preferencesManager(): PreferencesManager {
       return PreferencesManager.INSTANCE;

--- a/src/client/components/PreferencesIcon.vue
+++ b/src/client/components/PreferencesIcon.vue
@@ -1,44 +1,25 @@
-<template>
-  <div class="sidebar_item sidebar_item--settings">
-    <i class="sidebar_icon sidebar_icon--settings" :title="$t('Player Settings')" :class="{'sidebar_item--is-active': preferencesPanelOpen}" @click="preferencesPanelOpen = !preferencesPanelOpen"></i>
-    <PreferencesDialog v-show="preferencesPanelOpen" @okButtonClicked="preferencesPanelOpen = false" :preferencesManager="preferencesManager"/>
-  </div>
-</template>
+<script setup lang="ts">
 
-<script lang="ts">
-
-import {defineComponent} from 'vue';
+import {onBeforeUnmount, onMounted, ref} from 'vue';
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 import PreferencesDialog from '@/client/components/PreferencesDialog.vue';
 
-export default defineComponent({
-  name: 'PreferencesIcon',
-  components: {
-    PreferencesDialog,
-  },
-  data() {
-    return {
-      preferencesPanelOpen: false,
-    };
-  },
-  mounted() {
-    document.addEventListener('click', this.closeOnOutsideClick);
-  },
-  beforeUnmount() {
-    document.removeEventListener('click', this.closeOnOutsideClick);
-  },
-  methods: {
-    closeOnOutsideClick(event: MouseEvent) {
-      if (this.preferencesPanelOpen && event.target instanceof Node && !this.$el.contains(event.target)) {
-        this.preferencesPanelOpen = false;
-      }
-    },
-  },
-  computed: {
-    preferencesManager(): PreferencesManager {
-      return PreferencesManager.INSTANCE;
-    },
-  },
-});
+const root = ref<HTMLElement>();
+const preferencesPanelOpen = ref(false);
+
+function closeOnOutsideClick(event: MouseEvent) {
+  if (preferencesPanelOpen.value && event.target instanceof Node && root.value?.contains(event.target) === false) {
+    preferencesPanelOpen.value = false;
+  }
+}
+
+onMounted(() => document.addEventListener('click', closeOnOutsideClick));
+onBeforeUnmount(() => document.removeEventListener('click', closeOnOutsideClick));
 
 </script>
+<template>
+  <div ref="root" class="sidebar_item sidebar_item--settings">
+    <i class="sidebar_icon sidebar_icon--settings" :title="$t('Player Settings')" :class="{'sidebar_item--is-active': preferencesPanelOpen}" @click="preferencesPanelOpen = !preferencesPanelOpen"></i>
+    <PreferencesDialog v-show="preferencesPanelOpen" @okButtonClicked="preferencesPanelOpen = false" :preferencesManager="PreferencesManager.INSTANCE"/>
+  </div>
+</template>

--- a/src/client/components/StartScreen.vue
+++ b/src/client/components/StartScreen.vue
@@ -44,10 +44,10 @@ import * as constants from '@/common/constants';
 
 const previousViewport = ref('');
 
+// Set the viewport width to width=device-width on the start screen so mobile browsers use their actual CSS viewport width.
 // The current global viewport is width=1260, which prevents the home page from using the device width on phones.
-// On the start screen, this code changes it to width=device-width, so mobile browsers use their actual CSS viewport width.
 // This is a temporary solution in order to make this edit scoped to the start screen.
-// Once responsiveness covers the whole project, this code should be removed and the <meta name="viewport" content='width=1260, user-scalable=1' /> tag in index.html should be updated directly.
+// TODO: Once responsiveness covers the whole project, this code should be removed and the tag in index.html should be updated directly.
 onMounted(() => {
   const viewport = document.querySelector('meta[name="viewport"]');
   if (viewport !== null) {

--- a/src/client/components/StartScreen.vue
+++ b/src/client/components/StartScreen.vue
@@ -1,3 +1,38 @@
+<template>
+<div class="start-screen">
+  <div v-i18n class="start-screen-links">
+    <div class="start-screen-header start-screen-link--title">
+      <div class="start-screen-title-top">TERRAFORMING</div>
+      <div class="start-screen-title-bottom">MARS</div>
+    </div>
+    <a class="start-screen-link start-screen-link--new-game" href="new-game" v-i18n>New game</a>
+    <a class="start-screen-link start-screen-link--how-to-play" href="https://github.com/terraforming-mars/terraforming-mars/wiki/Rulebooks" target="_blank" v-i18n>How to Play</a>
+    <a class="start-screen-link start-screen-link--cards-list" href="cards" target="_blank" v-i18n>Cards list</a>
+    <a class="start-screen-link start-screen-link--board-game" href="https://boardgamegeek.com/boardgame/167791/terraforming-mars" target="_blank" v-i18n>Board game</a>
+    <a class="start-screen-link start-screen-link--about" href="https://github.com/terraforming-mars/terraforming-mars#README" target="_blank" v-i18n>About us</a>
+    <a class="start-screen-link start-screen-link--changelog" href="https://github.com/terraforming-mars/terraforming-mars/wiki/Changelog" target="_blank" v-i18n>Whats new?</a>
+    <a class="start-screen-link start-screen-link--chat" :href="DISCORD_INVITE" target="_blank" v-i18n>Join us on Discord</a>
+    <div class="start-screen-header start-screen-link--languages">
+      <LanguageSwitcher />
+      <div class="start-screen-version-cont">
+        <div class="nowrap start-screen-date"><span v-i18n>deployed</span>: {{raw_settings.builtAt}}</div>
+        <div class="nowrap start-screen-version"><span v-i18n>version</span>: {{raw_settings.head}}</div>
+      </div>
+      <div class="source-code">
+        <a href="https://github.com/terraforming-mars/terraforming-mars" target="_blank" class="source-code-text">
+        <img src="assets/misc/github.png" class="source-code-img">
+          source code
+        </a>
+      </div>
+    </div>
+  </div>
+  <div class="free-floating-preferences-icon">
+    <LanguageIcon class="corner-language-icon"/>
+    <PreferencesIcon/>
+  </div>
+</div>
+</template>
+
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 import LanguageSwitcher from '@/client/components/LanguageSwitcher.vue';
@@ -32,87 +67,3 @@ onBeforeUnmount(() => {
 
 const DISCORD_INVITE = constants.DISCORD_INVITE;
 </script>
-
-<template>
-  <div class="start-screen">
-    <div v-i18n class="start-screen-links">
-      <div class="start-screen-header start-screen-link--title">
-        <div class="start-screen-title-top">TERRAFORMING</div>
-        <div class="start-screen-title-bottom">MARS</div>
-      </div>
-      <a
-        class="start-screen-link start-screen-link--new-game"
-        href="new-game"
-        v-i18n
-        >New game</a
-      >
-      <a
-        class="start-screen-link start-screen-link--how-to-play"
-        href="https://github.com/terraforming-mars/terraforming-mars/wiki/Rulebooks"
-        target="_blank"
-        v-i18n
-        >How to Play</a
-      >
-      <a
-        class="start-screen-link start-screen-link--cards-list"
-        href="cards"
-        target="_blank"
-        v-i18n
-        >Cards list</a
-      >
-      <a
-        class="start-screen-link start-screen-link--board-game"
-        href="https://boardgamegeek.com/boardgame/167791/terraforming-mars"
-        target="_blank"
-        v-i18n
-        >Board game</a
-      >
-      <a
-        class="start-screen-link start-screen-link--about"
-        href="https://github.com/terraforming-mars/terraforming-mars#README"
-        target="_blank"
-        v-i18n
-        >About us</a
-      >
-      <a
-        class="start-screen-link start-screen-link--changelog"
-        href="https://github.com/terraforming-mars/terraforming-mars/wiki/Changelog"
-        target="_blank"
-        v-i18n
-        >Whats new?</a
-      >
-      <a
-        class="start-screen-link start-screen-link--chat"
-        :href="DISCORD_INVITE"
-        target="_blank"
-        v-i18n
-        >Join us on Discord</a
-      >
-      <div class="start-screen-header start-screen-link--languages">
-        <LanguageSwitcher />
-        <div class="start-screen-version-cont">
-          <div class="nowrap start-screen-date">
-            <span v-i18n>deployed</span>: {{ raw_settings.builtAt }}
-          </div>
-          <div class="nowrap start-screen-version">
-            <span v-i18n>version</span>: {{ raw_settings.head }}
-          </div>
-        </div>
-        <div class="source-code">
-          <a
-            href="https://github.com/terraforming-mars/terraforming-mars"
-            target="_blank"
-            class="source-code-text"
-          >
-            <img src="assets/misc/github.png" class="source-code-img" >
-            source code
-          </a>
-        </div>
-      </div>
-    </div>
-    <div class="free-floating-preferences-icon">
-      <LanguageIcon class="corner-language-icon" />
-      <PreferencesIcon />
-    </div>
-  </div>
-</template>

--- a/src/client/components/StartScreen.vue
+++ b/src/client/components/StartScreen.vue
@@ -9,8 +9,10 @@ import * as constants from '@/common/constants';
 
 const previousViewport = ref('');
 
-// Temporary: keep the responsive viewport limited to the homepage. Once responsiveness covers the
-// whole project, update <meta name="viewport" content='width=1260, user-scalable=1' /> directly.
+// The current global viewport is width=1260, which prevents the home page from using the device width on phones.
+// On the start screen, this code changes it to width=device-width, so mobile browsers use their actual CSS viewport width.
+// This is a temporary solution in order to make this edit scoped to the start screen.
+// Once responsiveness covers the whole project, this code should be removed and the <meta name="viewport" content='width=1260, user-scalable=1' /> tag in index.html should be updated directly.
 onMounted(() => {
   const viewport = document.querySelector('meta[name="viewport"]');
   if (viewport !== null) {

--- a/src/client/components/StartScreen.vue
+++ b/src/client/components/StartScreen.vue
@@ -1,41 +1,5 @@
-<template>
-<div class="start-screen">
-  <div v-i18n class="start-screen-links">
-    <div class="start-screen-header start-screen-link--title">
-      <div class="start-screen-title-top">TERRAFORMING</div>
-      <div class="start-screen-title-bottom">MARS</div>
-    </div>
-    <a class="start-screen-link start-screen-link--new-game" href="new-game" v-i18n>New game</a>
-    <a class="start-screen-link start-screen-link--how-to-play" href="https://github.com/terraforming-mars/terraforming-mars/wiki/Rulebooks" target="_blank" v-i18n>How to Play</a>
-    <a class="start-screen-link start-screen-link--cards-list" href="cards" target="_blank" v-i18n>Cards list</a>
-    <a class="start-screen-link start-screen-link--board-game" href="https://boardgamegeek.com/boardgame/167791/terraforming-mars" target="_blank" v-i18n>Board game</a>
-    <a class="start-screen-link start-screen-link--about" href="https://github.com/terraforming-mars/terraforming-mars#README" target="_blank" v-i18n>About us</a>
-    <a class="start-screen-link start-screen-link--changelog" href="https://github.com/terraforming-mars/terraforming-mars/wiki/Changelog" target="_blank" v-i18n>Whats new?</a>
-    <a class="start-screen-link start-screen-link--chat" :href="DISCORD_INVITE" target="_blank" v-i18n>Join us on Discord</a>
-    <div class="start-screen-header start-screen-link--languages">
-      <LanguageSwitcher />
-      <div class="start-screen-version-cont">
-        <div class="nowrap start-screen-date"><span v-i18n>deployed</span>: {{raw_settings.builtAt}}</div>
-        <div class="nowrap start-screen-version"><span v-i18n>version</span>: {{raw_settings.head}}</div>
-      </div>
-      <div class="source-code">
-        <a href="https://github.com/terraforming-mars/terraforming-mars" target="_blank" class="source-code-text">
-        <img src="assets/misc/github.png" class="source-code-img">
-          source code
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="free-floating-preferences-icon">
-    <LanguageIcon class="corner-language-icon"/>
-    <PreferencesIcon/>
-  </div>
-</div>
-</template>
-
-<script lang="ts">
-
-import {defineComponent} from 'vue';
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue';
 import LanguageSwitcher from '@/client/components/LanguageSwitcher.vue';
 import LanguageIcon from '@/client/components/LanguageIcon.vue';
 import PreferencesIcon from '@/client/components/PreferencesIcon.vue';
@@ -43,40 +7,110 @@ import PreferencesIcon from '@/client/components/PreferencesIcon.vue';
 import raw_settings from '@/genfiles/settings.json';
 import * as constants from '@/common/constants';
 
-export default defineComponent({
-  name: 'StartScreen',
-  components: {
-    LanguageSwitcher,
-    LanguageIcon,
-    PreferencesIcon,
-  },
-  data() {
-    return {
-      previousViewport: '',
-    };
-  },
+const previousViewport = ref('');
 
-  mounted() {
-    // Temporary: keep the responsive viewport limited to the homepage. Once responsiveness covers the
-    // whole project, update <meta name="viewport" content='width=1260, user-scalable=1' /> directly.
-    const viewport = document.querySelector('meta[name="viewport"]');
-    if (viewport !== null) {
-      this.previousViewport = viewport.getAttribute('content') ?? '';
-      viewport.setAttribute('content', 'width=device-width, initial-scale=1, viewport-fit=cover');
-    }
-  },
-
-  beforeUnmount() {
-    document.querySelector('meta[name="viewport"]')?.setAttribute('content', this.previousViewport);
-  },
-  computed: {
-    raw_settings(): typeof raw_settings {
-      return raw_settings;
-    },
-    DISCORD_INVITE(): string {
-      return constants.DISCORD_INVITE;
-    },
-  },
+// Temporary: keep the responsive viewport limited to the homepage. Once responsiveness covers the
+// whole project, update <meta name="viewport" content='width=1260, user-scalable=1' /> directly.
+onMounted(() => {
+  const viewport = document.querySelector('meta[name="viewport"]');
+  if (viewport !== null) {
+    previousViewport.value = viewport.getAttribute('content') ?? '';
+    viewport.setAttribute(
+      'content',
+      'width=device-width, initial-scale=1, viewport-fit=cover',
+    );
+  }
 });
 
+onBeforeUnmount(() => {
+  document
+    .querySelector('meta[name="viewport"]')
+    ?.setAttribute('content', previousViewport.value);
+});
+
+const DISCORD_INVITE = constants.DISCORD_INVITE;
 </script>
+
+<template>
+  <div class="start-screen">
+    <div v-i18n class="start-screen-links">
+      <div class="start-screen-header start-screen-link--title">
+        <div class="start-screen-title-top">TERRAFORMING</div>
+        <div class="start-screen-title-bottom">MARS</div>
+      </div>
+      <a
+        class="start-screen-link start-screen-link--new-game"
+        href="new-game"
+        v-i18n
+        >New game</a
+      >
+      <a
+        class="start-screen-link start-screen-link--how-to-play"
+        href="https://github.com/terraforming-mars/terraforming-mars/wiki/Rulebooks"
+        target="_blank"
+        v-i18n
+        >How to Play</a
+      >
+      <a
+        class="start-screen-link start-screen-link--cards-list"
+        href="cards"
+        target="_blank"
+        v-i18n
+        >Cards list</a
+      >
+      <a
+        class="start-screen-link start-screen-link--board-game"
+        href="https://boardgamegeek.com/boardgame/167791/terraforming-mars"
+        target="_blank"
+        v-i18n
+        >Board game</a
+      >
+      <a
+        class="start-screen-link start-screen-link--about"
+        href="https://github.com/terraforming-mars/terraforming-mars#README"
+        target="_blank"
+        v-i18n
+        >About us</a
+      >
+      <a
+        class="start-screen-link start-screen-link--changelog"
+        href="https://github.com/terraforming-mars/terraforming-mars/wiki/Changelog"
+        target="_blank"
+        v-i18n
+        >Whats new?</a
+      >
+      <a
+        class="start-screen-link start-screen-link--chat"
+        :href="DISCORD_INVITE"
+        target="_blank"
+        v-i18n
+        >Join us on Discord</a
+      >
+      <div class="start-screen-header start-screen-link--languages">
+        <LanguageSwitcher />
+        <div class="start-screen-version-cont">
+          <div class="nowrap start-screen-date">
+            <span v-i18n>deployed</span>: {{ raw_settings.builtAt }}
+          </div>
+          <div class="nowrap start-screen-version">
+            <span v-i18n>version</span>: {{ raw_settings.head }}
+          </div>
+        </div>
+        <div class="source-code">
+          <a
+            href="https://github.com/terraforming-mars/terraforming-mars"
+            target="_blank"
+            class="source-code-text"
+          >
+            <img src="assets/misc/github.png" class="source-code-img" >
+            source code
+          </a>
+        </div>
+      </div>
+    </div>
+    <div class="free-floating-preferences-icon">
+      <LanguageIcon class="corner-language-icon" />
+      <PreferencesIcon />
+    </div>
+  </div>
+</template>

--- a/src/client/components/StartScreen.vue
+++ b/src/client/components/StartScreen.vue
@@ -50,6 +50,25 @@ export default defineComponent({
     LanguageIcon,
     PreferencesIcon,
   },
+  data() {
+    return {
+      previousViewport: '',
+    };
+  },
+
+  mounted() {
+    // Temporary: keep the responsive viewport limited to the homepage. Once responsiveness covers the
+    // whole project, update <meta name="viewport" content='width=1260, user-scalable=1' /> directly.
+    const viewport = document.querySelector('meta[name="viewport"]');
+    if (viewport !== null) {
+      this.previousViewport = viewport.getAttribute('content') ?? '';
+      viewport.setAttribute('content', 'width=device-width, initial-scale=1, viewport-fit=cover');
+    }
+  },
+
+  beforeUnmount() {
+    document.querySelector('meta[name="viewport"]')?.setAttribute('content', this.previousViewport);
+  },
   computed: {
     raw_settings(): typeof raw_settings {
       return raw_settings;

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -81,9 +81,10 @@
     margin-top: -5px;
   }
 
-  .checkmark{
+  .checkmark {
     display: inline-block;
-    filter: invert(92%) sepia(11%) saturate(1093%) hue-rotate(46deg) brightness(98%) contrast(85%);
+    filter: invert(92%) sepia(11%) saturate(1093%) hue-rotate(46deg)
+      brightness(98%) contrast(85%);
     width: 18px;
     height: 18px;
   }
@@ -122,7 +123,13 @@
 }
 
 .preferences_acting_player {
-  background: linear-gradient(180deg, @grey_850 0%, @grey_850 25%, #745B54 80%, #745B54 100%);
+  background: linear-gradient(
+    180deg,
+    @grey_850 0%,
+    @grey_850 25%,
+    #745b54 80%,
+    #745b54 100%
+  );
 }
 .preferences_nonacting_player {
   background: @grey_850;
@@ -158,7 +165,7 @@
   bottom: 111px;
   left: 0px;
   margin-left: 7px;
-  height: 46px
+  height: 46px;
 }
 
 .sidebar_item--help {
@@ -166,7 +173,7 @@
   bottom: 60px;
   left: 0px;
   margin-left: 7px;
-  height: 46px
+  height: 46px;
 }
 
 .sidebar_item--settings {
@@ -174,7 +181,6 @@
   bottom: 4px;
   height: 46px;
 }
-
 
 .preferences_player {
   writing-mode: vertical-rl;
@@ -274,7 +280,6 @@
   }
 }
 
-
 .sidebar_item--is-active::after {
   content: " ";
   width: 10px;
@@ -309,12 +314,12 @@
 
 /*Selection check box room for smaller cards */
 .preferences_small_cards input[type="checkbox"] + .filterDiv.card-container,
-.preferences_small_cards input[type="radio"] + .filterDiv.card-container{
+.preferences_small_cards input[type="radio"] + .filterDiv.card-container {
   margin-top: -8px;
 }
 
 .preferences_small_cards input[type="checkbox"] + .filterDiv.card-standard-project,
-.preferences_small_cards input[type="radio"] + .filterDiv.card-standard-project{
+.preferences_small_cards input[type="radio"] + .filterDiv.card-standard-project {
   margin-top: 0px;
 }
 
@@ -372,11 +377,11 @@
   transform: scale(0.95);
 }
 
-.info_panel-spacing{
+.info_panel-spacing {
   padding-bottom: 40px;
 }
 
-.info-panel-title{
+.info-panel-title {
   font-size: 25px;
   font-style: normal;
   font-family: Arial, sans-serif;
@@ -448,5 +453,38 @@
   }
   a {
     color: blue;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .preferences_panel:not(.preferences_panel--language-switcher),
+  .preferences_panel.preferences_panel--language-switcher {
+    box-sizing: border-box;
+    position: fixed;
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    z-index: 110;
+    width: auto;
+    max-height: calc(100dvh - 16px);
+    overflow-x: hidden;
+    white-space: normal;
+  }
+
+  .corner-language-icon.sidebar_item--language
+  .preferences_panel.preferences_panel--language-switcher {
+    left: 8px;
+    bottom: 8px;
+  }
+
+  .preferences_panel_item label {
+    white-space: normal;
+    line-height: 1.35;
+  }
+
+  .preferences_panel_actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
   }
 }

--- a/src/styles/start_screen.less
+++ b/src/styles/start_screen.less
@@ -32,7 +32,9 @@
   line-height: 28px;
   border-radius: 10px;
   color: #eee;
-  text-shadow: 0 0 2px black, 0 2px 1px black;
+  text-shadow:
+    0 0 2px black,
+    0 2px 1px black;
   padding-left: 17px;
   width: 369px;
   height: 90px;
@@ -46,7 +48,10 @@
   flex-direction: column-reverse;
   background-image: url("assets/buttons-homepage/planets.jpg");
 
-  &:hover, &:visited, &:active, &:focus {
+  &:hover,
+  &:visited,
+  &:active,
+  &:focus {
     color: #eee;
     text-decoration: none;
   }
@@ -64,7 +69,9 @@
   line-height: 30px;
   color: #daab63;
   display: block;
-  text-shadow: 0 0 2px black, 0 2px 2px black;
+  text-shadow:
+    0 0 2px black,
+    0 2px 2px black;
   letter-spacing: 1px;
   background: url("assets/buttons-homepage/planets.jpg") no-repeat;
 }
@@ -143,7 +150,9 @@
 .source-code-text {
   color: white;
   font-size: smaller;
-  text-shadow: 0 0 2px darkgrey, 0 2px 2px darkgrey;
+  text-shadow:
+    0 0 2px darkgrey,
+    0 2px 2px darkgrey;
   letter-spacing: 0.25rem;
   text-decoration: none;
 }
@@ -158,4 +167,83 @@
 
 .source-code-text:visited {
   color: white;
+}
+
+@media only screen and (max-width: 1023px) {
+  .topmost-start-screen {
+    min-height: 100dvh;
+
+    .main-container {
+      margin: 0;
+    }
+  }
+
+  .start-screen {
+    box-sizing: border-box;
+    width: calc(100% - 64px);
+    max-width: 520px;
+  }
+
+  .start-screen-link,
+  .start-screen-header {
+    box-sizing: border-box;
+    width: 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 900%;
+  }
+
+  .start-screen-title-top,
+  .start-screen-title-bottom {
+    transform: none;
+    white-space: nowrap;
+  }
+
+  .start-screen-link--languages {
+    background-size: 100% 810px;
+    background-position: center -720px;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .topmost-start-screen {
+    overflow-x: clip;
+    padding-bottom: max(40px, env(safe-area-inset-bottom));
+
+    .notice {
+      position: static;
+      padding: 16px;
+      text-align: center;
+    }
+  }
+
+  .start-screen {
+    width: calc(100% - 32px);
+    max-width: 400px;
+  }
+
+  .start-screen-links {
+    padding-top: max(24px, env(safe-area-inset-top));
+  }
+
+  .start-screen-link {
+    min-height: 90px;
+    height: 90px;
+    padding: 12px 16px;
+    font-size: 20px;
+  }
+}
+
+@media only screen and (min-width: 768px) and (max-width: 1023px) {
+  .start-screen-link {
+    height: 104px;
+    font-size: 28px;
+  }
+
+  .start-screen-title-top {
+    font-size: 20px;
+  }
+
+  .start-screen-title-bottom {
+    font-size: 38px;
+  }
 }


### PR DESCRIPTION
## Summary

This PR improves the responsiveness of the start screen on smaller devices.

### Changes

- improve layout on small screens
- reduce horizontal scrolling
- better spacing for mobile devices
- makes space for preferences dialog
- introduces "click outside dialog" to close preferences dialogs (since in mobile view its )
- preserve desktop layout and all other pages
- migrated encountered components to <script setup>

**From**
<img width="282" height="623" alt="image" src="https://github.com/user-attachments/assets/6f68330c-f056-400b-af61-cb5ce1497f39" />

**To**
<img width="279" height="619" alt="image" src="https://github.com/user-attachments/assets/dab73e7a-465f-4ac6-b6e0-1a9adf3c20d2" />



Closes #8361
