### PR TITLE
Log selected behavior resource spends in Executor

### DIFF
--- a/src/server/behavior/Behavior.ts
+++ b/src/server/behavior/Behavior.ts
@@ -47,6 +47,8 @@ export type Behavior = {
   spend?: Partial<OneOfType<Spend>> & {
     canUseSteel?: boolean,
     canUseTitanium?: boolean,
+    /** Log a direct steel, titanium, plant, or energy spend. */
+    log?: true,
   };
 
   /**

--- a/src/server/behavior/Executor.ts
+++ b/src/server/behavior/Executor.ts
@@ -382,6 +382,9 @@ export class Executor implements BehaviorExecutor {
       if (spend.energy) {
         player.stock.deduct(Resource.ENERGY, spend.energy);
       }
+      if (spend.log === true) {
+        this.logSpend(player, spend);
+      }
       if (spend.heat) {
         player.defer(player.spendHeat(spend.heat, () => {
           this.execute(remainder, player, card);
@@ -723,6 +726,22 @@ export class Executor implements BehaviorExecutor {
       .replaceAll('${player}', '${0}')
       .replaceAll('${card}', '${1}');
     player.game.log(replaced, (b) => b.player(player).card(card));
+  }
+
+  private logSpend(player: IPlayer, spend: NonNullable<Behavior['spend']>) {
+    const directSpend = [
+      {amount: spend.steel, resource: 'steel'},
+      {amount: spend.titanium, resource: 'titanium'},
+      {amount: spend.plants, resource: spend.plants === 1 ? 'plant' : 'plants'},
+      {amount: spend.energy, resource: 'energy'},
+    ].find((entry) => typeof entry.amount === 'number');
+
+    if (typeof directSpend?.amount !== 'number') {
+      throw new Error('Cannot log this type of behavior spend.');
+    }
+
+    const amount = directSpend.amount;
+    player.game.log('${0} spent ${1} ${2}', (b) => b.player(player).number(amount).string(directSpend.resource));
   }
 
   public onDiscard(behavior: Behavior, player: IPlayer, _card: ICard) {

--- a/src/server/cards/base/ElectroCatapult.ts
+++ b/src/server/cards/base/ElectroCatapult.ts
@@ -23,12 +23,12 @@ export class ElectroCatapult extends ActionCard implements IProjectCard {
           autoSelect: true,
           behaviors: [{
             title: 'Spend 1 plant to gain 7 M€.',
-            spend: {plants: 1},
+            spend: {plants: 1, log: true},
             stock: {megacredits: 7},
           },
           {
             title: 'Spend 1 steel to gain 7 M€.',
-            spend: {steel: 1},
+            spend: {steel: 1, log: true},
             stock: {megacredits: 7},
           }],
         },

--- a/tests/behavior/Executor.spec.ts
+++ b/tests/behavior/Executor.spec.ts
@@ -623,12 +623,14 @@ describe('Executor', () => {
   });
 
   it('spend - steel', () => {
-    const behavior = {spend: {steel: 1}};
+    const behavior: Behavior = {spend: {steel: 1, log: true}};
     expect(executor.canExecute(behavior, player, fake)).is.false;
     player.steel = 1;
     expect(executor.canExecute(behavior, player, fake)).is.true;
+    game.gameLog = [];
     executor.execute(behavior, player, fake);
     expect(player.steel).eq(0);
+    expect(game.gameLog.map(formatMessage)).deep.eq(['blue spent 1 steel']);
   });
 
   it('spend - titanium', () => {


### PR DESCRIPTION
## Summary

- add an opt-in `spend.log` flag to the declarative behavior DSL and emit the selected direct-resource spend from `Executor`
- enable that flag for Electro Catapult's plant and steel alternatives without overriding the card action
- preserve `player.pay` for steel/titanium and leave every unannotated `behavior.spend` unchanged

## Demo

Before, a complete Electro Catapult action only exposed the gain:

```text
blue gained 7 M€
```

On this commit, the full action produces:

```text
plant: blue spent 1 plant | blue gained 7 M€
steel: blue spent 1 steel | blue gained 7 M€
```

## Testing

- focused Executor + Electro Catapult tests: 86 passing
- full server suite: 7261 passing
- `npm run build:tests`
- `npm run lint:server`
- `npm run lint:client`
- `npm run build`
- upstream PR gate passed for `61826f87`

## Notes

This replaces the card-specific implementation from closed PR #8395 with the Executor-owned approach requested by the maintainer. Gameplay and resource selection are unchanged.