### PR TITLE
Added a space before the "Why?" in PurgeWarning.vue

### DIFF
--- a/src/client/components/common/PurgeWarning.vue
+++ b/src/client/components/common/PurgeWarning.vue
@@ -3,7 +3,7 @@
     <div :class="hoursLeft < 48 ? 'general-warning' : ''">
       <span>{{translateTextWithParams('Warning: This game will be purged in approximately ${0} hours.', [Math.floor(hoursLeft).toString()])}}</span>
       <a href="https://github.com/terraforming-mars/terraforming-mars/wiki/FAQ#purge" target="_blank">
-        <span v-i18n> Why?</span>
+        &nbsp;<span v-i18n>Why?</span>
       </a>
     </div>
   </span>

--- a/src/client/components/common/PurgeWarning.vue
+++ b/src/client/components/common/PurgeWarning.vue
@@ -3,7 +3,7 @@
     <div :class="hoursLeft < 48 ? 'general-warning' : ''">
       <span>{{translateTextWithParams('Warning: This game will be purged in approximately ${0} hours.', [Math.floor(hoursLeft).toString()])}}</span>
       <a href="https://github.com/terraforming-mars/terraforming-mars/wiki/FAQ#purge" target="_blank">
-        <span v-i18n>Why?</span>
+        <span v-i18n> Why?</span>
       </a>
     </div>
   </span>


### PR DESCRIPTION
PurgeWarning lacks a space before the "Why?", which makes the text render right up against the warning.
<img width="251" height="112" alt="image" src="https://github.com/user-attachments/assets/f43f41eb-2386-48bb-8fef-8a8be4b4e3e5" />