### PR TITLE
Log Electro Catapult resource spend

### DIFF
--- a/src/server/cards/base/ElectroCatapult.ts
+++ b/src/server/cards/base/ElectroCatapult.ts
@@ -5,6 +5,11 @@ import {CardType} from '../../../common/cards/CardType';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {max} from '../Options';
+import {IPlayer} from '../../IPlayer';
+import {OrOptions} from '../../inputs/OrOptions';
+import {SelectOption} from '../../inputs/SelectOption';
+import {Resource} from '../../../common/Resource';
+import {Payment} from '../../../common/inputs/Payment';
 
 export class ElectroCatapult extends ActionCard implements IProjectCard {
   constructor() {
@@ -49,8 +54,41 @@ export class ElectroCatapult extends ActionCard implements IProjectCard {
     });
   }
 
-  // KEEP THIS
-  // private log(player: IPlayer, resource: Resources) {
-  //   player.game.log('${0} spent 1 ${1} to gain 7 M€', (b) => b.player(player).string(resource));
-  // }
+  public override action(player: IPlayer) {
+    const options: Array<SelectOption> = [];
+
+    if (player.plants > 0) {
+      options.push(new SelectOption('Spend 1 plant to gain 7 M€.').andThen(() => {
+        this.spendAndGain(player, Resource.PLANTS);
+        return undefined;
+      }));
+    }
+
+    if (player.steel > 0) {
+      options.push(new SelectOption('Spend 1 steel to gain 7 M€.').andThen(() => {
+        this.spendAndGain(player, Resource.STEEL);
+        return undefined;
+      }));
+    }
+
+    if (options.length === 1) {
+      options[0].cb(undefined);
+      return undefined;
+    }
+
+    player.defer(new OrOptions(...options));
+    return undefined;
+  }
+
+  private spendAndGain(player: IPlayer, resource: Resource.PLANTS | Resource.STEEL) {
+    if (resource === Resource.PLANTS) {
+      player.stock.deduct(Resource.PLANTS, 1);
+    } else {
+      player.pay(Payment.of({steel: 1}));
+    }
+
+    player.stock.add(Resource.MEGACREDITS, 7);
+    player.game.log('${0} spent 1 ${1} to gain 7 M€', (b) =>
+      b.player(player).string(resource === Resource.PLANTS ? 'plant' : 'steel'));
+  }
 }

--- a/tests/cards/base/ElectroCatapult.spec.ts
+++ b/tests/cards/base/ElectroCatapult.spec.ts
@@ -4,7 +4,7 @@ import {IGame} from '../../../src/server/IGame';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {Resource} from '../../../src/common/Resource';
 import {TestPlayer} from '../../TestPlayer';
-import {churn, setOxygenLevel} from '../../TestingUtils';
+import {churn, formatMessage, setOxygenLevel} from '../../TestingUtils';
 import {testGame} from '../../TestGame';
 import {cast} from '../../../src/common/utils/utils';
 
@@ -41,19 +41,54 @@ describe('ElectroCatapult', () => {
     expect(player.production.energy).to.eq(0);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });
-  it('Should act', () => {
+  it('Should offer both resources and log the selected plant', () => {
     player.plants = 1;
     player.steel = 1;
+    game.gameLog = [];
 
     const orOptions = cast(churn(card.action(player), player), OrOptions);
     expect(orOptions.options).has.lengthOf(2);
 
     orOptions.options[0].cb();
     expect(player.plants).to.eq(0);
+    expect(player.steel).to.eq(1);
     expect(player.megaCredits).to.eq(7);
+    expect(game.gameLog.map(formatMessage)).deep.eq([
+      'blue spent 1 plant to gain 7 M€',
+    ]);
+    expect(game.gameLog[0].playerId).is.undefined;
+  });
+
+  it('Should offer both resources and log the selected steel', () => {
+    player.plants = 1;
+    player.steel = 1;
+    game.gameLog = [];
+
+    const orOptions = cast(churn(card.action(player), player), OrOptions);
+    expect(orOptions.options).has.lengthOf(2);
 
     orOptions.options[1].cb();
+    expect(player.plants).to.eq(1);
     expect(player.steel).to.eq(0);
+    expect(player.megaCredits).to.eq(7);
+    expect(game.gameLog.map(formatMessage)).deep.eq([
+      'blue spent 1 steel to gain 7 M€',
+    ]);
+    expect(game.gameLog[0].playerId).is.undefined;
+  });
+
+  it('Should auto-select and log each repeated action', () => {
+    player.plants = 2;
+    game.gameLog = [];
+
+    expect(card.action(player)).is.undefined;
+    expect(card.action(player)).is.undefined;
+
+    expect(player.plants).to.eq(0);
     expect(player.megaCredits).to.eq(14);
+    expect(game.gameLog.map(formatMessage)).deep.eq([
+      'blue spent 1 plant to gain 7 M€',
+      'blue spent 1 plant to gain 7 M€',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Log whether Electro Catapult spends 1 plant or 1 steel. Gameplay remains unchanged.

## Demo

### Before

The action only reports the 7 M€ gain, so the spent resource is unknown.

<img width="1200" height="301" alt="electro-catapult-before" src="https://github.com/user-attachments/assets/c38ab0e9-7c60-4e78-a459-f3dfc08afa4d" />

### After

Plant spent:

<img width="1200" height="301" alt="electro-catapult-plant" src="https://github.com/user-attachments/assets/d985d782-4093-4b37-a844-71b6a6900f62" />

Steel spent:

<img width="1200" height="301" alt="electro-catapult-steel" src="https://github.com/user-attachments/assets/59c6cfff-586b-4e3e-8e5c-d43b0bfdaba6" />

## Testing

- ElectroCatapult tests: 7 passing
- npm run build:tests
- npm run lint:server
- npm run lint:client
- npm run build