### PR TITLE
Fix typos in Dutch translations in ui.json

### DIFF
--- a/src/locales/nl/ui.json
+++ b/src/locales/nl/ui.json
@@ -31,7 +31,7 @@
     "tharsis": "",
     "hellas": "",
     "elysium": "",
-    "random official": "Willekeurig (officiëel)",
+    "random official": "Willekeurig (officieel)",
     "random all": "Willekeurig (alle)",
     "random": "Willekeurig",
 
@@ -418,7 +418,7 @@
     "Add microbe": "Voeg een microbe toe",
     "Place your tile here?": "Wil je hier je tegel plaatsen?",
     "Pay with Megacredits": "Betaal met M€",
-    "Pay with Titanium": "Betaal met Titatium",
+    "Pay with Titanium": "Betaal met Titanium",
     "Pay with Steel": "Betaal met Staal",
     "Pay with Heat": "Betaal met Warmte",
     "Pay with Microbes": "Betaal met Microbes",


### PR DESCRIPTION
I fixed two spelling errors in the Dutch UI translation:

- `officiëel` -> `officieel`
- `Titatium` -> `Titanium`