### PR TITLE
Feature/mobile new game screen

### DIFF
--- a/src/client/components/GameHome.vue
+++ b/src/client/components/GameHome.vue
@@ -74,10 +74,12 @@ export default defineComponent({
     GameSetupDetail,
     PurgeWarning,
   },
+
   data() {
     return {
       // Variable to keep the state for the current copied player id. Used to display message of which button and which player playable link is currently in the clipboard
       urlCopiedPlayerId: DEFAULT_COPIED_PLAYER_ID,
+      previousViewport: '',
     };
   },
   methods: {
@@ -129,8 +131,24 @@ export default defineComponent({
     // Reset the copied player id after 3 seconds to hide the "copied" message
     setInterval(this.setCopiedIdToDefault, 3000);
     setDocumentTitle(this.game.name);
+    // Set the viewport width to width=device-width on the create game form so mobile browsers use their actual CSS viewport width.
+    // The current global viewport is width=1260, which prevents the create game form from using the device width on phones.
+    // This is a temporary solution in order to make this edit scoped to the create game form.
+    // TODO: Once responsiveness covers the whole project, this code should be removed and the tag in index.html should be updated directly.
+    const viewport = document.querySelector('meta[name="viewport"]');
+    if (viewport !== null) {
+      this.previousViewport = viewport.getAttribute('content') ?? '';
+      viewport.setAttribute(
+        'content',
+        'width=device-width, initial-scale=1, viewport-fit=cover',
+      );
+    }
+  },
+  beforeUnmount() {
+    document
+      .querySelector('meta[name="viewport"]')
+      ?.setAttribute('content', this.previousViewport);
   },
 });
 
 </script>
-

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -613,6 +613,7 @@ type Refs = {
 type FormModel = {
   preludeToggled: boolean;
   uploading: boolean;
+  previousViewport: string;
 };
 
 export default defineComponent({
@@ -622,6 +623,7 @@ export default defineComponent({
       ...defaultCreateGameModel(),
       preludeToggled: false,
       uploading: false,
+      previousViewport: '',
     };
   },
   components: {
@@ -680,6 +682,24 @@ export default defineComponent({
   mounted() {
     setDocumentTitle('Create New Game');
     this.restoreLastSettings();
+
+    // Set the viewport width to width=device-width on the create game form so mobile browsers use their actual CSS viewport width.
+    // The current global viewport is width=1260, which prevents the create game form from using the device width on phones.
+    // This is a temporary solution in order to make this edit scoped to the create game form.
+    // TODO: Once responsiveness covers the whole project, this code should be removed and the tag in index.html should be updated directly.
+    const viewport = document.querySelector('meta[name="viewport"]');
+    if (viewport !== null) {
+      this.previousViewport = viewport.getAttribute('content') ?? '';
+      viewport.setAttribute(
+        'content',
+        'width=device-width, initial-scale=1, viewport-fit=cover',
+      );
+    }
+  },
+  beforeUnmount() {
+    document
+      .querySelector('meta[name="viewport"]')
+      ?.setAttribute('content', this.previousViewport);
   },
   computed: {
     wikiUrls(): typeof RULEBOOK_URLS & typeof WIKI_URLS {

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -87,6 +87,11 @@
   position: fixed;
   width: 0;
 }
+
+.create-game-page-column input:focus-visible + label {
+  outline: 3px solid #ffcc64;
+  outline-offset: 2px;
+}
 .create-game-page-column input[type="radio"] {
   opacity: 0;
   position: fixed;
@@ -300,5 +305,92 @@
 
   .changelog {
     padding: 0px 15px;
+  }
+}
+
+@media only screen and (max-width: 1023px) {
+  .topmost-create-game-form {
+    min-height: 100dvh;
+    overflow-x: clip;
+
+    .main-container {
+      margin: 0;
+    }
+
+    .notice {
+      position: static;
+      padding: 16px;
+      text-align: center;
+    }
+  }
+
+  .create-game {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 12px;
+  }
+
+  .create-game--block {
+    margin: 16px 0 0;
+    padding: 0px 10px;
+  }
+
+  .create-game-page-container {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .create-game-page-column {
+    min-width: 0;
+    padding: 16px;
+
+    label {
+      min-height: 52px;
+      height: auto;
+      padding: 6px 12px;
+      font-size: 18px;
+      line-height: 1.25;
+      align-items: center;
+    }
+  }
+
+  .create-game-players-cont,
+  .create-game-action {
+    grid-column: 1 / -1;
+  }
+
+  .create-game-action {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    padding: 10px;
+    background: #000000;
+
+    .btn {
+      min-height: 44px;
+    }
+  }
+
+  .create-game-player {
+    width: 100%;
+    padding: 16px;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+
+  .create-game {
+    h1 {
+      font-size: 28px;
+      line-height: 1.15;
+    }
+  }
+
+  .create-game-page-container,
+  .create-game-page-column {
+    display: block;
   }
 }

--- a/src/styles/game_home.less
+++ b/src/styles/game_home.less
@@ -89,3 +89,80 @@
     }
   }
 }
+
+@media only screen and (max-width: 1023px) {
+  
+  .topmost-game-home {
+    min-height: 100dvh;
+
+    .main-container {
+      margin: 0;
+    }
+  }
+
+  .game-home-container {
+
+    padding: 24px;
+
+    h1 {
+      padding: 0px;
+    }
+
+    >h4 {
+      margin-left: 0;
+    }
+
+    .spacing-setup{
+      padding-bottom: 32px;
+    }
+  }
+
+  .game-setup-detail-container {
+    >ul {
+      margin: 0;
+      padding: 0;
+    }
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .topmost-game-home {
+    .notice {
+      position: static;
+      padding: 16px;
+      text-align: center;
+    }
+  }
+
+  .game-home-container {
+    h1 {
+      font-size: 28px;
+      line-height: 1.15;
+      padding: 0px;
+    }
+
+    >h4 {
+      font-size: 16px;
+      line-height: 1.4;
+    }
+
+    >ul >li {
+      font-size: 18px;
+    }
+    
+    .spacing-setup{
+      padding-bottom: 32px;
+    }
+  }
+
+  .game-setup-detail-container {
+    >ul >li {
+      font-size: 17px;
+    }
+
+    .setup-item {
+      font-size: 17px;
+    }
+  }
+
+}

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -180,6 +180,7 @@
   position: fixed;
   bottom: 4px;
   height: 46px;
+  z-index: 110;
 }
 
 .preferences_player {


### PR DESCRIPTION
Improved mobile interface for CreateGameForm.
From: 
<img width="400" height="933" alt="image" src="https://github.com/user-attachments/assets/034e897d-1bf6-48b2-8c5c-737ccae881f0" />

To:
<img width="415" height="931" alt="image" src="https://github.com/user-attachments/assets/20cc1f54-2c88-4eef-9c4f-f184c6a42f26" />

And GameHome screen

From:
<img width="406" height="929" alt="image" src="https://github.com/user-attachments/assets/32bda6a2-3355-4892-8faa-a853bdc7a3b7" />

To:
<img width="414" height="925" alt="image" src="https://github.com/user-attachments/assets/dd890dab-e54d-49b2-a5ea-ab582ed238aa" />

- I didn't switch to <script setup> because, expecially for CreateGameForm, because it would have changed a lot of lines, not related to responsiveness
- I added a sticky behavior for the main buttons, placed at the bottom of the screen
- i increased the z-index of the preferencesIcon to make it visible on top of the other elements